### PR TITLE
Fix continuous deployment on Ubuntu

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,8 +115,11 @@ jobs:
           path: ~/
 
       - name: Untar artifacts
+        run: tar -xzf ~/python.tar.gz -C $HOME
+
+      - name: Install netcdf
         run: |
-          tar -xzf ~/python.tar.gz -C $HOME
+          sudo apt-get update
           sudo apt-get install netcdf-bin libnetcdf-dev
 
       - name: Install wx


### PR DESCRIPTION
The continuous deployment part of the Ubuntu CI/CD pipeline is currently failing because `apt-get` is having issues. This can be solved by updating `apt-get` before it is used to install packages, as has been done for the CI part in #20 but forgotten for the CD part. This PR remedies that.