### PR TITLE
Fix Gromacs converter via macro name correction

### DIFF
--- a/Extensions/xtc/src/xdr_seek.c
+++ b/Extensions/xtc/src/xdr_seek.c
@@ -38,7 +38,7 @@ int xdr_seek(XDRFILE *xd, int64_t pos, int whence)
 #ifndef _WIN32
 	// use posix 64 bit ftell version
 	result = fseeko(fptr, pos, whence) < 0 ? exdrNR : exdrOK;
-#elif _MSVC_VER && !__INTEL_COMPILER
+#elif _MSC_VER && !__INTEL_COMPILER
 	result = _fseeki64(fptr, pos, whence) < 0 ? exdrNR : exdrOK;
 #else
 	result = fseek(fptr, pos, whence) < 0 ? exdrNR : exdrOK;


### PR DESCRIPTION
**Description of work.**

Fixes #31 and closes #32

The seek function uses during the calculation of offsets and the length used `_MSVC_VER` predefined macro to recognise the system as Windows and therefore use the appropriate function, `_fseeki64`, for the seeking process. However, such a macro does not exist, resulting in seeking occurring using the `fseek` function instead, which causes errors with large trajectories. This has been fixed by correcting the name of the predefined macro to `_MSC_VER` which does exist and so makes the code run as intended.

**To test:**

1. Acquire a large Gromacs trajectory (at least 75000 frames). Contact me or @sanghamitra-mukhopadhyay if you do not have one.
2. Run Gromacs converter on the trajectory using MDANSE from this branch

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**.