### PR TITLE
Fix velocity reading in CASTEP converter

### DIFF
--- a/Src/Framework/Jobs/Castep.py
+++ b/Src/Framework/Jobs/Castep.py
@@ -190,7 +190,7 @@ class CASTEPConverter(Converter):
         self._universe.initializeVelocitiesToTemperature(0.)
         self._velocities = ParticleVector(self._universe)
 
-        self._gradients = ParticleVector(self._universe)        
+        self._forces = ParticleVector(self._universe)
 
         # A MMTK trajectory is opened for writing.
         self._trajectory = Trajectory(self._universe, self.configuration['output_files']['files'][0], mode='w')
@@ -225,13 +225,13 @@ class CASTEPConverter(Converter):
         
         data = {"time": timeStep}
 
-        # Retrieve the positions multiplied by Units.Bohr*Units.Hartree/Units.hbar and save them as universe velocities
+        # Retrieve the velocities multiplied by Units.Bohr*Units.Hartree/Units.hbar and save them
         self._velocities.array = config[nAtoms:2*nAtoms, :]
         self._universe.setVelocities(self._velocities)
 
-        # Retrieve the positions multiplied by Units.Hartree/Units.Bohr and save them
-        self._gradients.array = config[2*nAtoms:3*nAtoms, :]
-        data["gradients"] = self._gradients
+        # Retrieve the forces multiplied by Units.Hartree/Units.Bohr and save them
+        self._forces.array = config[2 * nAtoms:3 * nAtoms, :]
+        data["forces"] = self._forces
 
         # Store a snapshot of the current configuration in the output trajectory.
         self._snapshot(data=data)                                          


### PR DESCRIPTION
**Description of work.**

Fixes #38, making progress on #27 

Currently, CASTEP converter correctly reads velocities and forces from MD files, but it does not save them into NetCDF file correctly. The cause of this has been identified as the fact that forces are saved as [energy] gradients, though the exact reason why MMTK has issues with gradients is unknown. By saving forces as forces, the same way it is done in the DL_POLY converter which works well, the CASTEP converter now correctly saves the read velocities into the .nc file, which then can be used in analyses.

**To test:**

1. Convert an MD file using the CASTEP converter.
2. Use that converted NetCDF file for the Current Correlation Function (or other ones which require velocities) analysis.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**.