### PR TITLE
Remove ability to plot non-meaningful data

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,11 +4,13 @@ MDANSE project has been created by:
 
 MDANSE source code is currently developed by
 
-* Eric Pellegrini
-* Remi Perenon
+* Sanghamitra Mukhopadhyay
+* Rastislav Turanyi
 
 MDANSE former contributors:
 
+* Eric Pellegrini
+* Remi Perenon
 * Bachir Aoun
 * Gael Goret
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,13 +4,11 @@ MDANSE project has been created by:
 
 MDANSE source code is currently developed by
 
-* Sanghamitra Mukhopadhyay
-* Rastislav Turanyi
+* Eric Pellegrini
+* Remi Perenon
 
 MDANSE former contributors:
 
-* Eric Pellegrini
-* Remi Perenon
 * Bachir Aoun
 * Gael Goret
 

--- a/Extensions/xtc/src/xdr_seek.c
+++ b/Extensions/xtc/src/xdr_seek.c
@@ -38,7 +38,7 @@ int xdr_seek(XDRFILE *xd, int64_t pos, int whence)
 #ifndef _WIN32
 	// use posix 64 bit ftell version
 	result = fseeko(fptr, pos, whence) < 0 ? exdrNR : exdrOK;
-#elif _MSVC_VER && !__INTEL_COMPILER
+#elif _MSC_VER && !__INTEL_COMPILER
 	result = _fseeki64(fptr, pos, whence) < 0 ? exdrNR : exdrOK;
 #else
 	result = fseek(fptr, pos, whence) < 0 ? exdrNR : exdrOK;

--- a/Src/Framework/InputData/MMTKTrajectoryInputData.py
+++ b/Src/Framework/InputData/MMTKTrajectoryInputData.py
@@ -63,7 +63,16 @@ class MMTKTrajectoryInputData(InputFileData):
         
         for k,v in molSize.items():
             val.append('\t- %d molecule(s) of %s (%d atoms)' % (molNumber[k],k,v))
-        val.append('\n')            
+
+        val.append("\nVariables found in trajectory:")
+        variables = self._data.variables()
+        for v in variables:
+            try:
+                shape = getattr(self._data,v).var.shape
+            except AttributeError:
+                shape = getattr(self._data,v).shape
+            val.append('\t- %s: %s' % (v,shape))
+
         val = "\n".join(val)
         
         return val

--- a/Src/Framework/InputData/NetCDFInputData.py
+++ b/Src/Framework/InputData/NetCDFInputData.py
@@ -24,6 +24,17 @@ class NetCDFInputData(InputFileData):
         
     extension = "nc"
     
+    def info(self):
+        
+        val = ['Variables found in NetCDF file:']
+
+        for k, v in self._netcdf.variables.items():
+            val.append('\t - %s: %s' % (k,v.shape))
+        
+        val = "\n".join(val)
+        
+        return val
+
     def load(self):
         
         try:

--- a/Src/Framework/Jobs/Castep.py
+++ b/Src/Framework/Jobs/Castep.py
@@ -195,8 +195,10 @@ class CASTEPConverter(Converter):
         # A MMTK trajectory is opened for writing.
         self._trajectory = Trajectory(self._universe, self.configuration['output_files']['files'][0], mode='w')
 
+        data_to_be_written = ["configuration","time","velocities","gradients"]
+
         # A frame generator is created.
-        self._snapshot = SnapshotGenerator(self._universe, actions=[TrajectoryOutput(self._trajectory, ["all"],
+        self._snapshot = SnapshotGenerator(self._universe, actions=[TrajectoryOutput(self._trajectory, data_to_be_written,
                                                                                      0, None, 1)])
     
     def run_step(self, index):
@@ -227,11 +229,11 @@ class CASTEPConverter(Converter):
 
         # Retrieve the velocities multiplied by Units.Bohr*Units.Hartree/Units.hbar and save them
         self._velocities.array = config[nAtoms:2*nAtoms, :]
-        self._universe.setVelocities(self._velocities)
+        data["velocities"] = self._velocities
 
         # Retrieve the forces multiplied by Units.Hartree/Units.Bohr and save them
         self._forces.array = config[2 * nAtoms:3 * nAtoms, :]
-        data["forces"] = self._forces
+        data["gradients"] = self._forces
 
         # Store a snapshot of the current configuration in the output trajectory.
         self._snapshot(data=data)                                          

--- a/Src/Framework/Jobs/Castep.py
+++ b/Src/Framework/Jobs/Castep.py
@@ -190,7 +190,7 @@ class CASTEPConverter(Converter):
         self._universe.initializeVelocitiesToTemperature(0.)
         self._velocities = ParticleVector(self._universe)
 
-        self._gradients = ParticleVector(self._universe)        
+        self._forces = ParticleVector(self._universe)
 
         # A MMTK trajectory is opened for writing.
         self._trajectory = Trajectory(self._universe, self.configuration['output_files']['files'][0], mode='w')
@@ -225,13 +225,13 @@ class CASTEPConverter(Converter):
         
         data = {"time": timeStep}
 
-        # Retrieve the positions multiplied by Units.Bohr*Units.Hartree/Units.hbar and save them as universe velocities
+        # Retrieve the velocities multiplied by Units.Bohr*Units.Hartree/Units.hbar and save them
         self._velocities.array = config[nAtoms:2*nAtoms, :]
         self._universe.setVelocities(self._velocities)
 
-        # Retrieve the positions multiplied by Units.Hartree/Units.Bohr and save them
-        self._gradients.array = config[2*nAtoms:3*nAtoms, :]
-        data["gradients"] = self._gradients
+        # Retrieve the forces multiplied by Units.Hartree/Units.Bohr and save them
+        self._forces.array = config[2 * nAtoms:3 * nAtoms, :]
+        data["forces"] = self._forces
 
         # Store a snapshot of the current configuration in the output trajectory.
         self._snapshot(data=data)                                          

--- a/Src/Framework/Jobs/DCDConverter.py
+++ b/Src/Framework/Jobs/DCDConverter.py
@@ -299,8 +299,10 @@ class DCDConverter(Converter):
         # A MMTK trajectory is opened for writing.
         self._trajectory = Trajectory(self._universe, self.configuration['output_files']['files'][0], mode='w')
         
+        data_to_be_written = ["configuration","time"]
+        
         # A frame generator is created.        
-        self._snapshot = SnapshotGenerator(self._universe, actions=[TrajectoryOutput(self._trajectory, ["all"], 0, None, 1)])
+        self._snapshot = SnapshotGenerator(self._universe, actions=[TrajectoryOutput(self._trajectory, data_to_be_written, 0, None, 1)])
 
     def run_step(self, index):
         """

--- a/Src/Framework/Jobs/DL_POLY.py
+++ b/Src/Framework/Jobs/DL_POLY.py
@@ -307,23 +307,25 @@ class DL_POLYConverter(Converter):
 
         self._velocities = None
         
-        self._forces = None
-
+        self._gradients = None
+                                
+        data_to_be_written = ['configuration','time']
         if self._historyFile["keytrj"] == 1:
             self._universe.initializeVelocitiesToTemperature(0.)
             self._velocities = ParticleVector(self._universe)
+            data_to_be_written.append('velocities')
             
         elif self._historyFile["keytrj"] == 2:
             self._universe.initializeVelocitiesToTemperature(0.)
             self._velocities = ParticleVector(self._universe)
-            self._forces = ParticleVector(self._universe)
-            
-                        
+            self._gradients = ParticleVector(self._universe)
+            data_to_be_written.extend(['velocities','gradients'])
+                                    
         # A MMTK trajectory is opened for writing.
         self._trajectory = Trajectory(self._universe, self.configuration['output_files']['files'][0], mode='w', comment=self._fieldFile["title"])
 
         # A frame generator is created.
-        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, ["all"], 0, None, 1)])
+        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, data_to_be_written, 0, None, 1)])
         
     def run_step(self, index):
         """Runs a single step of the job.
@@ -349,12 +351,12 @@ class DL_POLYConverter(Converter):
         
         if self._velocities is not None:
             self._velocities.array = config[:,3:6]
-            self._universe.setVelocities(self._velocities)
+            data["velocities"] = self._velocities
 
-        if self._forces is not None:
-            self._forces.array = config[:,6:9]
-            data["forces"] = self._forces
-                                        
+        if self._gradients is not None:
+            self._gradients.array = config[:,6:9]
+            data["gradients"] = self._gradients
+
         # Store a snapshot of the current configuration in the output trajectory.
         self._snapshot(data=data)
                                                                         

--- a/Src/Framework/Jobs/Discover.py
+++ b/Src/Framework/Jobs/Discover.py
@@ -244,15 +244,16 @@ class DiscoverConverter(Converter):
         self._universe.initializeVelocitiesToTemperature(0.)
         self._velocities = ParticleVector(self._universe)
         self._velocities.array = self._hisfile["initial_velocities"]
-        self._universe.setVelocities(self._velocities)
         
         self._universe.foldCoordinatesIntoBox()
             
         # A MMTK trajectory is opened for writing.
         self._trajectory = Trajectory(self._universe, self.configuration['output_files']['files'][0], mode='w', comment=self._hisfile["title"])
 
+        data_to_written = ["configuration","time","velocities"]
+
         # A frame generator is created.
-        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, ["all"], 0, None, 1)])
+        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, data_to_written, 0, None, 1)])
         
     def run_step(self, index):
         """Runs a single step of the job.
@@ -279,7 +280,7 @@ class DiscoverConverter(Converter):
         data = {"time" : time}
         
         self._velocities.array[movableAtoms,:] = vel
-        self._universe.setVelocities(self._velocities)
+        data["velocities"] = self._velocities
 
         # Store a snapshot of the current configuration in the output trajectory.
         self._snapshot(data=data)

--- a/Src/Framework/Jobs/Forcite.py
+++ b/Src/Framework/Jobs/Forcite.py
@@ -127,10 +127,10 @@ class TrjFile(dict):
         
         if VERSION < 2010:
             self["velocities_written"] = DATA[-3]
-            self["forces_written"] = 0
+            self["gradients_written"] = 0
         else:
             self["velocities_written"] = DATA[-4]
-            self["forces_written"] = DATA[-3]
+            self["gradients_written"] = DATA[-3]
         
         # Frame record 2        
         rec = '!12%s8x' % self._fp
@@ -171,14 +171,14 @@ class TrjFile(dict):
         self._configRecPos = trjfile.tell() - self._headerSize
                     
         if self["velocities_written"]:
-            if self["forces_written"]:
+            if self["gradients_written"]:
                 # Frame record 8,9,10,11,12,13,14,15,16
                 self._configRec = '!' + ('%d%s8x'*9) % ((self['totmov'],self._fp)*9)
             else:
                 # Frame record 8,9,10,11,12,13
                 self._configRec = '!' + ('%d%s8x'*6) % ((self['totmov'],self._fp)*6)
         else:
-            if self["forces_written"]:
+            if self["gradients_written"]:
                 # Frame record 8,9,10,14,15,16
                 self._configRec = '!' + ('%d%s8x'*6) % ((self['totmov'],self._fp)*6)
             else:
@@ -228,29 +228,29 @@ class TrjFile(dict):
         config = struct.unpack(self._configRec,trjfile.read(self._configRecSize))
         
         if self["velocities_written"]:
-            if self["forces_written"]:
+            if self["gradients_written"]:
                 config = numpy.transpose(numpy.reshape(config,(3,3, self['totmov'])))
                 xyz    = config[:,:,0]*Units.Ang
                 vel    = config[:,:,1]*Units.Ang
-                forces = config[:,:,2]*FORCE_FACTOR
+                gradients = config[:,:,2]*FORCE_FACTOR
             else:
                 config = numpy.transpose(numpy.reshape(config,(2,3, self['totmov'])))
                 xyz    = config[:,:,0]*Units.Ang
                 vel    = config[:,:,1]*Units.Ang
-                forces = None
+                gradients = None
         else:
-            if self["forces_written"]:
+            if self["gradients_written"]:
                 config = numpy.transpose(numpy.reshape(config,(2,3, self['totmov'])))
                 xyz    = config[:,:,0]*Units.Ang
                 vel    = None
-                forces = config[:,:,1]*FORCE_FACTOR
+                gradients = config[:,:,1]*FORCE_FACTOR
             else:
                 config = numpy.transpose(numpy.reshape(config,(1,3, self['totmov'])))
                 xyz    = config[:,:,0]*Units.Ang
                 vel    = None
-                forces = None
+                gradients = None
             
-        return timeStep, cell, xyz, vel, forces
+        return timeStep, cell, xyz, vel, gradients
 
     def close(self):
         self["instance"].close()
@@ -286,21 +286,26 @@ class ForciteConverter(Converter):
         self.numberOfSteps = self._trjfile['n_frames']
         
         self._velocities = None
-        self._forces = None
-                                                          
-        if self._trjfile["velocities_written"]:
-            self._velocities = ParticleVector(self._universe)
-            self._velocities.array[:,:] = 0.00
+        self._gradients = None
 
-        if self._trjfile["forces_written"]:
-            self._forces = ParticleVector(self._universe)
-            self._forces.array[:,:] = 0.00
+        data_to_be_written = ["configuration","time"]              
+        if self._trjfile["velocities_written"]:
+            self._universe.initializeVelocitiesToTemperature(0.)
+            self._velocities = ParticleVector(self._universe)
+            self._velocities.array[:,:] = 0.0
+            data_to_be_written.append("velocities")
+
+        if self._trjfile["gradients_written"]:
+            self._universe.initializeVelocitiesToTemperature(0.)
+            self._gradients = ParticleVector(self._universe)
+            self._gradients.array[:,:] = 0.0
+            data_to_be_written.append("gradients")
 
         # A MMTK trajectory is opened for writing.
         self._trajectory = Trajectory(self._universe, self.configuration['output_files']['files'][0], mode='w', comment=self._trjfile["title"])
 
         # A frame generator is created.
-        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, ["all"], 0, None, 1)])
+        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, data_to_be_written, 0, None, 1)])
                 
     def run_step(self, index):
         """Runs a single step of the job.
@@ -312,7 +317,7 @@ class ForciteConverter(Converter):
         """
                                                 
         # The x, y and z values of the current frame.
-        time, cell, xyz, vel, forces = self._trjfile.read_step(index)
+        time, cell, xyz, velocities, gradients = self._trjfile.read_step(index)
         
         # If the universe is periodic set its shape with the current dimensions of the unit cell.
         if self._universe.is_periodic and self._trjfile["defcel"]:
@@ -327,12 +332,12 @@ class ForciteConverter(Converter):
         data = {"time" : time}
 
         if self._velocities is not None:
-            self._velocities.array[movableAtoms,:] = vel
-            self._universe.setVelocities(self._velocities)
+            self._velocities.array[movableAtoms,:] = velocities
+            data["velocities"] = self._velocities
 
-        if self._forces is not None:
-            self._forces.array[movableAtoms,:] = forces
-            data["forces"] = self._forces
+        if self._gradients is not None:
+            self._gradients.array[movableAtoms,:] = gradients
+            data["gradients"] = self._gradients
 
         # Store a snapshot of the current configuration in the output trajectory.
         self._snapshot(data=data)

--- a/Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
@@ -17,7 +17,7 @@ import collections
 from MDANSE import REGISTRY
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import weight
-from MDANSE.Mathematics.Signal import correlation
+from MDANSE.Mathematics.Signal import correlation, normalize
 from MDANSE.MolecularDynamics.Trajectory import read_atoms_trajectory
 
 class GeneralAutoCorrelationFunction(IJob):
@@ -96,8 +96,7 @@ class GeneralAutoCorrelationFunction(IJob):
         element = self.configuration['atom_selection']["names"][index]
         
         self._outputData["gacf_%s" % element] += x        
-        
-    
+
     def finalize(self):
         """
         Finalizes the calculations (e.g. averaging the total term, output files creations ...).
@@ -105,16 +104,17 @@ class GeneralAutoCorrelationFunction(IJob):
         
         # The MSDs per element are averaged.
         nAtomsPerElement = self.configuration['atom_selection'].get_natoms()
+        self.configuration['atom_selection']['n_atoms_per_element'] = nAtomsPerElement
+
         for element, number in nAtomsPerElement.items():
             self._outputData["gacf_%s" % element] /= number
                 
         if self.configuration['normalize']["value"]:
-            for element in self.configuration['atom_selection']['n_atoms_per_element'].keys():
-                pacf = self._outputData["gacf_%s" % element]      
-                if pacf[0] == 0:
+            for element in nAtomsPerElement.keys():
+                if self._outputData["gacf_%s" % element][0] == 0:
                     raise ValueError("The normalization factor is equal to zero !!!") 
                 else:
-                    pacf /= pacf[0]
+                    self._outputData["gacf_%s" % element] = normalize(self._outputData["gacf_%s" % element], axis=0)
 
         weights = self.configuration["weights"].get_weights()
         gacfTotal = weight(weights,self._outputData,nAtomsPerElement,1,"gacf_%s")

--- a/Src/Framework/Jobs/Generic.py
+++ b/Src/Framework/Jobs/Generic.py
@@ -301,12 +301,15 @@ class GenericConverter(Converter):
         
         self._gtFile.seek(pos,0)
         
+        data_to_be_written = ["configuration","time"]
         if self._hasVelocities:
             self._universe.initializeVelocitiesToTemperature(0.0)
             self._velocities = ParticleVector(self._universe)
+            data_to_be_written.append("velocities")
             if self._hasForces:        
                 self._forces = ParticleVector(self._universe)
                 self._dataShape=(self._universe.numberOfAtoms(),9)
+                data_to_be_written.append("gradients")
             else:
                 self._dataShape=(self._universe.numberOfAtoms(),6)
         else:
@@ -316,7 +319,7 @@ class GenericConverter(Converter):
         self._trajectory = Trajectory(self._universe, self.configuration['output_files']['files'][0], mode='w')
  
         # A frame generator is created.
-        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, ["all"], 0, None, 1)])
+        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, data_to_be_written, 0, None, 1)])
             
     def run_step(self, index):
         """Runs a single step of the job.
@@ -349,11 +352,11 @@ class GenericConverter(Converter):
         
         if self._hasVelocities:
             self._velocities.array = config[:,3:6]
-            self._universe.setVelocities(self._velocities)
+            data["velocities"] = self._velocities
 
         if self._hasForces:
             self._forces.array = config[:,6:9]
-            data["forces"] = self._forces
+            data["gradients"] = self._forces
                              
         # Store a snapshot of the current configuration in the output trajectory.
         self._snapshot(data=data)

--- a/Src/Framework/Jobs/Gromacs.py
+++ b/Src/Framework/Jobs/Gromacs.py
@@ -65,8 +65,11 @@ class GromacsConverter(Converter):
         # A MMTK trajectory is opened for writing.
         self._trajectory = Trajectory(self._universe, self.configuration['output_files']['files'][0], mode='w')
 
+        data_to_be_written = ["configuration", "time"]
+
         # A frame generator is created.
-        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, ["all"], 0, None, 1)])
+        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory,
+                                                                                       data_to_be_written, 0, None, 1)])
 
     def run_step(self, index):
         """Runs a single step of the job.

--- a/Src/Framework/Jobs/LAMMPS.py
+++ b/Src/Framework/Jobs/LAMMPS.py
@@ -162,8 +162,11 @@ class LAMMPSConverter(Converter):
 
         self._nameToIndex = dict([(at.name,at.index) for at in self._universe.atomList()])
 
+        data_to_be_written = ["configuration", "time"]
+
         # A frame generator is created.
-        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, ["all"], 0, None, 1)])
+        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory,
+                                                                                       data_to_be_written, 0, None, 1)])
 
         # Estimate number of steps if needed
         if self.numberOfSteps == 0:

--- a/Src/Framework/Jobs/VASP.py
+++ b/Src/Framework/Jobs/VASP.py
@@ -48,7 +48,8 @@ class XDATCARFile(dict):
             if not line or line.lower().startswith("direct"):
                 self._frameHeaderSize = self["instance"].tell() - self._headerSize
                 break
-            header.append(line)                                   
+            header.append(line)
+                                   
         self["scale_factor"] = float(header[0])
 
         cell = " ".join(header[1:4]).split()
@@ -180,8 +181,10 @@ class VASPConverter(Converter):
         # A MMTK trajectory is opened for writing.
         self._trajectory = Trajectory(self._universe, self.configuration['output_files']['files'][0], mode='w')
 
+        data_to_be_written = ["configuration","time"]
+
         # A frame generator is created.
-        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, ["all"], 0, None, 1)])
+        self._snapshot = SnapshotGenerator(self._universe, actions = [TrajectoryOutput(self._trajectory, data_to_be_written, 0, None, 1)])
 
     def run_step(self, index):
         """Runs a single step of the job.

--- a/Src/GUI/ElementsDatabaseEditor.py
+++ b/Src/GUI/ElementsDatabaseEditor.py
@@ -21,108 +21,113 @@ from MDANSE import ELEMENTS, PLATFORM
 from MDANSE.Core.Error import Error
 from MDANSE.Core.Singleton import Singleton
 
+
 def create_mmtk_atom_entry(entryname, name, symbol, mass, **props):
-    '''
+    """
     Creates a new atom in mmtk database.
-    
-    :param name: the basename of the file in which the atom entry will be stored
+
+    :param entryname: the basename of the file in which the atom entry will be stored
+    :type entryname: str
+    :param name: the name of the atom as will be recorded in the file
     :type name: str
     :param symbol:
     :type symbol: str
-    :param mass: the mass of the atom 
+    :param mass: the mass of the atom
     :type mass: float
-    
+
     :return: the absolute path of the file that stores the newly created atom
     :rtype: str
-    '''
-    
+    """
+
     # Every entry of the MMTK database is searched in lower case.
     entryname = entryname.lower()
-            
-    filename = os.path.join(PLATFORM.local_mmtk_database_directory(),"Atoms", entryname)
+
+    filename = os.path.join(PLATFORM.local_mmtk_database_directory(), "Atoms", entryname)
 
     f = open(filename, 'w')
     # This three entries are compulsory for a MMTK.Atom to be valid
     f.write('name = "%s"' % name)
     f.write('\n\nsymbol = "%s"' % symbol)
     f.write('\n\nmass = %f' % mass)
-    
-    for k,v in props.items():
-        f.write('\n\n%s = %r' % (k,v))
-            
+
+    for k, v in props.items():
+        f.write('\n\n%s = %r' % (k, v))
+
     f.close()
-    
+
     return filename
+
 
 class ElementsDatabaseError(Error):
     pass
+
 
 class NewElementDialog(wx.Dialog):
     """
     This class pops up a dialog that prompts the user for registering a new element in the database.
     """
 
-    def __init__(self,*args,**kwargs):
+    def __init__(self, *args, **kwargs):
         """
         The constructor.
         """
 
         # The base class constructor
-        wx.Dialog.__init__(self,*args,**kwargs)
-        
+        wx.Dialog.__init__(self, *args, **kwargs)
+
         self.Center()
 
-        panel = wx.Panel(self,wx.ID_ANY)
-        
+        panel = wx.Panel(self, wx.ID_ANY)
+
+        # Create text and answer box widgets
         staticLabel0 = wx.StaticText(panel, -1, "Enter element settings")
-        
-        subPanel = wx.Panel(panel,wx.ID_ANY)
-        staticLabel1 = wx.StaticText(subPanel, wx.ID_ANY, "Entry name")
-        self._entry = wx.TextCtrl(subPanel, wx.ID_ANY)        
-        staticLabel2 = wx.StaticText(subPanel, wx.ID_ANY, "Atom name")
-        self._name = wx.TextCtrl(subPanel, id = wx.ID_ANY)
-        staticLabel3 = wx.StaticText(subPanel, wx.ID_ANY, "Atom symbol")
-        self._symbol = wx.TextCtrl(subPanel, wx.ID_ANY)        
-        staticLabel4 = wx.StaticText(subPanel, wx.ID_ANY, "Atom Mass (uma)")
-        self._mass = wx.TextCtrl(subPanel, id = wx.ID_ANY)
-        
-        staticLine = wx.StaticLine(self, wx.ID_ANY)
+        staticLabel1 = wx.StaticText(panel, wx.ID_ANY, "Entry name")
+        self._entry = wx.TextCtrl(panel, wx.ID_ANY)
+        staticLabel2 = wx.StaticText(panel, wx.ID_ANY, "Atom name")
+        self._name = wx.TextCtrl(panel, id=wx.ID_ANY)
+        staticLabel3 = wx.StaticText(panel, wx.ID_ANY, "Atom symbol")
+        self._symbol = wx.TextCtrl(panel, wx.ID_ANY)
+        staticLabel4 = wx.StaticText(panel, wx.ID_ANY, "Atom Mass (uma)")
+        self._mass = wx.TextCtrl(panel, id=wx.ID_ANY)
 
-        buttonPanel = wx.Panel(self,wx.ID_ANY)
-        ok = wx.Button(buttonPanel, wx.ID_OK, "OK")
+        # Create buttons
+        ok = wx.Button(panel, wx.ID_OK, "OK")
         ok.SetDefault()
-        cancel = wx.Button(buttonPanel, wx.ID_CANCEL, "Cancel")
+        cancel = wx.Button(panel, wx.ID_CANCEL, "Cancel")
 
-        panelSizer = wx.BoxSizer(wx.VERTICAL)
-        panelSizer.Add(staticLabel0, 0, wx.ALL|wx.ALIGN_LEFT, 5)
-        subsizer = wx.GridBagSizer(5,5)
-        subsizer.AddGrowableCol(1)
-        subsizer.Add(staticLabel1,pos=(0,0),flag=wx.ALIGN_CENTER_VERTICAL)
-        subsizer.Add(self._entry   ,pos=(0,1),flag=wx.ALIGN_CENTER_VERTICAL|wx.EXPAND)
-        subsizer.Add(staticLabel2,pos=(1,0),flag=wx.ALIGN_CENTER_VERTICAL)
-        subsizer.Add(self._name,pos=(1,1),flag=wx.ALIGN_CENTER_VERTICAL|wx.EXPAND)
-        subsizer.Add(staticLabel3,pos=(2,0),flag=wx.ALIGN_CENTER_VERTICAL)
-        subsizer.Add(self._symbol,pos=(2,1),flag=wx.ALIGN_CENTER_VERTICAL|wx.EXPAND)
-        subsizer.Add(staticLabel4,pos=(3,0),flag=wx.ALIGN_CENTER_VERTICAL)
-        subsizer.Add(self._mass,pos=(3,1),flag=wx.ALIGN_CENTER_VERTICAL|wx.EXPAND)
-        subPanel.SetSizer(subsizer)
-        panelSizer.Add(subPanel, 0, wx.ALL|wx.EXPAND, 5)
-        panel.SetSizer(panelSizer)
+        # Create main sizer and add the instruction text to the top
+        main_sizer = wx.FlexGridSizer(rows=3, cols=1, vgap=10, hgap=10)
+        main_sizer.Add(staticLabel0, 0, wx.ALL | wx.ALIGN_LEFT, 5)
 
-        btnsizer = wx.StdDialogButtonSizer()
-        btnsizer.AddButton(cancel)
-        btnsizer.AddButton(ok)
-        btnsizer.Realize()        
-        buttonPanel.SetSizer(btnsizer)
+        # Place the other text and answer box widgets in a grid
+        body_sizer = wx.FlexGridSizer(rows=4, cols=2, vgap=10, hgap=20)
+        body_sizer.Add(staticLabel1, flag=wx.ALIGN_CENTER_VERTICAL | wx.LEFT, border=10)
+        body_sizer.Add(self._entry, flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT | wx.EXPAND, border=10)
+        body_sizer.Add(staticLabel2, flag=wx.ALIGN_CENTER_VERTICAL | wx.LEFT, border=10)
+        body_sizer.Add(self._name, flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT | wx.EXPAND, border=10)
+        body_sizer.Add(staticLabel3, flag=wx.ALIGN_CENTER_VERTICAL | wx.LEFT, border=10)
+        body_sizer.Add(self._symbol, flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT | wx.EXPAND, border=10)
+        body_sizer.Add(staticLabel4, flag=wx.ALIGN_CENTER_VERTICAL | wx.LEFT, border=10)
+        body_sizer.Add(self._mass, flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT | wx.EXPAND, border=10)
+        main_sizer.Add(body_sizer, 0, wx.ALL | wx.EXPAND, 5)
 
-        dlgsizer = wx.BoxSizer(wx.VERTICAL)
-        dlgsizer.Add(panel, 1, wx.ALL|wx.EXPAND, 5)
-        dlgsizer.Add(staticLine, 0, wx.ALL|wx.EXPAND, 5)
-        dlgsizer.Add(buttonPanel, 0, wx.ALL|wx.ALIGN_RIGHT|wx.EXPAND, 5)
-        
-        # Bind the top sizer to the dialog.
-        self.SetSizer(dlgsizer)
-                          
+        # Place buttons to appear as a standard dialogue
+        button_sizer = wx.StdDialogButtonSizer()
+        button_sizer.AddButton(cancel)
+        button_sizer.AddButton(ok)
+        main_sizer.Add(button_sizer, 0, wx.EXPAND)
+        button_sizer.Realize()
+
+        # Add growth properties
+        main_sizer.AddGrowableCol(0)
+        main_sizer.AddGrowableRow(0)
+        body_sizer.AddGrowableCol(1)
+
+        # Give a minimum size for the dialog but ensure that everything fits inside
+        self.SetMinSize(wx.Size(400, 160))
+        panel.SetSizerAndFit(main_sizer)
+        self.Fit()
+
     def GetValue(self, event=None):
         """
         Handler called when the user clicks on the OK button of the property dialog.
@@ -131,7 +136,7 @@ class NewElementDialog(wx.Dialog):
         entry = str(self._entry.GetValue().strip())
         if not entry:
             raise ElementsDatabaseError("Empty entry name")
-                
+
         name = str(self._name.GetValue().strip())
         if not name:
             raise ElementsDatabaseError("Empty name")
@@ -139,89 +144,89 @@ class NewElementDialog(wx.Dialog):
         symbol = str(self._symbol.GetValue().strip())
         if not symbol:
             raise ElementsDatabaseError("Empty symbol")
-            
+
         try:
             mass = float(self._mass.GetValue().strip())
         except ValueError:
             raise ElementsDatabaseError("Invalid mass value")
-                                                            
-        return entry,name,symbol,mass
+
+        return entry, name, symbol, mass
+
 
 class NewPropertyDialog(wx.Dialog):
     """
     This class pops up a dialog that prompts the user for registering a new property in the database.
     """
-        
-    def __init__(self,*args,**kwargs):
+
+    def __init__(self, *args, **kwargs):
         """
         The constructor.
         """
 
         # The base class constructor
-        wx.Dialog.__init__(self,*args,**kwargs)
-        
+        wx.Dialog.__init__(self, *args, **kwargs)
+
         self.Center()
-        
-        panel = wx.Panel(self,wx.ID_ANY)
-        
+
+        panel = wx.Panel(self, wx.ID_ANY)
+
+        # Create text and answer box widgets
         staticLabel0 = wx.StaticText(panel, -1, "Enter property settings")
-        
-        subPanel = wx.Panel(panel,wx.ID_ANY)
-        staticLabel1 = wx.StaticText(subPanel, wx.ID_ANY, "Name")
-        self.name = wx.TextCtrl(subPanel, wx.ID_ANY)        
-        staticLabel2 = wx.StaticText(subPanel, wx.ID_ANY, "Numeric type")
-        self.propertyType = wx.ComboBox(subPanel, id = wx.ID_ANY, choices=ELEMENTS._TYPES.keys(), style=wx.CB_READONLY)
-        
-        staticLine = wx.StaticLine(self, wx.ID_ANY)
+        staticLabel1 = wx.StaticText(panel, wx.ID_ANY, "Name")
+        self.name = wx.TextCtrl(panel, wx.ID_ANY)
+        staticLabel2 = wx.StaticText(panel, wx.ID_ANY, "Numeric type")
+        self.propertyType = wx.ComboBox(panel, id=wx.ID_ANY, choices=ELEMENTS._TYPES.keys(), style=wx.CB_READONLY)
 
-        buttonPanel = wx.Panel(self,wx.ID_ANY)
-        ok = wx.Button(buttonPanel, wx.ID_OK, "OK")
+        # Create button widgets
+        cancel = wx.Button(panel, wx.ID_CANCEL, "Cancel")
+        ok = wx.Button(panel, wx.ID_OK, "OK")
         ok.SetDefault()
-        cancel = wx.Button(buttonPanel, wx.ID_CANCEL, "Cancel")
 
-        panelSizer = wx.BoxSizer(wx.VERTICAL)
-        panelSizer.Add(staticLabel0, 0, wx.ALL|wx.ALIGN_LEFT, 5)
-        subsizer = wx.GridBagSizer(5,5)
-        subsizer.AddGrowableCol(1)
-        subsizer.Add(staticLabel1,pos=(0,0),flag=wx.ALIGN_CENTER_VERTICAL)
-        subsizer.Add(self.name   ,pos=(0,1),flag=wx.ALIGN_CENTER_VERTICAL|wx.EXPAND)
-        subsizer.Add(staticLabel2,pos=(1,0),flag=wx.ALIGN_CENTER_VERTICAL)
-        subsizer.Add(self.propertyType,pos=(1,1),flag=wx.ALIGN_CENTER_VERTICAL|wx.EXPAND)
-        subPanel.SetSizer(subsizer)
-        panelSizer.Add(subPanel, 0, wx.ALL|wx.EXPAND, 5)
-        panel.SetSizer(panelSizer)
+        # Create the main sizer and add the instruction
+        main_sizer = wx.FlexGridSizer(rows=3, cols=1, vgap=10, hgap=10)
+        main_sizer.Add(staticLabel0, 0, wx.ALL | wx.ALIGN_LEFT, 5)
 
-        btnsizer = wx.StdDialogButtonSizer()
-        btnsizer.AddButton(cancel)
-        btnsizer.AddButton(ok)
-        btnsizer.Realize()        
-        buttonPanel.SetSizer(btnsizer)
+        # Create sizer for the other texts and the answer boxes, and add the widets
+        body_sizer = wx.FlexGridSizer(rows=2, cols=2, vgap=15, hgap=20)
+        main_sizer.Add(body_sizer, flag=wx.EXPAND)
+        body_sizer.Add(staticLabel1, flag=wx.ALIGN_LEFT | wx.LEFT, border=10)
+        body_sizer.Add(self.name, flag=wx.ALIGN_LEFT | wx.EXPAND | wx.RIGHT, border=10)
+        body_sizer.Add(staticLabel2, flag=wx.ALIGN_LEFT | wx.LEFT, border=10)
+        body_sizer.Add(self.propertyType, flag=wx.ALIGN_LEFT | wx.EXPAND | wx.RIGHT, border=10)
 
-        dlgsizer = wx.BoxSizer(wx.VERTICAL)
-        dlgsizer.Add(panel, 1, wx.ALL|wx.EXPAND, 5)
-        dlgsizer.Add(staticLine, 0, wx.ALL|wx.EXPAND, 5)
-        dlgsizer.Add(buttonPanel, 0, wx.ALL|wx.ALIGN_RIGHT|wx.EXPAND, 5)
-        
-        # Bind the top sizer to the dialog.
-        self.SetSizer(dlgsizer)
-                          
+        # Button sizer and widgets
+        button_sizer = wx.StdDialogButtonSizer()
+        button_sizer.AddButton(cancel)
+        button_sizer.AddButton(ok)
+        button_sizer.Realize()
+        main_sizer.Add(button_sizer, 0, wx.EXPAND)
+
+        # Allow for changing size
+        main_sizer.AddGrowableCol(0)
+        main_sizer.AddGrowableRow(1)
+        body_sizer.AddGrowableCol(1)
+
+        # Give a minimum size for the dialog but ensure that everything fits inside
+        self.SetMinSize(wx.Size(400, 160))
+        panel.SetSizerAndFit(main_sizer)
+        self.Fit()
+
     def GetValue(self, event=None):
         """
         Handler called when the user clicks on the OK button of the property dialog.
         """
-                
+
         pname = str(self.name.GetValue().strip())
-        
+
         pdefault = str(self.propertyType.GetValue())
-                                
-        return pname,pdefault
- 
+
+        return pname, pdefault
+
+
 class Database(wxgrid.PyGridTableBase):
-    
     __metaclass__ = Singleton
-                                    
+
     def GetColLabelValue(self, col):
-        
         return "%s" % ELEMENTS.properties[col]
 
     def GetNumberCols(self):
@@ -231,238 +236,238 @@ class Database(wxgrid.PyGridTableBase):
         return ELEMENTS.nElements
 
     def GetRowLabelValue(self, row):
-
         return ELEMENTS.elements[row]
 
     def GetValue(self, row, col):
-                    
-        return ELEMENTS[ELEMENTS.elements[row],ELEMENTS.properties[col]]
-    
-    def SetValue(self, row, col, val):
-        
-        ELEMENTS[ELEMENTS.elements[row],ELEMENTS.properties[col]] = val                                           
+        return ELEMENTS[ELEMENTS.elements[row], ELEMENTS.properties[col]]
 
-    def add_column(self, pname,pdefault):
-        
+    def SetValue(self, row, col, val):
+        ELEMENTS[ELEMENTS.elements[row], ELEMENTS.properties[col]] = val
+
+    def add_column(self, pname, pdefault):
         ELEMENTS.add_property(pname, pdefault)
-        
+
         self.notify_grid(wxgrid.GRIDTABLE_NOTIFY_COLS_APPENDED, 1)
-    
+
     def add_row(self, entry, name, symbol, mass):
-        
         if ELEMENTS.has_element(entry):
             return
-                                        
+
         create_mmtk_atom_entry(entry, name, symbol, mass)
 
         ELEMENTS.add_element(entry)
-        ELEMENTS[entry,"name"] = name
-        ELEMENTS[entry,"symbol"] = symbol
-        ELEMENTS[entry,"atomic_weight"] = mass
-                                        
+        ELEMENTS[entry, "name"] = name
+        ELEMENTS[entry, "symbol"] = symbol
+        ELEMENTS[entry, "atomic_weight"] = mass
+
         self.notify_grid(wxgrid.GRIDTABLE_NOTIFY_ROWS_APPENDED, 1)
-        
+
     def notify_grid(self, msg, count):
-        "Notifies the grid of the message and the affected count."
-        
-        tbl_msg = wxgrid.GridTableMessage(self, msg, count)                      
-         
+        """Notifies the grid of the message and the affected count."""
+
+        tbl_msg = wxgrid.GridTableMessage(self, msg, count)
+
         self.GetView().ProcessTableMessage(tbl_msg)
-        
-    def saveas(self,fmt,filename):
-        
-        ELEMENTS.export(fmt,filename)
-        
-    def save(self, fmt="csv", filename=None):
-        
-        ELEMENTS.save()                    
+
+    @staticmethod
+    def saveas(fmt, filename):
+        ELEMENTS.export(fmt, filename)
+
+    @staticmethod
+    def save(fmt="csv", filename=None):
+        ELEMENTS.save()
+
 
 class ElementsDatabaseEditor(wx.Frame):
-    
+
     def __init__(self, parent):
         """
         The constructor.
         :Parameters:
             #. parent  (wx window): the parent window.
         """
-                
-        wx.Frame.__init__(self, parent, wx.ID_ANY, title="Elements database editor", style=wx.DEFAULT_FRAME_STYLE|wx.RESIZE_BORDER)
-                
+
+        wx.Frame.__init__(self, parent, wx.ID_ANY, title="Elements database editor",
+                          style=wx.DEFAULT_FRAME_STYLE | wx.RESIZE_BORDER)
+
         self._database = Database()
-        
+
         self.build_dialog()
-        
+
         self.build_menu()
-        
+
         self.CenterOnParent()
-        
+
     def build_dialog(self):
-        
-        mainPanel = wx.Panel(self,wx.ID_ANY)
-                
+
+        mainPanel = wx.Panel(self, wx.ID_ANY)
+
         mainSizer = wx.BoxSizer(wx.VERTICAL)
-  
-        # The wx grid that will store the database.            
+
+        # The wx grid that will store the database.
         self._grid = wxgrid.Grid(mainPanel)
-  
+
         # The grid style is set. This will be a standard text editor.
         self._grid.SetDefaultEditor(wxgrid.GridCellTextEditor())
-                                                    
+
         self._grid.SetTable(self._database)
-          
+
         self._grid.SetDefaultCellBackgroundColour(wx.NamedColour("LIGHT BLUE"))
-          
+
         self._grid.SetColLabelAlignment(wx.ALIGN_CENTRE, wx.ALIGN_CENTRE)
-          
+
         self._grid.SetRowLabelAlignment(wx.ALIGN_LEFT, wx.ALIGN_CENTRE)
-  
+
         self._grid.SetColMinimalAcceptableWidth(100)
-          
-        self._grid.Bind(wxgrid.EVT_GRID_CELL_CHANGE,self.on_edit_cell)
+
+        self._grid.Bind(wxgrid.EVT_GRID_CELL_CHANGE, self.on_edit_cell)
         self._grid.Bind(wxgrid.EVT_GRID_CELL_RIGHT_CLICK, self.on_show_popup_menu)
-        mainSizer.Add(self._grid,1,wx.EXPAND|wx.ALL,5)
-                                        
+        mainSizer.Add(self._grid, 1, wx.EXPAND | wx.ALL, 5)
+
         mainPanel.SetSizer(mainSizer)
-        
-        self.SetSize((800,400))
-        
+
+        self.SetSize((800, 400))
+
         self.Bind(wx.EVT_CONTEXT_MENU, self.on_show_popup_menu)
-        
+
         self.Bind(wx.EVT_CLOSE, self.on_close)
 
     def build_menu(self):
- 
+
         menubar = wx.MenuBar()
-         
+
         fileMenu = wx.Menu()
-        saveItem   = fileMenu.Append(wx.ID_ANY, '&Save database\tCtrl+S')
-        saveasItem = fileMenu.Append(wx.ID_ANY, '&Save database as ...\tCtrl+Shift+S')        
+        saveItem = fileMenu.Append(wx.ID_ANY, '&Save database\tCtrl+S')
+        saveasItem = fileMenu.Append(wx.ID_ANY, '&Save database as ...\tCtrl+Shift+S')
         menubar.Append(fileMenu, "File")
- 
+
         databaseMenu = wx.Menu()
         addElementItem = databaseMenu.Append(wx.ID_ANY, 'New element')
         addPropertyItem = databaseMenu.Append(wx.ID_ANY, 'New property')
         menubar.Append(databaseMenu, "Database")
-                 
-        self.Bind(wx.EVT_MENU,self.on_add_element, addElementItem)
-        self.Bind(wx.EVT_MENU,self.on_add_property, addPropertyItem)
- 
-        self.Bind(wx.EVT_MENU,self.on_save_database, saveItem)
-        self.Bind(wx.EVT_MENU,self.on_saveas_database, saveasItem)
- 
+
+        self.Bind(wx.EVT_MENU, self.on_add_element, addElementItem)
+        self.Bind(wx.EVT_MENU, self.on_add_property, addPropertyItem)
+
+        self.Bind(wx.EVT_MENU, self.on_save_database, saveItem)
+        self.Bind(wx.EVT_MENU, self.on_saveas_database, saveasItem)
+
         self.SetMenuBar(menubar)
-                
+
     def on_show_popup_menu(self, event):
 
         menu = wx.Menu()
 
         saveItem = menu.Append(wx.ID_ANY, 'Save database')
-        saveasItem = menu.Append(wx.ID_ANY, 'Save database as ...')        
+        saveasItem = menu.Append(wx.ID_ANY, 'Save database as ...')
         menu.AppendSeparator()
 
         addElementItem = menu.Append(wx.ID_ANY, 'New element')
         addPropertyItem = menu.Append(wx.ID_ANY, 'New property')
 
-        self.Bind(wx.EVT_MENU,self.on_add_element,addElementItem)
-        self.Bind(wx.EVT_MENU,self.on_add_property,addPropertyItem)
+        self.Bind(wx.EVT_MENU, self.on_add_element, addElementItem)
+        self.Bind(wx.EVT_MENU, self.on_add_property, addPropertyItem)
 
-        self.Bind(wx.EVT_MENU,self.on_save_database, saveItem)
-        self.Bind(wx.EVT_MENU,self.on_saveas_database, saveasItem)
+        self.Bind(wx.EVT_MENU, self.on_save_database, saveItem)
+        self.Bind(wx.EVT_MENU, self.on_saveas_database, saveasItem)
 
         self.PopupMenu(menu)
 
         menu.Destroy()
-        
-    def on_close(self,event):
-        
-        d = wx.MessageDialog(None, 'This will close the database editor. Continue ?', 'Question', wx.YES_NO|wx.YES_DEFAULT|wx.ICON_WARNING)
-                 
+
+    def on_close(self, event):
+
+        d = wx.MessageDialog(None, 'This will close the database editor. Continue ?', 'Question',
+                             wx.YES_NO | wx.YES_DEFAULT | wx.ICON_WARNING)
+
         if d.ShowModal() == wx.ID_NO:
             return
-        
+
         self.Destroy()
-                        
-    def on_edit_cell(self,event):
-        
+
+    def on_edit_cell(self, event):
+
         event.Skip()
-        
+
         self._grid.Refresh()
 
     def on_add_element(self, event):
         """
         Handler called when the user add new elements to the database.
         """
- 
-        d = NewElementDialog(self,title="Add element",size=(400,220))
- 
-        # If the new element dialog is closed by clicking on OK. 
+
+        d = NewElementDialog(self, title="Add element", size=(400, 220))
+
+        # If the new element dialog is closed by clicking on OK.
         if d.ShowModal() == wx.ID_CANCEL:
             return
- 
+
         # Get rid of wxpython unicode string formatting
-        entry,name,symbol,mass = d.GetValue()
-                                                                                  
-        self._database.add_row(entry,name,symbol,mass)
-                        
+        entry, name, symbol, mass = d.GetValue()
+
+        self._database.add_row(entry, name, symbol, mass)
+
     def on_add_property(self, message):
         """
         Handler called when the user add a property to the database.
         """
- 
-        d = NewPropertyDialog(self,title="Add property",size=(400,160))
- 
+
+        d = NewPropertyDialog(self, title="Add property")
+
         if d.ShowModal() == wx.ID_CANCEL:
             return
- 
-        pname,pdefault = d.GetValue()
-                     
+
+        pname, pdefault = d.GetValue()
+
         if not pname:
             return
-        
+
         # Get rid of wxpython unicode string formatting
         pname = str(pname)
-                                     
-        self._database.add_column(pname,pdefault)      
-  
-    def on_save_database(self,event=None):
+
+        self._database.add_column(pname, pdefault)
+
+    def on_save_database(self, event=None):
         """
         Handler called when the user saves the database to its defaut location.
         """
- 
-        d = wx.MessageDialog(None, 'This will overwrite your database. Continue ?', 'Question', wx.YES_NO|wx.YES_DEFAULT|wx.ICON_WARNING)
-                 
+
+        d = wx.MessageDialog(None, 'This will overwrite your database. Continue ?', 'Question',
+                             wx.YES_NO | wx.YES_DEFAULT | wx.ICON_WARNING)
+
         if d.ShowModal() == wx.ID_NO:
             return
-         
+
         self._database.save()
-         
-    def on_saveas_database(self,event=None):
+
+    def on_saveas_database(self, event=None):
         """
         Handler called when the user saves the database to any location.
         """
- 
+
         d = wx.FileDialog(self,
                           message="Save database as ...",
                           defaultDir=os.getcwd(),
                           defaultFile="elements_database",
                           wildcard="XML file (*.xml)|*.xml|CSV file (*.csv)|*.csv",
-                          style=wx.SAVE|wx.FD_OVERWRITE_PROMPT)
- 
+                          style=wx.SAVE | wx.FD_OVERWRITE_PROMPT)
+
         if d.ShowModal() == wx.ID_CANCEL:
             return
-         
+
         filename = str(d.GetPath())
-         
+
         if d.GetFilterIndex() == 0:
             fmt = 'xml'
-             
+
         elif d.GetFilterIndex() == 1:
             fmt = 'csv'
-                     
-        self._database.saveas(fmt,filename)
-                  
+
+        self._database.saveas(fmt, filename)
+
+
 if __name__ == "__main__":
     app = wx.App(False)
     f = ElementsDatabaseEditor(None)
     f.Show()
-    app.MainLoop()    
+    app.MainLoop()

--- a/Src/GUI/Plugins/Plotter1D.py
+++ b/Src/GUI/Plugins/Plotter1D.py
@@ -30,92 +30,92 @@ from MDANSE.Externals.magnitude import magnitude
 from MDANSE.GUI.Plugins.PlotterSettings import LinesSettingsDialog, GeneralSettingsDialog, AxesSettingsDialog
 from MDANSE.GUI.Plugins.PlotterTicker import ScaledFormatter, ScaledLocator
 
-NORMALIZER = {'log': LogNorm(), 'auto' : Normalize()}
+NORMALIZER = {'log': LogNorm(), 'auto': Normalize()}
+
 
 class Plotter1DError(Error):
-    pass   
+    pass
+
 
 class Plotter1D(wx.Panel):
-
     type = 'line'
-    
-    def __init__(self, parent, data = None):
-    
+
+    def __init__(self, parent, data=None):
+
         wx.Panel.__init__(self, parent, wx.ID_ANY)
-        
+
         self.setting = None
-                
+
         ### Initialize variables ###
         self.parent = parent
-        self.figure = Figure(figsize=(5,4), dpi=None)
-        
+        self.figure = Figure(figsize=(5, 4), dpi=None)
+
         if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
-            self.axes = self.figure.add_axes( (10,10,10,10), frameon=True, axis_bgcolor='b')
+            self.axes = self.figure.add_axes((10, 10, 10, 10), frameon=True, axis_bgcolor='b')
         else:
-            self.axes = self.figure.add_axes( (10,10,10,10), frameon=True, facecolor='b')
-        self.canvas = FigureCanvasWxAgg( self, wx.ID_ANY, self.figure )
+            self.axes = self.figure.add_axes((10, 10, 10, 10), frameon=True, facecolor='b')
+        self.canvas = FigureCanvasWxAgg(self, wx.ID_ANY, self.figure)
         self.toolbar = NavigationToolbar2WxAgg(self.canvas)
         self.plots = {}
         self.selectedLine = None
-        
-    
-        self.annotation =  wx.StaticText(self, label='x : , y : ' , style=wx.ALIGN_CENTER_VERTICAL)
+
+        self.annotation = wx.StaticText(self, label='x : , y : ', style=wx.ALIGN_CENTER_VERTICAL)
 
         ### Initialize figure parameters ###
         self.title = ''
         self.titleStyle = 0
         self.titleWeight = 0
-        self.titleWidth = 4 # large
-        
+        self.titleWidth = 4  # large
+
         self.xlabel = ''
         self.xlabelStyle = 0
         self.xlabelWeight = 0
-        self.xlabelWidth = 3 # medium
-        
+        self.xlabelWidth = 3  # medium
+
         self.ylabel = ''
         self.ylabelStyle = 0
         self.ylabelWeight = 0
-        self.ylabelWidth = 3 # medium
-        
+        self.ylabelWidth = 3  # medium
+
         self.gridStyle = 'None'
         self.gridWidth = 1
-        self.gridColor = (1,0,0)
-        
+        self.gridColor = (1, 0, 0)
+
         self.Xscale = 'linear'
         self.Yscale = 'linear'
-        
+
         self.xMinorTicks = False
         self.yMinorTicks = False
-        
+
         self.Xposition = 'none'
         self.Yposition = 'none'
 
         self.Xlabel = ''
         self.Ylabel = ''
-        
+
         self.Xaxis_label = ''
         self.Yaxis_label = ''
-        
+
         self.Xunit = None
         self.Yunit = None
-        
+
         self.Xinit_unit = None
         self.Yinit_unit = None
-        
+
         self.Xaxis = numpy.array([])
         self.Yaxis = numpy.array([])
-        
+
         self.Xticks = []
         self.Yticks = []
-        
+
         self.Xmax = 0
         self.Ymax = 0
         self.Xmin = 0
         self.Ymin = 0
-        
+
         self.offset = 0.0
         self.verticalCut = None
-        
+
         self.show_legend = False
         self.legend_location = 'best'
         self.legend_frameon = True
@@ -123,88 +123,88 @@ class Plotter1D(wx.Panel):
         self.legend_fancybox = False
 
         # add sliders
-        self.offset_label = wx.StaticText(self, label="Offset Value" , style=wx.ALIGN_CENTER_VERTICAL)
-        self.yAxisSliderOffset = wx.Slider(self, wx.ID_ANY, size = (60,27), style = wx.SL_HORIZONTAL)
-        self.offset_multiplier_label = wx.StaticText(self, label="Modulation" , style=wx.ALIGN_CENTER_VERTICAL)
-        self.yAxisOffset = wx.TextCtrl(self, wx.ID_ANY, size = (60,27), style = wx.TE_PROCESS_ENTER )
+        self.offset_label = wx.StaticText(self, label="Offset Value", style=wx.ALIGN_CENTER_VERTICAL)
+        self.yAxisSliderOffset = wx.Slider(self, wx.ID_ANY, size=(60, 27), style=wx.SL_HORIZONTAL)
+        self.offset_multiplier_label = wx.StaticText(self, label="Modulation", style=wx.ALIGN_CENTER_VERTICAL)
+        self.yAxisOffset = wx.TextCtrl(self, wx.ID_ANY, size=(60, 27), style=wx.TE_PROCESS_ENTER)
         self.yAxisOffset.SetValue('0.0')
-        self.autoFitAxesButton = wx.Button(self, label = "Fit axes range", size = (120,27))
+        self.autoFitAxesButton = wx.Button(self, label="Fit axes range", size=(120, 27))
 
         hsizer = wx.BoxSizer()
-        hsizer.Add(self.toolbar, 0, flag=wx.ALL|wx.EXPAND)
+        hsizer.Add(self.toolbar, 0, flag=wx.ALL | wx.EXPAND)
         hsizer.AddSpacer(25)
         hsizer.Add(self.annotation, 0, flag=wx.ALIGN_CENTER_VERTICAL)
-        
+
         hsizer2 = wx.BoxSizer()
         hsizer2.AddSpacer(5)
         hsizer2.Add(self.offset_label, 0, flag=wx.ALIGN_CENTER_VERTICAL)
         hsizer2.AddSpacer(5)
         hsizer2.Add(self.yAxisOffset, 0, flag=wx.ALIGN_CENTER_VERTICAL)
         hsizer2.AddSpacer(5)
-        hsizer2.Add(self.offset_multiplier_label, 0, flag=wx.ALIGN_CENTER_VERTICAL )
+        hsizer2.Add(self.offset_multiplier_label, 0, flag=wx.ALIGN_CENTER_VERTICAL)
         hsizer2.AddSpacer(5)
-        hsizer2.Add(self.yAxisSliderOffset, 1, flag=wx.ALL|wx.ALIGN_CENTER_VERTICAL|wx.EXPAND)
+        hsizer2.Add(self.yAxisSliderOffset, 1, flag=wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
         hsizer2.AddSpacer(5)
-        hsizer2.Add(self.autoFitAxesButton,0, flag = wx.ALIGN_CENTER_VERTICAL)
-        
+        hsizer2.Add(self.autoFitAxesButton, 0, flag=wx.ALIGN_CENTER_VERTICAL)
+
         ### sizer ###
         self.sizer = wx.BoxSizer(wx.VERTICAL)
-        self.sizer.Add(self.canvas, 1, flag=wx.EXPAND) 
+        self.sizer.Add(self.canvas, 1, flag=wx.EXPAND)
         self.sizer.Add(hsizer, 0, flag=wx.EXPAND)
         self.sizer.Add(hsizer2, 0, flag=wx.EXPAND)
-        self.SetSizer(self.sizer) 
-        
+        self.SetSizer(self.sizer)
+
         ### set bindings ###
-        self.Bind(wx.EVT_CLOSE, self.on_close_figure) 
-        self.Bind(wx.EVT_TEXT_ENTER, self.on_offset ,id = self.yAxisOffset.GetId())
-        self.Bind(wx.EVT_SCROLL,self.on_offset ,id = self.yAxisSliderOffset.GetId())
-        self.Bind(wx.EVT_BUTTON, self.on_auto_fit, id = self.autoFitAxesButton.GetId())
-#         self.Bind(wx.EVT_CHECKBOX, self.slice, id = self.slice_checkbox.GetId())
-        
+        self.Bind(wx.EVT_CLOSE, self.on_close_figure)
+        self.Bind(wx.EVT_TEXT_ENTER, self.on_offset, id=self.yAxisOffset.GetId())
+        self.Bind(wx.EVT_SCROLL, self.on_offset, id=self.yAxisSliderOffset.GetId())
+        self.Bind(wx.EVT_BUTTON, self.on_auto_fit, id=self.autoFitAxesButton.GetId())
+        #         self.Bind(wx.EVT_CHECKBOX, self.slice, id = self.slice_checkbox.GetId())
+
         self.binds_mpl_events()
 
         #### sizer automatically fitting window size ####
         self.toolbar.Realize()
-        self.SetSizeHints(600,500,1000,1000) # SetSizeHints(minW, minH, maxW, maxH)
+        self.SetSizeHints(600, 500, 1000, 1000)  # SetSizeHints(minW, minH, maxW, maxH)
         self.sizer.Fit(self)
         self.Show(True)
-        
+
     @property
     def dataproxy(self):
         return self.parent.dataproxy
-    
+
     @property
     def fmt_Xunit(self):
         if not self.Xunit:
             return ''
-        else:    
+        else:
             return ' (' + self.Xunit + ')'
-    
+
     @property
     def fmt_Yunit(self):
         if not self.Yunit:
             return ''
-        else:    
+        else:
             return ' (' + self.Yunit + ')'
-    
+
     def binds_mpl_events(self):
         self.menu_event_id = self.canvas.mpl_connect('button_press_event', self.on_click)
         self.pick_event_id = self.canvas.mpl_connect("pick_event", self.on_pick_line)
-        self.key_event_id = self.canvas.mpl_connect('key_press_event', self.on_key)  
+        self.key_event_id = self.canvas.mpl_connect('key_press_event', self.on_key)
         self.on_motion_id = self.canvas.mpl_connect('motion_notify_event', self.on_motion)
-        
-    def on_click(self, event = None):
+
+    def on_click(self, event=None):
         if event.button != 3:
             return
-        
+
         popupMenu = wx.Menu()
 
         general = popupMenu.Append(wx.ID_ANY, "General settings")
         popupMenu.Bind(wx.EVT_MENU, self.general_setting_dialog, general)
-        
+
         axes = popupMenu.Append(wx.ID_ANY, "Axes settings")
         popupMenu.Bind(wx.EVT_MENU, self.axes_setting_dialog, axes)
-        
+
         lines = popupMenu.Append(wx.ID_ANY, "Lines settings")
         popupMenu.Bind(wx.EVT_MENU, self.lines_setting_dialog, lines)
 
@@ -213,82 +213,81 @@ class Plotter1D(wx.Panel):
         clear = popupMenu.Append(wx.ID_ANY, "Clear")
         popupMenu.Bind(wx.EVT_MENU, self.clear, clear)
 
-        popupMenu.AppendSeparator()        
-
+        popupMenu.AppendSeparator()
 
         export = popupMenu.Append(wx.ID_ANY, "Export data")
         popupMenu.Bind(wx.EVT_MENU, self.export_data, export)
-        
+
         self.canvas.ReleaseMouse()
-        wx.CallAfter(self.PopupMenu, popupMenu) 
-    
+        wx.CallAfter(self.PopupMenu, popupMenu)
+
     def on_motion(self, event):
         if event.inaxes:
             x = event.xdata
             y = event.ydata
-            self.annotation.SetLabel('x : %g, y : %g'%(x,y))
+            self.annotation.SetLabel('x : %g, y : %g' % (x, y))
         else:
             self.annotation.SetLabel('')
-            
-    def clear(self, event = None):
+
+    def clear(self, event=None):
         d = wx.MessageDialog(None,
-                 'Do you really want clean the plot window ?',
-                 'Question',
-                 wx.YES_NO|wx.YES_DEFAULT|wx.ICON_QUESTION)
+                             'Do you really want clean the plot window ?',
+                             'Question',
+                             wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION)
         if d.ShowModal() == wx.ID_YES:
             pass
         else:
             return
         self.plots = {}
         self.figure.gca().clear()
-        self.figure.canvas.draw()  
-           
-    def on_offset(self, event = None):
-        try :
+        self.figure.canvas.draw()
+
+    def on_offset(self, event=None):
+        try:
             offsetValue = float(self.yAxisOffset.GetValue())
         except:
             offsetValue = 0.
-        offsetPercent = float(self.yAxisSliderOffset.GetValue())/100.0
-        AddFactor = float(offsetValue*offsetPercent) - float(self.offset)
-        self.offset = float(offsetValue*offsetPercent) 
-        
+        offsetPercent = float(self.yAxisSliderOffset.GetValue()) / 100.0
+        AddFactor = float(offsetValue * offsetPercent) - float(self.offset)
+        self.offset = float(offsetValue * offsetPercent)
+
         self.add_offset(AddFactor)
-    
-    def export_data(self, event = None):
+
+    def export_data(self, event=None):
 
         first = True
-                        
+
         for v in self.plots.values():
-           
+
             line, label, varname = v
             if first:
                 try:
                     axis = self.dataproxy[varname]['axis'][0]
-                    data = [self.dataproxy[axis]['data']*self.Xunit_conversion_factor]
-                    labels = ['%s (%s)'%(axis, self.Xunit)]
+                    data = [self.dataproxy[axis]['data'] * self.Xunit_conversion_factor]
+                    labels = ['%s (%s)' % (axis, self.Xunit)]
                 except:
                     data = [numpy.arange(self.dataproxy[varname]['data'].shape[0])]
                     labels = ['default_axis (au)']
                 first = False
-                    
+
             try:
                 line.get_xydata()
-                data.append(line.get_ydata()*self.Yunit_conversion_factor)
-                labels.append('%s (%s)'%(label, self.Yunit))
+                data.append(line.get_ydata() * self.Yunit_conversion_factor)
+                labels.append('%s (%s)' % (label, self.Yunit))
             except:
                 raise Plotter1DError('encounter issue for variable %r while exporting data' % varname)
         header = '# '
         if labels:
-            for l in labels:
-                header += '%s, '%l
-            header = header[:-2] + os.linesep   
+            for label in labels:
+                header += '%s, ' % label
+            header = header[:-2] + os.linesep
         output_fname = self.get_output_filename()
         if output_fname:
             with open(output_fname, 'w') as f:
                 f.write(header)
-                numpy.savetxt(f,numpy.column_stack(data), fmt='%12.4e', delimiter="  ")
+                numpy.savetxt(f, numpy.column_stack(data), fmt='%12.4e', delimiter="  ")
                 f.close()
-        
+
     def get_output_filename(self):
         path = ''
         dlg = wx.FileDialog(self, "Save As", '', '', "All Files|*.*", wx.SAVE)
@@ -296,58 +295,58 @@ class Plotter1D(wx.Panel):
             path = dlg.GetPath()
         dlg.Destroy()
         return path
-            
+
     def add_offset(self, offset):
         lines = self.figure.gca().lines
         # remove vertical line if existing
-        if self.verticalCut is not None :        
+        if self.verticalCut is not None:
             lines.remove(self.verticalCut)
             self.verticalCut = None
-            
+
         for idx in range(len(lines)):
             line = lines[idx]
-            
+
             y = line.get_ydata()
-            line.set_ydata( (idx+1)*offset +y  )
-        
+            line.set_ydata((idx + 1) * offset + y)
+
         # set activeFigure to this figure
         self.figure.canvas.draw()
 
-    def on_auto_fit(self, event = None):
+    def on_auto_fit(self, event=None):
         lines = self.figure.gca().lines
-        if lines == []:
+        if not lines:
             return
         xMin = 1.0e10
         xMax = 0
         yMin = 1.0e10
         yMax = 0
         for line in lines:
-            xMin = min( xMin, min(line.get_xdata()) )
-            xMax = max( xMax, max(line.get_xdata()) )
-            yMin = min( yMin, min(line.get_ydata()) )
-            yMax = max( yMax, max(line.get_ydata()) )
-   
-        self.Xmin =xMin
+            xMin = min(xMin, min(line.get_xdata()))
+            xMax = max(xMax, max(line.get_xdata()))
+            yMin = min(yMin, min(line.get_ydata()))
+            yMax = max(yMax, max(line.get_ydata()))
+
+        self.Xmin = xMin
         self.Xmax = xMax
         self.Ymin = yMin
-        self.Ymax=  yMax + 0.05*(yMax-yMin)
-        
+        self.Ymax = yMax + 0.05 * (yMax - yMin)
+
         self.figure.gca().axis([self.Xmin, self.Xmax, self.Ymin, self.Ymax])
         self.figure.canvas.draw()
-    
-    def on_key(self, event = None):
-        if event.key =='delete':
+
+    def on_key(self, event=None):
+        if event.key == 'delete':
             if self.selectedLine is None:
                 return
             # remove offset
             self.add_offset(-self.offset)
             # actualize plotsFileData
-            for k,v in self.plots.items():
+            for k, v in self.plots.items():
                 if v[0] is self.selectedLine:
                     d = wx.MessageDialog(None,
-                             'Do you really want delete this line ?',
-                             'Question',
-                             wx.YES_NO|wx.YES_DEFAULT|wx.ICON_QUESTION)
+                                         'Do you really want delete this line ?',
+                                         'Question',
+                                         wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION)
                     if d.ShowModal() == wx.ID_YES:
                         pass
                     else:
@@ -360,23 +359,23 @@ class Plotter1D(wx.Panel):
             self.update_legend()
             self.selectedLine = None
             self.canvas.draw()
-    
-    def delete_line(self, line): 
+
+    def delete_line(self, line):
         self.add_offset(-self.offset)
-        
-        for k,v in self.plots.items():
-            if v[0] is line: 
+
+        for k, v in self.plots.items():
+            if v[0] is line:
                 self.plots.pop(k)
-        
+
         line.remove()
         self.add_offset(self.offset)
         self.canvas.draw()
-        
-    def on_close_figure(self, event = None):
+
+    def on_close_figure(self, event=None):
         # remove any selection made in any figure
         if self.parent.selectedPlot is not None:
             self.parent.selectedPlot = None
-        
+
         # destroy window
         self.Destroy()
         self = None
@@ -385,7 +384,7 @@ class Plotter1D(wx.Panel):
         scaleStr = self.Xscale
         if scaleStr == 'linear':
             self.figure.gca().set_xscale('linear')
-        elif  scaleStr == 'symlog':
+        elif scaleStr == 'symlog':
             self.figure.gca().set_xscale('symlog')
         elif scaleStr == 'ln':
             self.figure.gca().set_xscale('log', basex=numpy.exp(1))
@@ -393,14 +392,14 @@ class Plotter1D(wx.Panel):
             self.figure.gca().set_xscale('log', basex=10)
         elif scaleStr == 'log 2':
             self.figure.gca().set_xscale('log', basex=2)
-        self.on_auto_fit()  
+        self.on_auto_fit()
         self.figure.canvas.draw()
-        
+
     def scale_yAxis(self):
         scaleStr = self.Yscale
         if scaleStr == 'linear':
             self.figure.gca().set_yscale('linear')
-        elif  scaleStr == 'symlog':
+        elif scaleStr == 'symlog':
             self.figure.gca().set_yscale('symlog')
         elif scaleStr == 'ln':
             self.figure.gca().set_yscale('log', basey=numpy.exp(1))
@@ -408,114 +407,124 @@ class Plotter1D(wx.Panel):
             self.figure.gca().set_yscale('log', basey=10)
         elif scaleStr == 'log 2':
             self.figure.gca().set_yscale('log', basey=2)
-        self.on_auto_fit() 
+        self.on_auto_fit()
         self.figure.canvas.draw()
-        
-    def on_pick_line(self, event = None):
+
+    def on_pick_line(self, event=None):
         # set alpha of previous selection to 1
-        if self.selectedLine is not None: 
+        if self.selectedLine is not None:
             self.selectedLine.set_alpha(1.0)
             self.selectedLine.figure.canvas.draw()
         # unselect previous selection
         if event.artist == self.selectedLine:
             self.selectedLine = None
-            return 
-        # set new selection and alpha  
+            return
+            # set new selection and alpha
         self.selectedLine = event.artist
         self.selectedLine.set_alpha(0.4)
         self.selectedLine.figure.canvas.draw()
 
     def update_legend(self):
-        legend = [[],[]] 
+        legend = [[], []]
         for v in self.plots.values():
             legend[0].append(v[0])
-            legend[1].append(v[1]) 
-        self.figure.gca().legend(tuple(legend[0]), tuple(legend[1]), loc = self.legend_location, frameon = self.legend_frameon, shadow = self.legend_shadow, fancybox = self.legend_fancybox) 
+            legend[1].append(v[1])
+        self.figure.gca().legend(tuple(legend[0]), tuple(legend[1]), loc=self.legend_location,
+                                 frameon=self.legend_frameon, shadow=self.legend_shadow, fancybox=self.legend_fancybox)
         self.show_legend = True
-        
+
     def plot(self, data, varname):
         if data is None:
             return
+
+        try:
+            [float(d) for d in data]
+        except ValueError:
+            raise Plotter1DError('Data containing non-numeric values cannot be plotted.')
+
         self.set_axis_property(varname, data)
-        self.subplot = self.figure.add_subplot( 111 )  
-        name = self.unique(varname, self.plots) 
-        self.plots[name] = [self.subplot.plot(self.Xaxis, data, picker = 3)[0], name, varname]
+        self.subplot = self.figure.add_subplot(111)
+        name = self.unique(varname, self.plots)
+        self.plots[name] = [self.subplot.plot(self.Xaxis, data, picker=3)[0], name, varname]
         self.set_ticks()
         self.Xlabel = self.Xaxis_label
         self.Ylabel = self.Yaxis_label
-        self.figure.gca().set_xlabel(self.Xlabel + self.fmt_Xunit )
-        self.figure.gca().set_ylabel(self.Ylabel + self.fmt_Yunit )
+        self.figure.gca().set_xlabel(self.Xlabel + self.fmt_Xunit)
+        self.figure.gca().set_ylabel(self.Ylabel + self.fmt_Yunit)
         self.on_auto_fit()
-        self.canvas.draw() 
-    
+        self.canvas.draw()
+
     def set_axis_property(self, varname, data):
         oldXunit = self.Xinit_unit
         oldYunit = self.Yinit_unit
         self.Yaxis_label = varname
         self.Yaxis = self.dataproxy[varname]['data']
-        try :
+        try:
             self.Xaxis_label = self.dataproxy[varname]['axis'][0]
             self.Xunit = self.Xinit_unit = self.dataproxy[self.Xaxis_label]['units']
             self.Xaxis = self.dataproxy[self.Xaxis_label]['data']
         except:
             self.Xunit = self.Xinit_unit = 'au'
-            self.Xaxis = numpy.arange(data.shape[0]) 
-        try :
+            self.Xaxis = numpy.arange(data.shape[0])
+        try:
             self.Yunit = self.Yinit_unit = self.dataproxy[varname]['units']
         except:
             self.Yunit = self.Yinit_unit = 'au'
-            
-        
-        
-        if not oldXunit is None:
+
+        if oldXunit is not None:
             if oldXunit != self.Xinit_unit:
-                raise Plotter1DError('the x axis unit (%s) of data-set %r is inconsistent with the unit (%s) of the precedent data plotted '%(self.Xinit_unit, varname,  oldXunit))
-        if not oldYunit is None:
+                raise Plotter1DError(
+                    'the x axis unit (%s) of data-set %r is inconsistent with the unit (%s) of the precedent data '
+                    'plotted ' % (self.Xinit_unit, varname, oldXunit))
+        if oldYunit is not None:
             if oldYunit != self.Yinit_unit:
-                raise Plotter1DError('the y axis unit (%s) of data-set %r is inconsistent with the unit (%s) of the precedent data plotted '%(self.Yinit_unit, varname,  oldYunit))
-    
+                raise Plotter1DError(
+                    'the y axis unit (%s) of data-set %r is inconsistent with the unit (%s) of the precedent data '
+                    'plotted ' % (self.Yinit_unit, varname, oldYunit))
+
     def compute_conversion_factor(self):
         try:
             self.Xunit_conversion_factor = magnitude.mg(1., self.Xinit_unit, self.Xunit).toval()
         except magnitude.MagnitudeError:
             self.Xunit_conversion_factor = 1.0
-        
+
         try:
             self.Yunit_conversion_factor = magnitude.mg(1., self.Yinit_unit, self.Yunit).toval()
         except magnitude.MagnitudeError:
             self.Yunit_conversion_factor = 1.0
-                   
+
     def set_ticks(self):
         self.compute_conversion_factor()
-        
-        self.figure.gca().xaxis.set_major_locator(ScaledLocator(dx = self.Xunit_conversion_factor))
-        self.figure.gca().xaxis.set_major_formatter(ScaledFormatter(dx = self.Xunit_conversion_factor))      
-        
-        self.figure.gca().yaxis.set_major_locator(ScaledLocator(dx = self.Yunit_conversion_factor))
-        self.figure.gca().yaxis.set_major_formatter(ScaledFormatter(dx = self.Yunit_conversion_factor)) 
-                                                    
-    def unique(self, key, dic):
+
+        self.figure.gca().xaxis.set_major_locator(ScaledLocator(dx=self.Xunit_conversion_factor))
+        self.figure.gca().xaxis.set_major_formatter(ScaledFormatter(dx=self.Xunit_conversion_factor))
+
+        self.figure.gca().yaxis.set_major_locator(ScaledLocator(dx=self.Yunit_conversion_factor))
+        self.figure.gca().yaxis.set_major_formatter(ScaledFormatter(dx=self.Yunit_conversion_factor))
+
+    @staticmethod
+    def unique(key, dic):
         skey = key
         i = 0
         while dic.has_key(key):
-            key = skey + '_%d'%i
+            key = skey + '_%d' % i
             i += 1
-        return key 
-    
-    def general_setting_dialog(self, event = None):
+        return key
+
+    def general_setting_dialog(self, event=None):
         d = GeneralSettingsDialog(self)
         d.SetFocus()
         d.ShowModal()
         d.Destroy()
-        
-    def axes_setting_dialog(self, event = None):
+
+    def axes_setting_dialog(self, event=None):
         d = AxesSettingsDialog(self)
         d.SetFocus()
         d.ShowModal()
         d.Destroy()
-        
-    def lines_setting_dialog(self, event = None):
+
+    def lines_setting_dialog(self, event=None):
         d = LinesSettingsDialog(self)
         d.SetFocus()
         d.ShowModal()
-        d.Destroy()    
+        d.Destroy()

--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -233,7 +233,7 @@ class DataPanel(wx.Panel):
         
     def show_data(self):
         self.datalist.DeleteAllItems()
-        forbidden_vars = ['description', 'step', 'time', 'box size', 'configuration', 'gradients']
+        forbidden_vars = ['description', 'step', 'time', 'box_size', 'configuration', 'gradients', 'velocities']
         variables = [key for key in self.dataproxy.keys() if key not in forbidden_vars]
         for i, var in enumerate(sorted(variables)):
             self.datalist.InsertStringItem(i, var)

--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -14,6 +14,8 @@
 
 import collections
 
+import numpy
+
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg
 
@@ -425,6 +427,9 @@ class PlotterFrame(wx.Frame):
             _vars = f.variables
             data = collections.OrderedDict()
             for k in _vars:
+                dtype = _vars[k].getValue().dtype
+                if not numpy.issubdtype(dtype,numpy.number):
+                    continue
                 data[k]={}
                 if hasattr(_vars[k], 'axis'):
                     if _vars[k].axis:

--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -233,7 +233,9 @@ class DataPanel(wx.Panel):
         
     def show_data(self):
         self.datalist.DeleteAllItems()
-        for i, var in enumerate(sorted(self.dataproxy.keys())):
+        forbidden_vars = ['description', 'step', 'time', 'box size', 'configuration', 'gradients']
+        variables = [key for key in self.dataproxy.keys() if key not in forbidden_vars]
+        for i, var in enumerate(sorted(variables)):
             self.datalist.InsertStringItem(i, var)
             #self.datalist.SetStringItem(i, 1,self.dataproxy[var]['units'])
             axis = ','.join(self.dataproxy[var]['axis'])

--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -109,23 +109,29 @@ class DataPanel(wx.Panel):
         sizer0 =  wx.BoxSizer(wx.VERTICAL)
         
         if self.standalone:
-            self.datasetlist = wx.ListCtrl(self.setup, wx.ID_ANY,style = wx.LC_REPORT|wx.LC_SINGLE_SEL)
+            splitterWindow = wx.SplitterWindow(self.setup, style=wx.SP_LIVE_UPDATE)
+            splitterWindow.SetMinimumPaneSize(50)
+
+            self.datasetlist = wx.ListCtrl(splitterWindow, wx.ID_ANY,style = wx.LC_REPORT|wx.LC_SINGLE_SEL)
             self.datasetlist.InsertColumn(0, 'key', width=100)
             self.datasetlist.InsertColumn(1, 'filename', width=100)
             self.datasetlist.InsertColumn(2, 'path', width=500)
             
-            sizer0.Add(self.datasetlist, 1, wx.ALL|wx.EXPAND, 2)
-            
             self.Bind(wx.EVT_LIST_ITEM_SELECTED, self.on_select_dataset,  self.datasetlist) 
             self.Bind(wx.EVT_LIST_KEY_DOWN, self.delete_dataset, self.datasetlist)
 
-        self.datalist = wx.ListCtrl(self.setup, wx.ID_ANY,style = wx.LC_REPORT|wx.LC_SINGLE_SEL)
+            self.datalist = wx.ListCtrl(splitterWindow, wx.ID_ANY,style = wx.LC_REPORT|wx.LC_SINGLE_SEL)
+        else:
+            self.datalist = wx.ListCtrl(self.setup, wx.ID_ANY,style = wx.LC_REPORT|wx.LC_SINGLE_SEL)
+
         self.datalist.InsertColumn(0, 'Variable', width=100)
-#        self.datalist.InsertColumn(1, 'Unit', width=65)
         self.datalist.InsertColumn(1, 'Axis', width=50)
         self.datalist.InsertColumn(2, 'Dimension')
         self.datalist.InsertColumn(3, 'Size')
         
+        if self.standalone:
+            splitterWindow.SplitHorizontally(self.datasetlist,self.datalist)
+
         sizer1 =  wx.BoxSizer(wx.HORIZONTAL)
        
         self.plot_type_label = wx.StaticText(self.setup, label="Select Plotter")
@@ -143,7 +149,10 @@ class DataPanel(wx.Panel):
         sizer2.Add(self.plot_button, 1, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND)
         sizer2.Add(self.replot_button, 1, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND)
         
-        sizer0.Add(self.datalist, 2, wx.ALL|wx.EXPAND, 2)
+        if self.standalone:        
+            sizer0.Add(splitterWindow, 2, wx.ALL|wx.EXPAND, 2)
+        else:
+            sizer0.Add(self.datalist, 2, wx.ALL|wx.EXPAND, 2)
         sizer0.Add(sizer1, 0, wx.ALL|wx.EXPAND, 2)
         sizer0.Add(sizer2, 0, wx.ALL|wx.EXPAND, 2)
         

--- a/Src/GUI/Plugins/PlotterSettings.py
+++ b/Src/GUI/Plugins/PlotterSettings.py
@@ -492,7 +492,7 @@ class AxesSettingsDialog(wx.Dialog, UnitsSettingsDialog):
         self.parent.canvas.draw()
     
     def auto_fit(self, event = None):
-        self.parent.on_auto_fit()
+        self.parent.on_auto_fit(event=event)
         self.Xmin.SetValue(str(self.parent.Xmin))
         self.Ymin.SetValue(str(self.parent.Ymin))
         self.Xmax.SetValue(str(self.parent.Xmax))


### PR DESCRIPTION
**Description of work.**

Fixes #24 

Currently, it is possible to plot all variables in a NetCDF file, including those that have no use or even those that do not make sense, such as the description of the trajectory, or time against atomic mass. Several such variables have been prevented from being displayed in the list of variables. If anyone knows of other variables which should not be available for plotting, please let me know.

Furthermore, when data containing non-numeric values is attempted to be plotted, it now results in an error with a meaningful message without actually plotting the data.

**To test:**

1. Load an .nc file containing a trajectory into 2D/3D Plotter.
2. Observe that there are no variables titled 'description', 'step', or 'time' available for plotting.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**.