### PR TITLE
Fix normalisation in GACF and PACF

### DIFF
--- a/Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
@@ -17,7 +17,7 @@ import collections
 from MDANSE import REGISTRY
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import weight
-from MDANSE.Mathematics.Signal import correlation
+from MDANSE.Mathematics.Signal import correlation, normalize
 from MDANSE.MolecularDynamics.Trajectory import read_atoms_trajectory
 
 class GeneralAutoCorrelationFunction(IJob):
@@ -96,8 +96,7 @@ class GeneralAutoCorrelationFunction(IJob):
         element = self.configuration['atom_selection']["names"][index]
         
         self._outputData["gacf_%s" % element] += x        
-        
-    
+
     def finalize(self):
         """
         Finalizes the calculations (e.g. averaging the total term, output files creations ...).
@@ -112,11 +111,11 @@ class GeneralAutoCorrelationFunction(IJob):
                 
         if self.configuration['normalize']["value"]:
             for element in nAtomsPerElement.keys():
-                pacf = self._outputData["gacf_%s" % element]      
-                if pacf[0] == 0:
+                gacf = self._outputData["gacf_%s" % element]
+                if gacf[0] == 0:
                     raise ValueError("The normalization factor is equal to zero !!!") 
                 else:
-                    pacf /= pacf[0]
+                    self._outputData["vacf_%s" % element] = normalize(gacf, axis=0)
 
         weights = self.configuration["weights"].get_weights()
         gacfTotal = weight(weights,self._outputData,nAtomsPerElement,1,"gacf_%s")

--- a/Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
@@ -111,11 +111,10 @@ class GeneralAutoCorrelationFunction(IJob):
                 
         if self.configuration['normalize']["value"]:
             for element in nAtomsPerElement.keys():
-                gacf = self._outputData["gacf_%s" % element]
-                if gacf[0] == 0:
+                if self._outputData["gacf_%s" % element][0] == 0:
                     raise ValueError("The normalization factor is equal to zero !!!") 
                 else:
-                    self._outputData["vacf_%s" % element] = normalize(gacf, axis=0)
+                    self._outputData["gacf_%s" % element] = normalize(self._outputData["gacf_%s" % element], axis=0)
 
         weights = self.configuration["weights"].get_weights()
         gacfTotal = weight(weights,self._outputData,nAtomsPerElement,1,"gacf_%s")

--- a/Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
@@ -105,11 +105,13 @@ class GeneralAutoCorrelationFunction(IJob):
         
         # The MSDs per element are averaged.
         nAtomsPerElement = self.configuration['atom_selection'].get_natoms()
+        self.configuration['atom_selection']['n_atoms_per_element'] = nAtomsPerElement
+
         for element, number in nAtomsPerElement.items():
             self._outputData["gacf_%s" % element] /= number
                 
         if self.configuration['normalize']["value"]:
-            for element in self.configuration['atom_selection']['n_atoms_per_element'].keys():
+            for element in nAtomsPerElement.keys():
                 pacf = self._outputData["gacf_%s" % element]      
                 if pacf[0] == 0:
                     raise ValueError("The normalization factor is equal to zero !!!") 

--- a/Src/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -17,7 +17,7 @@ import collections
 from MDANSE import REGISTRY
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import weight
-from MDANSE.Mathematics.Signal import correlation
+from MDANSE.Mathematics.Signal import correlation, normalize
 from MDANSE.MolecularDynamics.Trajectory import read_atoms_trajectory
 
 class PositionAutoCorrelationFunction(IJob):
@@ -111,11 +111,11 @@ class PositionAutoCorrelationFunction(IJob):
                 
         if self.configuration['normalize']["value"]:
             for element in nAtomsPerElement.keys():
-                pacf = self._outputData["pacf_%s" % element]      
+                pacf = self._outputData["pacf_%s" % element]
                 if pacf[0] == 0:
                     raise ValueError("The normalization factor is equal to zero !!!") 
                 else:
-                    pacf /= pacf[0]
+                    self._outputData["vacf_%s" % element] = normalize(pacf, axis=0)
 
         weights = self.configuration["weights"].get_weights()
         pacfTotal = weight(weights,self._outputData,nAtomsPerElement,1,"pacf_%s")

--- a/Src/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -111,11 +111,10 @@ class PositionAutoCorrelationFunction(IJob):
                 
         if self.configuration['normalize']["value"]:
             for element in nAtomsPerElement.keys():
-                pacf = self._outputData["pacf_%s" % element]
-                if pacf[0] == 0:
+                if self._outputData["pacf_%s" % element][0] == 0:
                     raise ValueError("The normalization factor is equal to zero !!!") 
                 else:
-                    self._outputData["vacf_%s" % element] = normalize(pacf, axis=0)
+                    self._outputData["pacf_%s" % element] = normalize(self._outputData["pacf_%s" % element], axis=0)
 
         weights = self.configuration["weights"].get_weights()
         pacfTotal = weight(weights,self._outputData,nAtomsPerElement,1,"pacf_%s")

--- a/Src/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -104,11 +104,13 @@ class PositionAutoCorrelationFunction(IJob):
         """ 
 
         nAtomsPerElement = self.configuration['atom_selection'].get_natoms()
+        self.configuration['atom_selection']['n_atoms_per_element'] = nAtomsPerElement
+
         for element, number in nAtomsPerElement.items():
             self._outputData["pacf_%s" % element] /= number
                 
         if self.configuration['normalize']["value"]:
-            for element in self.configuration['atom_selection']['n_atoms_per_element'].keys():
+            for element in nAtomsPerElement.keys():
                 pacf = self._outputData["pacf_%s" % element]      
                 if pacf[0] == 0:
                     raise ValueError("The normalization factor is equal to zero !!!") 


### PR DESCRIPTION
**Description of work.**

Fixes #22 

Currently, normalisation does not work in GACF and PACF because during it, a part of the configuration dictionary which does not exist is being accessed. This has been fixed by add the necessary values to configuration. The old normalisation has also been replaced with the `MDANSE.Mathematics.Signal.normalize` function that is used in VACF.

**To test:**

1. Run GACF analysis with `normalize` box ticked.
2. Run PACF analysis with `normalize` box ticked.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**.