### PR TITLE
Use netCDF4 as the NetCDF dependency instead of Scientific.IO/NetCDF

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -372,7 +372,8 @@ jobs:
           dir
         shell: cmd
 
-      - run: %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe -c "import netCDF4"
+      - run: "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -c "import netCDF4"
+        shell: cmd
 
       - name: Install static dependencies
         if: steps.python-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -217,12 +217,13 @@ jobs:
         run: |
           sudo conda create -p ~/tempenv python=2.7
           sudo conda install -p ~/tempenv netcdf4
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
           sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libmfhdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libjpeg* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
 
       - name: Install NetCDF
         run: |
@@ -372,15 +373,11 @@ jobs:
         run: C:\Miniconda\condabin\conda.bat install -p D:\tempenv netcdf4
         shell: cmd
 
-      - run: |
+      - name: Copy installed packages to main python and copy netcdf dlls into netCDF directory
+        run: |
           xcopy "D:\tempenv\lib\site-packages\netCDF4" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4\" /e /r /h /a /y /I /f
           xcopy "D:\tempenv\lib\site-packages\cftime" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime\" /e /r /h /a /y /I /f
-        shell: cmd
-
-      - run: |
           copy %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\netcdf\*.dll %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4\
-          "D:\tempenv\python.exe" -c "import netCDF4"
-          "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -c "import netCDF4"
         shell: cmd
 
       - name: Install static dependencies
@@ -544,12 +541,20 @@ jobs:
           "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -m pip install --upgrade numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro sphinx==1.6.7 stdeb docutils==0.17.1
         shell: cmd
 
-      - name: Install netCDF4 python package
+      - name: Create conda environment
+        run: C:\Miniconda\condabin\conda.bat create -p D:\tempenv python=2.7
+        shell: cmd
+
+      - name: Install netCDF4 into the environment
+        run: C:\Miniconda\condabin\conda.bat install -p D:\tempenv netcdf4
+        shell: cmd
+
+      - name: Copy installed packages to main python and copy netcdf dlls into netCDF directory
         run: |
-          C:\Miniconda\condabin\conda.bat create -p %HOME%\tempenv python=2.7
-          C:\Miniconda\condabin\conda.bat install -p %HOME%\tempenv netcdf4
-          xcopy %HOME%\tempenv\lib\python2.7\site-packages\netCDF4 %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
-          xcopy %HOME%\tempenv\lib\python2.7\site-packages\cftime %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
+          xcopy "D:\tempenv\lib\site-packages\netCDF4" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4\" /e /r /h /a /y /I /f
+          xcopy "D:\tempenv\lib\site-packages\cftime" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime\" /e /r /h /a /y /I /f
+          copy %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\netcdf\*.dll %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4\ /y
+        shell: cmd
 
       - name: Deploy
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,15 +35,6 @@ jobs:
           python2 -m pip install numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro sphinx==1.6.7 stdeb docutils==0.17.1
           sudo cp /usr/include/netcdf.h $RUNNER_TOOL_CACHE/Python/2.7.18/x64/include/python2.7
 
-      - name: Install netCDF4 python package
-        run: |
-          sudo conda create -p ~/tempenv python=2.7
-          sudo conda install -p ~/tempenv netcdf4
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
-          sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
-          sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
-
       - name: Install ScientificPython
         run: |
           cd $HOME
@@ -59,19 +50,32 @@ jobs:
           sudo cp -fv $GITHUB_WORKSPACE/BuildServer/Unix/setup.py ~/mmtk
           sudo $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python setup.py install
 
+      - run: |
+          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/Scientific
+          ls
+          export PATH=$PATH:/usr/lib/x86_64-linux-gnu
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
+          $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "from Scientific.IO import NetCDF"
+          $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "from MMTK.Trajectory import Trajectory"
+
+      - name: Install netCDF4 python package
+        run: |
+          sudo conda create -p ~/tempenv python=2.7
+          sudo conda install -p ~/tempenv netcdf4
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
+          sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+
       - name: Install MDANSE
         run: |
           cd $GITHUB_WORKSPACE
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python setup.py install
 
-      - run: |
-          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/Scientific
-          ls
-          $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "from Scientific.IO import NetCDF"
-
       - name: Run tests
         run: |
           export PATH=$PATH:/usr/lib/x86_64-linux-gnu
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
           source $GITHUB_WORKSPACE/BuildServer/Unix/MacOS/definitions.sh
           $GITHUB_WORKSPACE/BuildServer/Unix/tests.sh
 
@@ -368,12 +372,10 @@ jobs:
       - run: |
           xcopy "D:\tempenv\lib\site-packages\netCDF4" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4\" /e /r /h /a /y /I /f
           xcopy "D:\tempenv\lib\site-packages\cftime" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime\" /e /r /h /a /y /I /f
-          copy "D:\tempenv\msvc*" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64"
-          cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64"
-          dir
         shell: cmd
 
       - run: |
+          copy %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\netcdf\*.dll %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\DLLs
           "D:\tempenv\python.exe" -c "import netCDF4"
           "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -c "import netCDF4"
         shell: cmd

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,8 +39,10 @@ jobs:
         run: |
           sudo conda create -p ~/tempenv python=2.7
           sudo conda install -p ~/tempenv netcdf4
-          sudo cp -r ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
-          sudo cp -r ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          cd ~/tempenv/lib/python2.7/site-packages/
+          ls
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
 
       - name: Install ScientificPython
         run: |
@@ -349,8 +351,8 @@ jobs:
         run: |
           C:\Miniconda\condabin\conda.bat create -p %HOME%\tempenv python=2.7
           C:\Miniconda\condabin\conda.bat install -p %HOME%\tempenv netcdf4
-          xcopy %HOME%\tempenv\lib\python2.7\site-packages\netCDF4 %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
-          xcopy %HOME%\tempenv\lib\python2.7\site-packages\cftime %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
+          xcopy %HOME%\tempenv\lib\site-packages\netCDF4 %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
+          xcopy %HOME%\tempenv\lib\site-packages\cftime %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
 
       - name: Install static dependencies
         if: steps.python-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           export PATH=$PATH:/usr/lib/x86_64-linux-gnu
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
-          source $GITHUB_WORKSPACE/BuildServer/Unix/MacOS/definitions.sh
+          source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/definitions.sh
           $GITHUB_WORKSPACE/BuildServer/Unix/tests.sh
 
       - name: Tar artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,11 +67,11 @@ jobs:
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python setup.py install
 
       - run: |
-          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          cd /usr/lib
           ls
-          cd python2.7
-          ls
-          cd site-packages
+          echo $PATH
+          echo $LD_LIBRARY_PATH
+          cd /usr/local/lib
           ls
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "import Scientific.IO.NetCDF"
 
@@ -374,8 +374,8 @@ jobs:
       - run: |
           cd /d "D:\tempenv\lib\site-packages\"
           dir
-          xcopy "D:\tempenv\lib\site-packages\netCDF4" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
-          xcopy "D:\tempenv\lib\site-packages\cftime" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
+          xcopy "D:\tempenv\lib\site-packages\netCDF4" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4\" /e /r /h /a /y /I /f
+          xcopy "D:\tempenv\lib\site-packages\cftime" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime\" /e /r /h /a /y /I /f
           cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"
           dir
         shell: cmd

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,14 +62,6 @@ jobs:
           sudo cp -fv $GITHUB_WORKSPACE/BuildServer/Unix/setup.py ~/mmtk
           sudo $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python setup.py install
 
-      - run: |
-          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/Scientific
-          ls
-          export PATH=$PATH:/usr/lib/x86_64-linux-gnu
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
-          $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "from Scientific.IO import NetCDF"
-          $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "from MMTK.Trajectory import Trajectory"
-
       - name: Install MDANSE
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,8 @@ jobs:
           sudo conda install -p ~/tempenv netcdf4
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
+          sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
 
       - name: Install ScientificPython
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,8 +41,8 @@ jobs:
           sudo conda install -p ~/tempenv netcdf4
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
-          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
-          ls
+          sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
 
       - name: Install ScientificPython
         run: |
@@ -206,6 +206,8 @@ jobs:
           sudo conda install -p ~/tempenv netcdf4
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
+          sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
 
       - name: Install NetCDF
         run: |
@@ -350,11 +352,12 @@ jobs:
       - name: Install netCDF4 python package
         run: |
           set HOME=%HOMEDRIVE%%HOMEPATH%
-          echo %HOME%
-          C:\Miniconda\condabin\conda.bat create -p %HOMEDRIVE%%HOMEPATH%\tempenv python=2.7
-          C:\Miniconda\condabin\conda.bat install -p %HOMEDRIVE%%HOMEPATH%\tempenv netcdf4
-          xcopy %HOMEDRIVE%%HOMEPATH%\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
-          xcopy %HOMEDRIVE%%HOMEPATH%\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
+          C:\Miniconda\condabin\conda.bat create -p %HOME%\tempenv python=2.7
+          C:\Miniconda\condabin\conda.bat install -p %HOME%\tempenv netcdf4
+          xcopy %HOME%\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I /f
+          xcopy %HOME%\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I /f
+          cd %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\
+          dir
         shell: cmd
 
       - name: Install static dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,10 +64,14 @@ jobs:
           cd $GITHUB_WORKSPACE
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python setup.py install
 
+      - run: |
+          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/Scientific
+          ls
+          $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "from MMTK.Trajectory import Trajectory"
+
       - name: Run tests
         run: |
           export PATH=$PATH:/usr/lib/x86_64-linux-gnu
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
           source $GITHUB_WORKSPACE/BuildServer/Unix/MacOS/definitions.sh
           $GITHUB_WORKSPACE/BuildServer/Unix/tests.sh
 
@@ -367,6 +371,8 @@ jobs:
           cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4"
           dir
         shell: cmd
+
+      - run: %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe -c "import netCDF4"
 
       - name: Install static dependencies
         if: steps.python-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,9 +18,6 @@ jobs:
         with:
           python-version: '2.7.18'
 
-      - run: |
-          ls -lrth /
-
       - name: Install libraries on ubuntu 18
         if: ${{ (matrix.os == 'ubuntu-18.04') }}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,9 +39,9 @@ jobs:
         run: |
           sudo conda create -p ~/tempenv python=2.7
           sudo conda install -p ~/tempenv netcdf4
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages/
-          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
+          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
           ls
 
       - name: Install ScientificPython
@@ -204,8 +204,8 @@ jobs:
         run: |
           sudo conda create -p ~/tempenv python=2.7
           sudo conda install -p ~/tempenv netcdf4
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
 
       - name: Install NetCDF
         run: |
@@ -350,10 +350,11 @@ jobs:
       - name: Install netCDF4 python package
         run: |
           set HOME=%HOMEDRIVE%%HOMEPATH%
-          C:\Miniconda\condabin\conda.bat create -p %HOME%\tempenv python=2.7
-          C:\Miniconda\condabin\conda.bat install -p %HOME%\tempenv netcdf4
-          xcopy %HOME%\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
-          xcopy %HOME%\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
+          echo %HOME%
+          C:\Miniconda\condabin\conda.bat create -p %HOMEDRIVE%%HOMEPATH%\tempenv python=2.7
+          C:\Miniconda\condabin\conda.bat install -p %HOMEDRIVE%%HOMEPATH%\tempenv netcdf4
+          xcopy %HOMEDRIVE%%HOMEPATH%\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
+          xcopy %HOMEDRIVE%%HOMEPATH%\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
         shell: cmd
 
       - name: Install static dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,9 +39,8 @@ jobs:
         run: |
           sudo conda create -p ~/tempenv python=2.7
           sudo conda install -p ~/tempenv netcdf4
-          cd ~/tempenv/lib/python2.7/site-packages/
-          ls
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          sudo mkdir $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages/netCDF4
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages/netCDF4
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
 
       - name: Install ScientificPython
@@ -351,8 +350,10 @@ jobs:
         run: |
           C:\Miniconda\condabin\conda.bat create -p %HOME%\tempenv python=2.7
           C:\Miniconda\condabin\conda.bat install -p %HOME%\tempenv netcdf4
-          xcopy %HOME%\tempenv\lib\site-packages\netCDF4 %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
-          xcopy %HOME%\tempenv\lib\site-packages\cftime %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
+          cd %HOME%\tempenv\lib\site-packages\
+          dir
+          xcopy %HOME%\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
+          xcopy %HOME%\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
 
       - name: Install static dependencies
         if: steps.python-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,17 +62,10 @@ jobs:
           cd $GITHUB_WORKSPACE
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python setup.py install
 
-      - run: |
-          cd /usr/lib/x86_64-linux-gnu
-          ls
-          export PATH=$PATH:/usr/lib/x86_64-linux-gnu
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
-          echo $PATH
-          echo $LD_LIBRARY_PATH
-          $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "import Scientific.IO.NetCDF"
-
       - name: Run tests
         run: |
+          export PATH=$PATH:/usr/lib/x86_64-linux-gnu
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
           source $GITHUB_WORKSPACE/BuildServer/Unix/MacOS/definitions.sh
           $GITHUB_WORKSPACE/BuildServer/Unix/tests.sh
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,14 @@ jobs:
           cd $GITHUB_WORKSPACE
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python setup.py install
 
-      - run: $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "import Scientific.IO.NetCDF"
+      - run: |
+          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          ls
+          cd python2.7
+          ls
+          cd site-packages
+          ls
+          $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "import Scientific.IO.NetCDF"
 
       - name: Run tests
         run: |
@@ -367,8 +374,8 @@ jobs:
       - run: |
           cd /d "D:\tempenv\lib\site-packages\"
           dir
-          xcopy "D:\tempenv\lib\site-packages\netCDF4\" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
-          xcopy "D:\tempenv\lib\site-packages\cftime\" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
+          xcopy "D:\tempenv\lib\site-packages\netCDF4" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
+          xcopy "D:\tempenv\lib\site-packages\cftime" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
           cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"
           dir
         shell: cmd

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,13 @@ jobs:
           python2 -m pip install numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro sphinx==1.6.7 stdeb docutils==0.17.1
           sudo cp /usr/include/netcdf.h $RUNNER_TOOL_CACHE/Python/2.7.18/x64/include/python2.7
 
+      - name: Install netCDF4 python package
+        run: |
+          sudo conda create -p ~/tempenv python=2.7
+          sudo conda install -p ~/tempenv netcdf4
+          sudo cp -r ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          sudo cp -r ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+
       - name: Install ScientificPython
         run: |
           cd $HOME
@@ -191,6 +198,13 @@ jobs:
         run: |
           python2 -m pip install numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro sphinx==1.6.7 stdeb docutils==0.17.1 py2app==0.26.1
 
+      - name: Install netCDF4 python package
+        run: |
+          sudo conda create -p ~/tempenv python=2.7
+          sudo conda install -p ~/tempenv netcdf4
+          sudo cp -r ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          sudo cp -r ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+
       - name: Install NetCDF
         run: |
           brew install netcdf
@@ -330,6 +344,13 @@ jobs:
         run: |
           "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -m pip install --upgrade numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro sphinx==1.6.7 stdeb docutils==0.17.1
         shell: cmd
+
+      - name: Install netCDF4 python package
+        run: |
+          C:\Miniconda\condabin\conda.bat create -p %HOME%\tempenv python=2.7
+          C:\Miniconda\condabin\conda.bat install -p %HOME%\tempenv netcdf4
+          xcopy %HOME%\tempenv\lib\python2.7\site-packages\netCDF4 %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
+          xcopy %HOME%\tempenv\lib\python2.7\site-packages\cftime %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
 
       - name: Install static dependencies
         if: steps.python-cache.outputs.cache-hit != 'true'
@@ -491,6 +512,13 @@ jobs:
         run: |
           "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -m pip install --upgrade numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro sphinx==1.6.7 stdeb docutils==0.17.1
         shell: cmd
+
+      - name: Install netCDF4 python package
+        run: |
+          C:\Miniconda\condabin\conda.bat create -p %HOME%\tempenv python=2.7
+          C:\Miniconda\condabin\conda.bat install -p %HOME%\tempenv netcdf4
+          xcopy %HOME%\tempenv\lib\python2.7\site-packages\netCDF4 %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
+          xcopy %HOME%\tempenv\lib\python2.7\site-packages\cftime %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
 
       - name: Deploy
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,10 +41,6 @@ jobs:
           sudo conda install -p ~/tempenv netcdf4
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
-          sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
-          sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
-          sudo cp -rfv ~/tempenv/lib/libmfhdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
-          sudo cp -rfv ~/tempenv/lib/libdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
 
       - name: Install ScientificPython
         run: |
@@ -67,12 +63,12 @@ jobs:
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python setup.py install
 
       - run: |
-          cd /usr/lib
+          cd /usr/lib/x86_64-linux-gnu
           ls
+          export PATH=$PATH:/usr/lib/x86_64-linux-gnu
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
           echo $PATH
           echo $LD_LIBRARY_PATH
-          cd /usr/local/lib
-          ls
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "import Scientific.IO.NetCDF"
 
       - name: Run tests
@@ -362,21 +358,18 @@ jobs:
           "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -m pip install --upgrade numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro sphinx==1.6.7 stdeb docutils==0.17.1
         shell: cmd
 
-      - name: Install netCDF4 python package
-        run: |
-          C:\Miniconda\condabin\conda.bat create -p D:\tempenv python=2.7
+      - name: Create conda environment
+        run: C:\Miniconda\condabin\conda.bat create -p D:\tempenv python=2.7
+        shell: cmd
+
+      - name: Install netCDF4 into the environment
+        run: C:\Miniconda\condabin\conda.bat install -p D:\tempenv netcdf4
         shell: cmd
 
       - run: |
-          C:\Miniconda\condabin\conda.bat install -p D:\tempenv netcdf4
-        shell: cmd
-
-      - run: |
-          cd /d "D:\tempenv\lib\site-packages\"
-          dir
           xcopy "D:\tempenv\lib\site-packages\netCDF4" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4\" /e /r /h /a /y /I /f
           xcopy "D:\tempenv\lib\site-packages\cftime" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime\" /e /r /h /a /y /I /f
-          cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"
+          cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4"
           dir
         shell: cmd
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,7 @@ jobs:
           sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libmfhdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
 
       - name: Install ScientificPython
         run: |
@@ -212,6 +213,7 @@ jobs:
           sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libmfhdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
 
       - name: Install NetCDF
         run: |
@@ -363,6 +365,8 @@ jobs:
         shell: cmd
 
       - run: |
+          cd /d "D:\tempenv\lib\site-packages\"
+          dir
           xcopy "D:\tempenv\lib\site-packages\netCDF4\" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
           xcopy "D:\tempenv\lib\site-packages\cftime\" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
           cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,6 +64,8 @@ jobs:
           cd $GITHUB_WORKSPACE
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python setup.py install
 
+      - run: $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "import Scientific.IO.NetCDF"
+
       - name: Run tests
         run: |
           source $GITHUB_WORKSPACE/BuildServer/Unix/MacOS/definitions.sh
@@ -354,17 +356,17 @@ jobs:
           set HOME=%HOMEDRIVE%%HOMEPATH%
           C:\Miniconda\condabin\conda.bat create -p D:\tempenv python=2.7
           C:\Miniconda\condabin\conda.bat install -p D:\tempenv netcdf4
-          xcopy D:\tempenv\lib\site-packages\netCDF4\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4" /e /r /h /a /y /I /f
-          xcopy D:\tempenv\lib\site-packages\cftime\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime" /e /r /h /a /y /I /f
-          cd "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"
+          xcopy D:\tempenv\lib\site-packages\netCDF4\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages" /e /r /h /a /y /I /f
+          xcopy D:\tempenv\lib\site-packages\cftime\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages" /e /r /h /a /y /I /f
+          cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"
           dir
         shell: cmd
 
       - run: |
-          echo %RUNNER_TOOL_CACHE%
-          xcopy D:\tempenv\lib\site-packages\netCDF4\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4" /e /r /h /a /y /I /f
-          xcopy D:\tempenv\lib\site-packages\cftime\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime" /e /r /h /a /y /I /f
-          cd "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"
+          echo "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4"
+          xcopy "D:\tempenv\lib\site-packages\netCDF4\" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
+          xcopy "D:\tempenv\lib\site-packages\cftime\" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
+          cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"
           dir
         shell: cmd
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,7 @@ jobs:
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
           sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libmfhdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
 
       - name: Install ScientificPython
         run: |
@@ -210,6 +211,7 @@ jobs:
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
           sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libmfhdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
 
       - name: Install NetCDF
         run: |
@@ -353,17 +355,14 @@ jobs:
 
       - name: Install netCDF4 python package
         run: |
-          set HOME=%HOMEDRIVE%%HOMEPATH%
           C:\Miniconda\condabin\conda.bat create -p D:\tempenv python=2.7
-          C:\Miniconda\condabin\conda.bat install -p D:\tempenv netcdf4
-          xcopy D:\tempenv\lib\site-packages\netCDF4\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages" /e /r /h /a /y /I /f
-          xcopy D:\tempenv\lib\site-packages\cftime\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages" /e /r /h /a /y /I /f
-          cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"
-          dir
         shell: cmd
 
       - run: |
-          echo "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4"
+          C:\Miniconda\condabin\conda.bat install -p D:\tempenv netcdf4
+        shell: cmd
+
+      - run: |
           xcopy "D:\tempenv\lib\site-packages\netCDF4\" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
           xcopy "D:\tempenv\lib\site-packages\cftime\" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\" /e /r /h /a /y /I /f
           cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,9 +39,12 @@ jobs:
         run: |
           sudo conda create -p ~/tempenv python=2.7
           sudo conda install -p ~/tempenv netcdf4
-          sudo mkdir $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages/netCDF4
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages/netCDF4
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages/
+          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          ls
+          sudo mkdir netCDF4/
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages/netCDF4
 
       - name: Install ScientificPython
         run: |
@@ -203,8 +206,8 @@ jobs:
         run: |
           sudo conda create -p ~/tempenv python=2.7
           sudo conda install -p ~/tempenv netcdf4
-          sudo cp -r ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
-          sudo cp -r ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
 
       - name: Install NetCDF
         run: |
@@ -348,9 +351,11 @@ jobs:
 
       - name: Install netCDF4 python package
         run: |
+          echo %HOME%
           C:\Miniconda\condabin\conda.bat create -p %HOME%\tempenv python=2.7
           C:\Miniconda\condabin\conda.bat install -p %HOME%\tempenv netcdf4
-          cd %HOME%\tempenv\lib\site-packages\
+          echo %HOME%
+          cd "%HOME%\tempenv\lib\site-packages\"
           dir
           xcopy %HOME%\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
           xcopy %HOME%\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
       - run: |
           cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/Scientific
           ls
-          $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "from MMTK.Trajectory import Trajectory"
+          $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "from Scientific.IO import NetCDF"
 
       - name: Run tests
         run: |
@@ -368,11 +368,13 @@ jobs:
       - run: |
           xcopy "D:\tempenv\lib\site-packages\netCDF4" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4\" /e /r /h /a /y /I /f
           xcopy "D:\tempenv\lib\site-packages\cftime" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime\" /e /r /h /a /y /I /f
-          cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4"
+          copy "D:\tempenv\msvc*" "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64"
+          cd /d "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64"
           dir
         shell: cmd
 
       - run: |
+          "D:\tempenv\python.exe" -c "import netCDF4"
           "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -c "import netCDF4"
         shell: cmd
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -352,13 +352,19 @@ jobs:
       - name: Install netCDF4 python package
         run: |
           set HOME=%HOMEDRIVE%%HOMEPATH%
-          C:\Miniconda\condabin\conda.bat create -p %HOME%\tempenv python=2.7
-          C:\Miniconda\condabin\conda.bat install -p %HOME%\tempenv netcdf4
-          xcopy %HOME%\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I /f
-          xcopy %HOME%\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I /f
+          C:\Miniconda\condabin\conda.bat create -p D:\tempenv python=2.7
+          C:\Miniconda\condabin\conda.bat install -p D:\tempenv netcdf4
+          xcopy D:\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I /f
+          xcopy D:\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I /f
           cd %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\
           dir
         shell: cmd
+
+      - run: |
+          xcopy D:\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I /f
+          xcopy D:\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I /f
+          cd %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\
+          dir
 
       - name: Install static dependencies
         if: steps.python-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -354,17 +354,19 @@ jobs:
           set HOME=%HOMEDRIVE%%HOMEPATH%
           C:\Miniconda\condabin\conda.bat create -p D:\tempenv python=2.7
           C:\Miniconda\condabin\conda.bat install -p D:\tempenv netcdf4
-          xcopy D:\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I /f
-          xcopy D:\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I /f
-          cd %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\
+          xcopy D:\tempenv\lib\site-packages\netCDF4\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4" /e /r /h /a /y /I /f
+          xcopy D:\tempenv\lib\site-packages\cftime\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime" /e /r /h /a /y /I /f
+          cd "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"
           dir
         shell: cmd
 
       - run: |
-          xcopy D:\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I /f
-          xcopy D:\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I /f
-          cd %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\
+          echo %RUNNER_TOOL_CACHE%
+          xcopy D:\tempenv\lib\site-packages\netCDF4\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4" /e /r /h /a /y /I /f
+          xcopy D:\tempenv\lib\site-packages\cftime\ "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime" /e /r /h /a /y /I /f
+          cd "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\"
           dir
+        shell: cmd
 
       - name: Install static dependencies
         if: steps.python-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -372,7 +372,8 @@ jobs:
           dir
         shell: cmd
 
-      - run: "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -c "import netCDF4"
+      - run: |
+          "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -c "import netCDF4"
         shell: cmd
 
       - name: Install static dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,8 +43,6 @@ jobs:
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages/
           cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages
           ls
-          sudo mkdir netCDF4/
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/site-packages/netCDF4
 
       - name: Install ScientificPython
         run: |
@@ -351,14 +349,12 @@ jobs:
 
       - name: Install netCDF4 python package
         run: |
-          echo %HOME%
+          set HOME=%HOMEDRIVE%%HOMEPATH%
           C:\Miniconda\condabin\conda.bat create -p %HOME%\tempenv python=2.7
           C:\Miniconda\condabin\conda.bat install -p %HOME%\tempenv netcdf4
-          echo %HOME%
-          cd "%HOME%\tempenv\lib\site-packages\"
-          dir
           xcopy %HOME%\tempenv\lib\site-packages\netCDF4\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4 /e /r /h /a /y /I
           xcopy %HOME%\tempenv\lib\site-packages\cftime\ %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\cftime /e /r /h /a /y /I
+        shell: cmd
 
       - name: Install static dependencies
         if: steps.python-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,18 @@ jobs:
           python2 -m pip install numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro sphinx==1.6.7 stdeb docutils==0.17.1
           sudo cp /usr/include/netcdf.h $RUNNER_TOOL_CACHE/Python/2.7.18/x64/include/python2.7
 
+      - name: Install netCDF4 python package
+        run: |
+          sudo conda create -p ~/tempenv python=2.7
+          sudo conda install -p ~/tempenv netcdf4
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
+          sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libmfhdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+          sudo cp -rfv ~/tempenv/lib/libjpeg* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
+
       - name: Install ScientificPython
         run: |
           cd $HOME
@@ -57,15 +69,6 @@ jobs:
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "from Scientific.IO import NetCDF"
           $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python -c "from MMTK.Trajectory import Trajectory"
-
-      - name: Install netCDF4 python package
-        run: |
-          sudo conda create -p ~/tempenv python=2.7
-          sudo conda install -p ~/tempenv netcdf4
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
-          sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
-          sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
 
       - name: Install MDANSE
         run: |
@@ -375,7 +378,7 @@ jobs:
         shell: cmd
 
       - run: |
-          copy %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\netcdf\*.dll %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\DLLs
+          copy %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\netcdf\*.dll %RUNNER_TOOL_CACHE%\Python\2.7.18\x64\lib\site-packages\netCDF4\
           "D:\tempenv\python.exe" -c "import netCDF4"
           "%RUNNER_TOOL_CACHE%\Python\2.7.18\x64\python.exe" -c "import netCDF4"
         shell: cmd

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           python-version: '2.7.18'
 
+      - run: |
+          ls -lrth /
+
       - name: Install libraries on ubuntu 18
         if: ${{ (matrix.os == 'ubuntu-18.04') }}
         run: |

--- a/BuildServer/Unix/tests.sh
+++ b/BuildServer/Unix/tests.sh
@@ -35,7 +35,7 @@ fi
 echo -e "${BLUE}""Performing functional tests""${NORMAL}"
 cd $GITHUB_WORKSPACE/Tests/FunctionalTests/Jobs
 python2 BuildJobTests.py
-sudo $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python AllTests.py
+python2 AllTests.py
 status=$?
 if [ $status -ne 0 ]; then
 	echo -e "${RED}" "One or several functional tests failed"

--- a/BuildServer/Unix/tests.sh
+++ b/BuildServer/Unix/tests.sh
@@ -34,9 +34,8 @@ fi
 #############################
 echo -e "${BLUE}""Performing functional tests""${NORMAL}"
 cd $GITHUB_WORKSPACE/Tests/FunctionalTests/Jobs
-rm -rf Test_*
 python2 BuildJobTests.py
-python2 AllTests.py
+sudo $RUNNER_TOOL_CACHE/Python/2.7.18/x64/bin/python AllTests.py
 status=$?
 if [ $status -ne 0 ]; then
 	echo -e "${RED}" "One or several functional tests failed"

--- a/Src/Framework/Configurable.py
+++ b/Src/Framework/Configurable.py
@@ -252,7 +252,8 @@ class Configurable(object):
             try:
                 cfg=REGISTRY["configurator"][typ](name, **kwds)
             except KeyError:
-                raise KeyError(typ, REGISTRY["configurator"])
+                from MDANSE.Framework.Configurators.NetCDFInputFileConfigurator import NetCDFInputFileConfigurator as nc
+                cfg = nc(name, **kwds)
             params[name] = cfg.default
             
         return params

--- a/Src/Framework/Configurable.py
+++ b/Src/Framework/Configurable.py
@@ -249,7 +249,10 @@ class Configurable(object):
                                     
         params = collections.OrderedDict()
         for name,(typ,kwds) in settings.items():
-            cfg=REGISTRY["configurator"][typ](name, **kwds)        
+            try:
+                cfg=REGISTRY["configurator"][typ](name, **kwds)
+            except KeyError:
+                raise KeyError(typ, settings.items(), cls)
             params[name] = cfg.default
             
         return params

--- a/Src/Framework/Configurable.py
+++ b/Src/Framework/Configurable.py
@@ -252,7 +252,7 @@ class Configurable(object):
             try:
                 cfg=REGISTRY["configurator"][typ](name, **kwds)
             except KeyError:
-                raise KeyError(typ, settings.items(), cls)
+                raise KeyError(typ, REGISTRY["configurator"])
             params[name] = cfg.default
             
         return params

--- a/Src/Framework/Configurable.py
+++ b/Src/Framework/Configurable.py
@@ -249,11 +249,7 @@ class Configurable(object):
                                     
         params = collections.OrderedDict()
         for name,(typ,kwds) in settings.items():
-            try:
-                cfg=REGISTRY["configurator"][typ](name, **kwds)
-            except KeyError:
-                from MDANSE.Framework.Configurators.NetCDFInputFileConfigurator import NetCDFInputFileConfigurator as nc
-                cfg = nc(name, **kwds)
+            cfg=REGISTRY["configurator"][typ](name, **kwds)
             params[name] = cfg.default
             
         return params

--- a/Src/Framework/Configurators/NetCDFInputFileConfigurator.py
+++ b/Src/Framework/Configurators/NetCDFInputFileConfigurator.py
@@ -13,7 +13,7 @@
 #
 # **************************************************************************
 
-from Scientific.IO.NetCDF import NetCDFFile
+import netCDF4
 
 from MDANSE import REGISTRY
 from MDANSE.Framework.Configurators.IConfigurator import ConfiguratorError
@@ -59,7 +59,7 @@ class NetCDFInputFileConfigurator(InputFileConfigurator):
         InputFileConfigurator.configure(self, value)
         
         try:
-            self['instance'] = NetCDFFile(self['value'], 'r')
+            self['instance'] = netCDF4.Dataset(self['value'], 'r')
             
         except IOError:
             raise ConfiguratorError("can not open %r NetCDF file for reading" % self['value'])

--- a/Src/Framework/Formats/ASCIIFormat.py
+++ b/Src/Framework/Formats/ASCIIFormat.py
@@ -48,7 +48,7 @@ class ASCIIFormat(IFormat):
         '''
                 
         filename = os.path.splitext(filename)[0]
-        filename = "%s.tar" % filename
+        filename = "%s_ascii.tar" % filename
 
         tf = tarfile.open(filename,'w')
         
@@ -60,7 +60,7 @@ class ASCIIFormat(IFormat):
             cls.write_array(tempStr,var)
             tempStr.seek(0)
 
-            info = tarfile.TarInfo(name='%s%s' % (var.name,cls.extensions[0]))
+            info = tarfile.TarInfo(name='%s%s' % (var.varname,cls.extensions[0]))
             info.size=tempStr.len
             tf.addfile(tarinfo=info, fileobj=tempStr)
             

--- a/Src/Framework/Formats/NetCDFFormat.py
+++ b/Src/Framework/Formats/NetCDFFormat.py
@@ -17,7 +17,7 @@ import os
 
 import numpy
 
-from Scientific.IO.NetCDF import NetCDFFile
+import netCDF4
 
 from MDANSE import REGISTRY
 from MDANSE.Framework.Formats.IFormat import IFormat
@@ -49,7 +49,7 @@ class NetCDFFormat(IFormat):
         filename = "%s%s" % (filename,cls.extensions[0])
        
         # The NetCDF output file is opened for writing.
-        outputFile = NetCDFFile(filename, 'w')
+        outputFile = netCDF4.Dataset(filename, 'w')
         
         if header:
             # This is to avoid any segmentation fault when writing the NetCDF header field
@@ -74,7 +74,7 @@ class NetCDFFormat(IFormat):
             NETCDFVAR = outputFile.createVariable(varName, numpy.dtype(var.dtype).char, tuple(dimensions))
 
             # The array stored in the OutputVariable instance is written to the NetCDF file.
-            NETCDFVAR.assignValue(var)  
+            NETCDFVAR[:] = var
 
             # All the attributes stored in the OutputVariable instance are written to the NetCDF file.
             for k, v in vars(var).items():

--- a/Src/Framework/Formats/NetCDFFormat.py
+++ b/Src/Framework/Formats/NetCDFFormat.py
@@ -61,7 +61,7 @@ class NetCDFFormat(IFormat):
         
         for var in data.values():
                                     
-            varName = str(var.name).strip().encode('string-escape').replace('/', '|')
+            varName = str(var.varname).strip().encode('string-escape').replace('/', '|')
             
             # The NetCDF dimensions are created for all the dimensions of the OutputVariable instance.
             dimensions = []

--- a/Src/Framework/Formats/SVGFormat.py
+++ b/Src/Framework/Formats/SVGFormat.py
@@ -74,15 +74,15 @@ class SVGFormat(IFormat):
                 axis = numpy.arange(len(var))
                 xtitle = 'index'
                 
-            ytitle = "%s (%s)" % (var.name,format_unit_string(var.units))
+            ytitle = "%s (%s)" % (var.varname,format_unit_string(var.units))
                         
             pl = Poly(zip(axis,var),stroke='blue')
 
-            svgfilename = os.path.join(os.path.dirname(filename),'%s%s' % (var.name,cls.extensions[0]))
+            svgfilename = os.path.join(os.path.dirname(filename),'%s%s' % (var.varname,cls.extensions[0]))
             
             Frame(min(axis),max(axis),min(var),max(var),pl,xtitle=xtitle,ytitle=ytitle).SVG().save(svgfilename)
 
-            tf.add(svgfilename, arcname='%s%s' % (var.name,cls.extensions[0]))
+            tf.add(svgfilename, arcname='%s%s' % (var.varname,cls.extensions[0]))
             
             os.remove(svgfilename)
             

--- a/Src/Framework/InputData/NetCDFInputData.py
+++ b/Src/Framework/InputData/NetCDFInputData.py
@@ -15,7 +15,7 @@
 
 import collections
 
-from Scientific.IO.NetCDF import NetCDFFile
+import netCDF4
 
 from MDANSE import REGISTRY
 from MDANSE.Framework.InputData.IInputData import InputDataError
@@ -39,7 +39,7 @@ class NetCDFInputData(InputFileData):
     def load(self):
         
         try:
-            self._netcdf = NetCDFFile(self._name,"r")
+            self._netcdf = netCDF4.Dataset(self._name,"r")
             
         except IOError:
             raise InputDataError("The data stored in %r filename could not be loaded properly." % self._name)
@@ -56,7 +56,7 @@ class NetCDFInputData(InputFileData):
                         self._data[k]['axis'] = []
                 except:
                     self._data[k]['axis'] = []
-                self._data[k]['data'] = variables[k].getValue()
+                self._data[k]['data'] = variables[k][:]
                 self._data[k]['units'] = getattr(variables[k], 'units', 'au')
 
     def close(self):

--- a/Src/Framework/Jobs/LAMMPS.py
+++ b/Src/Framework/Jobs/LAMMPS.py
@@ -292,7 +292,7 @@ class LAMMPSConverter(Converter):
             netcdf.createDimension("MDANSE_NBONDS",self._lammpsConfig["n_bonds"])
             netcdf.createDimension("MDANSE_TWO",2)
             VAR = netcdf.createVariable("mdanse_bonds", numpy.dtype(numpy.int32).char, ("MDANSE_NBONDS","MDANSE_TWO"))
-            VAR.assignValue(self._lammpsConfig["bonds"]) 
+            VAR[:,:] = self._lammpsConfig["bonds"]
                 
         # Close the output trajectory.
         self._trajectory.close()

--- a/Src/Framework/Jobs/McStasVirtualInstrument.py
+++ b/Src/Framework/Jobs/McStasVirtualInstrument.py
@@ -126,7 +126,7 @@ class McStasVirtualInstrument(IJob):
             for var in self.configuration[typ].variables:
                 fout.write("# %s\n" %var)
                 
-                data = self.configuration[typ][var].getValue()
+                data = self.configuration[typ][var][:]
                 try:
                     data *= MCSTAS_UNITS_LUT[self.configuration[typ][var].units]
                 except KeyError:

--- a/Src/Framework/Jobs/RigidBodyTrajectory.py
+++ b/Src/Framework/Jobs/RigidBodyTrajectory.py
@@ -18,10 +18,11 @@ import operator
 
 import numpy
 
+import netCDF4
+
 from Scientific.Geometry import Vector
 from Scientific.Geometry.Quaternion import Quaternion
 from Scientific.Geometry.Transformation import Translation
-from Scientific.IO.NetCDF import NetCDFFile
 
 from MMTK.Collections import Collection
 from MMTK.Trajectory import SnapshotGenerator, Trajectory, TrajectoryOutput
@@ -144,7 +145,7 @@ class RigidBodyTrajectory(IJob):
         '''
         '''
         
-        outputFile = NetCDFFile(self.configuration['output_files']['files'][0], 'a')
+        outputFile = netCDF4.Dataset(self.configuration['output_files']['files'][0], 'a')
  
         outputFile.createDimension('NGROUPS', self.configuration['atom_selection']['selection_length'])
         outputFile.createDimension('NFRAMES', self.configuration['frames']['number'])

--- a/Src/Framework/Jobs/StructureFactorFromScatteringFunction.py
+++ b/Src/Framework/Jobs/StructureFactorFromScatteringFunction.py
@@ -49,25 +49,25 @@ class StructureFactorFromScatteringFunction(IJob):
         
         resolution = self.configuration["instrument_resolution"]
         
-        self._outputData.add("time","line", inputFile.variables['time'].getValue(), units='ps')
+        self._outputData.add("time","line", inputFile.variables['time'][:], units='ps')
 
-        self._outputData.add("time_window","line", inputFile.variables['time_window'].getValue(), axis="time", units="au") 
+        self._outputData.add("time_window","line", inputFile.variables['time_window'][:], axis="time", units="au") 
 
-        self._outputData.add("q","line", inputFile.variables['q'].getValue(), units="inv_nm") 
+        self._outputData.add("q","line", inputFile.variables['q'][:], units="inv_nm") 
 
         self._outputData.add("omega","line", resolution["omega"], units='rad/ps')
         
         self._outputData.add("omega_window","line", resolution["omega_window"], axis="omega", units="au") 
 
-        nQVectors = len(inputFile.variables['q'].getValue())
+        nQVectors = len(inputFile.variables['q'][:])
         nOmegas = resolution['n_omegas']
 
         for k, v in inputFile.variables.items():
             if k.startswith('f(q,t)_'):
-                self._outputData.add(k,"surface", v.getValue(), axis="q|time", units="au")                                                 
+                self._outputData.add(k,"surface", v[:], axis="q|time", units="au")                                                 
                 suffix = k[7:]
                 self._outputData.add("s(q,f)_%s" % suffix,"surface", (nQVectors,nOmegas), axis="q|omega", units="au") 
-                self._outputData["s(q,f)_%s" % suffix][:] = get_spectrum(v.getValue(),
+                self._outputData["s(q,f)_%s" % suffix][:] = get_spectrum(v[:],
                                                                          self.configuration["instrument_resolution"]["time_window"],
                                                                          self.configuration["instrument_resolution"]["time_step"],
                                                                          axis=1)

--- a/Src/Framework/OutputVariables/IOutputVariable.py
+++ b/Src/Framework/OutputVariables/IOutputVariable.py
@@ -44,15 +44,15 @@ class IOutputVariable(numpy.ndarray):
     
     _registry = "output_variable"
         
-    def __new__(cls, value, name, axis='index', units="unitless"):
+    def __new__(cls, value, varname, axis='index', units="unitless"):
         '''
         Instanciate a new MDANSE output variable.
                 
         @param cls: the class to instantiate.
         @type cls: an OutputVariable object
         
-        @param name: the name of the output variable.
-        @type name: string
+        @param varname: the name of the output variable.
+        @type varname: string
         
         @param value: the input numpy array.
         @type value: numpy array
@@ -74,7 +74,7 @@ class IOutputVariable(numpy.ndarray):
         obj = numpy.asarray(value).view(cls)
                                                         
         # The name of the output variable.               
-        obj.name = name
+        obj.varname = varname
                         
         obj.units = units
 
@@ -87,7 +87,7 @@ class IOutputVariable(numpy.ndarray):
         if obj is None:
             return
                 
-        self.name = getattr(obj, 'name', None)
+        self.varname = getattr(obj, 'varname', None)
     
         self.axis = getattr(obj, 'axis',())
 
@@ -101,7 +101,7 @@ class IOutputVariable(numpy.ndarray):
         
         info = []
 
-        info.append("# variable name: %s"  % self.name)
+        info.append("# variable name: %s"  % self.varname)
         info.append("# \ttype: %s"  % self._type)
         info.append("# \taxis: %s" % str(self.axis))
         info.append("# \tunits: %s" % self.units)

--- a/Src/GUI/Plugins/DensitySuperpositionPlugin.py
+++ b/Src/GUI/Plugins/DensitySuperpositionPlugin.py
@@ -20,7 +20,7 @@ import vtk
 
 import numpy
 
-from Scientific.IO.NetCDF import NetCDFFile
+import netCDF4
 
 from MDANSE import REGISTRY
 from MDANSE.Core.Error import Error
@@ -202,13 +202,13 @@ class DensitySuperpositionPlugin(ComponentPlugin):
 
     def select_file(self, filename):
         self.currentFilename = filename
-        f = NetCDFFile(filename,"r")
+        f = netCDF4.Dataset(filename,"r")
         variables = f.variables
         
         if not variables.has_key('molecular_trace'):
             raise DensitySuperpositionError('Trace file format not compatible with Plugin')
         
-        self.dim.SetValue(str(variables['molecular_trace'].getValue().shape))
+        self.dim.SetValue(str(variables['molecular_trace'][:].shape))
         f.close()
             
     def on_select_file(self, event):
@@ -242,12 +242,12 @@ class DensitySuperpositionPlugin(ComponentPlugin):
         opacity = float(self.opacity.GetValue())
         filename = self.get_file()
         
-        f = NetCDFFile(filename,"r")
+        f = netCDF4.Dataset(filename,"r")
         variables = f.variables
         
-        data = variables['molecular_trace'].getValue()
-        origin = variables['origin'].getValue()
-        spacing = variables['spacing'].getValue()
+        data = variables['molecular_trace'][:]
+        origin = variables['origin'][:]
+        spacing = variables['spacing'][:]
         
         f.close()
         

--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -17,13 +17,13 @@ import collections
 
 import numpy
 
+import netCDF4
+
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg
 
 import wx
 import wx.aui as wxaui
-
-from Scientific.IO.NetCDF import NetCDFFile
 
 from MDANSE import REGISTRY
 from MDANSE.Core.Error import Error
@@ -472,11 +472,11 @@ class PlotterFrame(wx.Frame):
             basename = baselist[i]    
             filename = filelist[i]
             
-            f = NetCDFFile(filename,"r")
+            f = netCDF4.Dataset(filename,"r")
             _vars = f.variables
             data = collections.OrderedDict()
             for k in _vars:
-                dtype = _vars[k].getValue().dtype
+                dtype = _vars[k][:].dtype
                 if not numpy.issubdtype(dtype,numpy.number):
                     continue
                 data[k]={}
@@ -487,7 +487,7 @@ class PlotterFrame(wx.Frame):
                         data[k]['axis'] = []
                 else:
                     data[k]['axis'] = []
-                data[k]['data'] = _vars[k].getValue()
+                data[k]['data'] = _vars[k][:]
                 data[k]['units'] = getattr(_vars[k],"units","au")
             
             unique_name = self.unique(basename, self.plugin._dataDict)

--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -468,32 +468,29 @@ class PlotterFrame(wx.Frame):
         baselist = dialog.GetFilenames()
         filelist = dialog.GetPaths()
         
-        for i in range(len(filelist)):
-            basename = baselist[i]    
-            filename = filelist[i]
-            
-            f = netCDF4.Dataset(filename,"r")
-            _vars = f.variables
-            data = collections.OrderedDict()
-            for k in _vars:
-                dtype = _vars[k][:].dtype
-                if not numpy.issubdtype(dtype,numpy.number):
-                    continue
-                data[k]={}
-                if hasattr(_vars[k], 'axis'):
-                    if _vars[k].axis:
-                        data[k]['axis'] =  _vars[k].axis.split('|')
+        for basename, filename in zip(baselist, filelist):
+            with netCDF4.Dataset(filename, "r") as f:
+                _vars = f.variables
+                data = collections.OrderedDict()
+                for k in _vars:
+                    dtype = _vars[k][:].dtype
+                    if not numpy.issubdtype(dtype, numpy.number):
+                        continue
+                    data[k]={}
+                    if hasattr(_vars[k], 'axis'):
+                        if _vars[k].axis:
+                            data[k]['axis'] = _vars[k].axis.split('|')
+                        else:
+                            data[k]['axis'] = []
                     else:
                         data[k]['axis'] = []
-                else:
-                    data[k]['axis'] = []
-                data[k]['data'] = _vars[k][:]
-                data[k]['units'] = getattr(_vars[k],"units","au")
+                    data[k]['data'] = _vars[k][:]
+                    data[k]['units'] = getattr(_vars[k], "units", "au")
             
-            unique_name = self.unique(basename, self.plugin._dataDict)
+                unique_name = self.unique(basename, self.plugin._dataDict)
             
-            self.plugin._dataDict[unique_name]={'data':data,'path':filename,'basename':basename}
-            self.plugin._dataPanel.show_dataset(-1)
+                self.plugin._dataDict[unique_name]={'data': data, 'path': filename, 'basename': basename}
+                self.plugin._dataPanel.show_dataset(-1)
     
     def unique(self, key, dic):
         skey = key

--- a/Src/GUI/Widgets/NetCDFInputFileWidget.py
+++ b/Src/GUI/Widgets/NetCDFInputFileWidget.py
@@ -15,7 +15,7 @@
 
 import wx
 
-from Scientific.IO.NetCDF import _NetCDFFile
+import netCDF4
 
 from MDANSE import REGISTRY
 from MDANSE.Framework.Configurable import ConfigurationError
@@ -28,7 +28,7 @@ class NetCDFInputFileWidget(IWidget):
         
     def __getattr__(self, attr):
         
-        return self._netcdf.variables[attr].getValue()
+        return self._netcdf.variables[attr][:]
 
     def add_widgets(self):
 
@@ -52,7 +52,7 @@ class NetCDFInputFileWidget(IWidget):
                         
         self._netcdf = DATA_CONTROLLER[datakey].netcdf
                         
-        if not isinstance(self._netcdf, _NetCDFFile):
+        if not isinstance(self._netcdf, netCDF4.Dataset):
             return
 
         self._selectNetCDF.SetItems(DATA_CONTROLLER.keys())

--- a/Tests/FunctionalTests/Jobs/BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/BuildJobTests.py
@@ -135,7 +135,7 @@ class JobFileGenerator():
             temp = 'parameters[%r] = %r\n' % (k, v)
             test_string = test_string + '        ' + temp.replace('\\\\', '/')
         if self.job._type == 'dp' and isinstance(PLATFORM, PlatformLinux):
-            test_string += '        parameters["output_files"][0] = "~/output"'
+            test_string += '        parameters["output_files"][0] = "~/output"\n'
         test_string += '        job = REGISTRY[%r][%r]()\n\n' % ('job', self.job._type)
         test_string += '        try:\n' \
                        '            output_path = parameters["output_files"][0]\n' \

--- a/Tests/FunctionalTests/Jobs/BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/BuildJobTests.py
@@ -151,7 +151,14 @@ class JobFileGenerator():
         if self.multiprocessor:
             test_string += '        print "Launching job in multiprocessor mode"\n' \
                            '        parameters["running_mode"] = ("multiprocessor",2)\n' \
-                           '        job.run(parameters,False)\n' \
+                           '        try:\n' \
+                           '            job.run(parameters, status=False)\n' \
+                           '        except IOError:\n' \
+                           '            try:\n' \
+                           '                os.remove(output_path + ".nc")\n' \
+                           '            except OSError:\n' \
+                           '                pass\n' \
+                           '            job.run(parameters, status=False)\n' \
                            '        shutil.copy(output_path + ".nc", reference_data_path + "_multi" + ".nc")\n' \
                            '        print "Multiprocessor execution completed"\n\n'
 

--- a/Tests/FunctionalTests/Jobs/BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/BuildJobTests.py
@@ -99,19 +99,20 @@ class JobFileGenerator():
         :return: String of python code of the compare function.
         :rtype: str
         """
-        return 'def compare(file1, file2):\n'          \
-               '    ret = True\n'                      \
-               '    f = netCDF4.Dataset(file1,"r")\n'       \
-               '    res1 = {}\n'                       \
-               '    for k,v in f.variables.items():\n' \
-               '        res1[k] = v[:]\n'      \
-               '    f.close()\n'                       \
-               '    f = netCDF4.Dataset(file2,"r")\n'       \
-               '    res2 = {}\n'                       \
-               '    for k,v in f.variables.items():\n' \
-               '        res2[k] = v[:]\n'      \
-               '    f.close()\n'                       \
-               '    return Comparator.Comparator().compare(res1, res2)\n\n'
+        return 'def compare(file1, file2):\n' \
+               '    ret = True\n' \
+               '    ignored_vars = ["temperature", "kinetic_energy"]\n\n' \
+               '    res1 = {}\n' \
+               '    with netCDF4.Dataset(file1,"r") as f:\n' \
+               '        for k, v in f.variables.items():\n' \
+               '            if k not in ignored_vars:\n' \
+               '                res1[k] = v[:]\n\n' \
+               '    res2 = {}\n' \
+               '    with netCDF4.Dataset(file1,"r") as f:\n' \
+               '        for k, v in f.variables.items():\n' \
+               '            if k not in ignored_vars:\n' \
+               '                res2[k] = v[:]\n\n' \
+               '    return Comparator.Comparator().compare(res1, res2)\n\n\n'
 
     def __create_test(self, parameters, test_name):
         """

--- a/Tests/FunctionalTests/Jobs/BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/BuildJobTests.py
@@ -143,7 +143,14 @@ class JobFileGenerator():
         # Launch the job in monoprocessor mode and copy output file
         test_string += '        print "Launching job in monoprocessor mode"\n' \
                        '        parameters["running_mode"] = ("monoprocessor",1)\n' \
-                       '        job.run(parameters, status=False)\n' \
+                       '        try:\n' \
+                       '            job.run(parameters, status=False)\n' \
+                       '        except IOError:\n' \
+                       '            try:\n' \
+                       '                os.remove(output_path + ".nc")\n' \
+                       '            except OSError:\n' \
+                       '                pass\n' \
+                       '            job.run(parameters, status=False)\n' \
                        '        shutil.copy(output_path + ".nc", reference_data_path + "_mono" + ".nc")\n' \
                        '        print "Monoprocessor execution completed"\n\n'
 

--- a/Tests/FunctionalTests/Jobs/BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/BuildJobTests.py
@@ -17,8 +17,7 @@ import os
 import stat
 import sys
 
-from MDANSE import REGISTRY, PLATFORM
-from MDANSE.Core.Platform import PlatformLinux
+from MDANSE import REGISTRY
 
 
 class JobFileGenerator():

--- a/Tests/FunctionalTests/Jobs/BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/BuildJobTests.py
@@ -135,7 +135,7 @@ class JobFileGenerator():
             temp = 'parameters[%r] = %r\n' % (k, v)
             test_string = test_string + '        ' + temp.replace('\\\\', '/')
         if self.job._type == 'dp' and isinstance(PLATFORM, PlatformLinux):
-            test_string += '        parameters["output_files"] = ("~/output", ["netcdf"])\n'
+            test_string += '        parameters["output_files"] = ("../../../output", ["netcdf"])\n'
         test_string += '        job = REGISTRY[%r][%r]()\n\n' % ('job', self.job._type)
         test_string += '        try:\n' \
                        '            output_path = parameters["output_files"][0]\n' \

--- a/Tests/FunctionalTests/Jobs/BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/BuildJobTests.py
@@ -81,7 +81,7 @@ class JobFileGenerator():
             array_of_python_dependencies_string.append("time")
 
         # Add NetCDF
-        array_of_mdanse_dependencies_string.append('from Scientific.IO.NetCDF import NetCDFFile')
+        array_of_mdanse_dependencies_string.append('import netCDF4')
         array_of_mdanse_dependencies_string.append('import Comparator')
 
         # Sort arrays to write imports in the alphabetical order
@@ -99,26 +99,19 @@ class JobFileGenerator():
         :return: String of python code of the compare function.
         :rtype: str
         """
-        return 'def compare(file1, file2):\n' \
-               '    ret = True\n' \
-               '    ignored_vars = ["temperature", "kinetic_energy"]\n\n' \
-               '    f = NetCDFFile(file1,"r")\n' \
-               '    try:\n' \
-               '        res1 = {}\n' \
-               '        for k, v in f.variables.items():\n' \
-               '            if k not in ignored_vars:\n' \
-               '                res1[k] = v.getValue()\n' \
-               '    finally:\n' \
-               '        f.close()\n\n' \
-               '    f = NetCDFFile(file2,"r")\n' \
-               '    try:\n' \
-               '        res2 = {}\n' \
-               '        for k,v in f.variables.items():\n' \
-               '            if k not in ignored_vars:\n' \
-               '                res2[k] = v.getValue()\n' \
-               '    finally:\n' \
-               '        f.close()\n\n' \
-               '    return Comparator.Comparator().compare(res1, res2)\n\n\n'
+        return 'def compare(file1, file2):\n'          \
+               '    ret = True\n'                      \
+               '    f = netCDF4.Dataset(file1,"r")\n'       \
+               '    res1 = {}\n'                       \
+               '    for k,v in f.variables.items():\n' \
+               '        res1[k] = v[:]\n'      \
+               '    f.close()\n'                       \
+               '    f = netCDF4.Dataset(file2,"r")\n'       \
+               '    res2 = {}\n'                       \
+               '    for k,v in f.variables.items():\n' \
+               '        res2[k] = v[:]\n'      \
+               '    f.close()\n'                       \
+               '    return Comparator.Comparator().compare(res1, res2)\n\n'
 
     def __create_test(self, parameters, test_name):
         """

--- a/Tests/FunctionalTests/Jobs/BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/BuildJobTests.py
@@ -17,7 +17,8 @@ import os
 import stat
 import sys
 
-from MDANSE import REGISTRY
+from MDANSE import REGISTRY, PLATFORM
+from MDANSE.Core.Platform import PlatformLinux
 
 
 class JobFileGenerator():
@@ -133,6 +134,8 @@ class JobFileGenerator():
         for k, v in sorted(parameters.items()):
             temp = 'parameters[%r] = %r\n' % (k, v)
             test_string = test_string + '        ' + temp.replace('\\\\', '/')
+        if self.job._type == 'dp' and isinstance(PLATFORM, PlatformLinux):
+            test_string += '        parameters["output_files"][0] = "~/output"'
         test_string += '        job = REGISTRY[%r][%r]()\n\n' % ('job', self.job._type)
         test_string += '        try:\n' \
                        '            output_path = parameters["output_files"][0]\n' \

--- a/Tests/FunctionalTests/Jobs/BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/BuildJobTests.py
@@ -135,7 +135,7 @@ class JobFileGenerator():
             temp = 'parameters[%r] = %r\n' % (k, v)
             test_string = test_string + '        ' + temp.replace('\\\\', '/')
         if self.job._type == 'dp' and isinstance(PLATFORM, PlatformLinux):
-            test_string += '        parameters["output_files"][0] = "~/output"\n'
+            test_string += '        parameters["output_files"] = ("~/output", ["netcdf"])\n'
         test_string += '        job = REGISTRY[%r][%r]()\n\n' % ('job', self.job._type)
         test_string += '        try:\n' \
                        '            output_path = parameters["output_files"][0]\n' \

--- a/Tests/FunctionalTests/Jobs/test_gromacs_trr.py
+++ b/Tests/FunctionalTests/Jobs/test_gromacs_trr.py
@@ -3,27 +3,28 @@ from shutil import copy
 import os
 import unittest
 
+import netCDF4
+
 from MDANSE import REGISTRY
-from Scientific.IO.NetCDF import NetCDFFile
 import Comparator
 
 
 def compare(file1, file2, array_tolerance):
-    f = NetCDFFile(file1, "r")
+    f = netCDF4.Dataset(file1, "r")
     try:
         res1 = {}
         for k, v in f.variables.items():
             if k not in ['velocities', 'gradients', 'temperature', 'kinetic_energy']:
-                res1[k] = v.getValue()
+                res1[k] = v[:]
     finally:
         f.close()
 
-    f = NetCDFFile(file2, "r")
+    f = netCDF4.Dataset(file2, "r")
     try:
         res2 = {}
         for k, v in f.variables.items():
             if k not in ['velocities', 'gradients', 'temperature', 'kinetic_energy']:
-                res2[k] = v.getValue()
+                res2[k] = v[:]
     finally:
         f.close()
 
@@ -74,9 +75,9 @@ class TestGromacsADK(unittest.TestCase):
         # Load velocities that have been generated from the same trajectory with MDAnalysis + convert angstrom to nm
         expected = np.load(r'../../../Data/Trajectories/Gromacs/adk_oplsaa.npy') / 10
 
-        f = NetCDFFile(self.trr_copy, "r")
+        f = netCDF4.Dataset(self.trr_copy, "r")
         try:
-            velocities = f.variables['velocities'].getValue()
+            velocities = f.variables['velocities'][:]
         finally:
             f.close()
 
@@ -85,7 +86,7 @@ class TestGromacsADK(unittest.TestCase):
     def test_gradients(self):
         # adk_oplsaa.trr does not contain forces
 
-        f = NetCDFFile(self.trr_copy, "r")
+        f = netCDF4.Dataset(self.trr_copy, "r")
         try:
             self.assertFalse('gradients' in f.variables)
         finally:
@@ -141,9 +142,9 @@ class TestGromacsCobrotoxin(unittest.TestCase):
         # Load velocities that have been generated from the same trajectory with MDAnalysis + convert angstrom to nm
         expected = np.load(r'../../../Data/Trajectories/Gromacs/cobrotoxin_vels.npy') / 10
 
-        f = NetCDFFile(self.trr_copy, "r")
+        f = netCDF4.Dataset(self.trr_copy, "r")
         try:
-            velocities = f.variables['velocities'].getValue()
+            velocities = f.variables['velocities'][:]
         finally:
             f.close()
 
@@ -153,9 +154,9 @@ class TestGromacsCobrotoxin(unittest.TestCase):
         # Load forces that have been generated from the same trajectory with MDAnalysis + convert angstrom to nm
         expected = np.load(r'../../../Data/Trajectories/Gromacs/cobrotoxin_forces.npy') * 10
 
-        f = NetCDFFile(self.trr_copy, "r")
+        f = netCDF4.Dataset(self.trr_copy, "r")
         try:
-            gradients = f.variables['gradients'].getValue()
+            gradients = f.variables['gradients'][:]
         finally:
             f.close()
 

--- a/Tests/FunctionalTests/Jobs/test_gromacs_trr.py
+++ b/Tests/FunctionalTests/Jobs/test_gromacs_trr.py
@@ -10,23 +10,17 @@ import Comparator
 
 
 def compare(file1, file2, array_tolerance):
-    f = netCDF4.Dataset(file1, "r")
-    try:
-        res1 = {}
+    res1 = {}
+    with netCDF4.Dataset(file1, "r") as f:
         for k, v in f.variables.items():
             if k not in ['velocities', 'gradients', 'temperature', 'kinetic_energy']:
                 res1[k] = v[:]
-    finally:
-        f.close()
 
-    f = netCDF4.Dataset(file2, "r")
-    try:
-        res2 = {}
+    res2 = {}
+    with netCDF4.Dataset(file2, "r") as f:
         for k, v in f.variables.items():
             if k not in ['velocities', 'gradients', 'temperature', 'kinetic_energy']:
                 res2[k] = v[:]
-    finally:
-        f.close()
 
     return Comparator.Comparator().compare(res1, res2, array_tolerance)
 

--- a/Tests/FunctionalTests/Jobs/test_gromacs_trr.py
+++ b/Tests/FunctionalTests/Jobs/test_gromacs_trr.py
@@ -75,22 +75,16 @@ class TestGromacsADK(unittest.TestCase):
         # Load velocities that have been generated from the same trajectory with MDAnalysis + convert angstrom to nm
         expected = np.load(r'../../../Data/Trajectories/Gromacs/adk_oplsaa.npy') / 10
 
-        f = netCDF4.Dataset(self.trr_copy, "r")
-        try:
+        with netCDF4.Dataset(self.trr_copy, "r") as f:
             velocities = f.variables['velocities'][:]
-        finally:
-            f.close()
 
         self.assertTrue(np.allclose(expected, velocities, 0, 0.000001))
 
     def test_gradients(self):
         # adk_oplsaa.trr does not contain forces
 
-        f = netCDF4.Dataset(self.trr_copy, "r")
-        try:
+        with netCDF4.Dataset(self.trr_copy, "r") as f:
             self.assertFalse('gradients' in f.variables)
-        finally:
-            f.close()
 
     @classmethod
     def tearDownClass(cls):
@@ -142,11 +136,8 @@ class TestGromacsCobrotoxin(unittest.TestCase):
         # Load velocities that have been generated from the same trajectory with MDAnalysis + convert angstrom to nm
         expected = np.load(r'../../../Data/Trajectories/Gromacs/cobrotoxin_vels.npy') / 10
 
-        f = netCDF4.Dataset(self.trr_copy, "r")
-        try:
+        with netCDF4.Dataset(self.trr_copy, "r") as f:
             velocities = f.variables['velocities'][:]
-        finally:
-            f.close()
 
         self.assertTrue(np.allclose(expected, velocities, 0, 0.000001))
 
@@ -154,11 +145,8 @@ class TestGromacsCobrotoxin(unittest.TestCase):
         # Load forces that have been generated from the same trajectory with MDAnalysis + convert angstrom to nm
         expected = np.load(r'../../../Data/Trajectories/Gromacs/cobrotoxin_forces.npy') * 10
 
-        f = netCDF4.Dataset(self.trr_copy, "r")
-        try:
+        with netCDF4.Dataset(self.trr_copy, "r") as f:
             gradients = f.variables['gradients'][:]
-        finally:
-            f.close()
 
         self.assertTrue(np.allclose(expected, gradients, 0, 0.001))
         # Such a large tolerance is required because most gradients are > 100


### PR DESCRIPTION
In the process of getting rid of ScientificPython and MMTK, I use in this PR a dependency to NetCDF4 library which is standard (can you please install it in the build machine). I had to change the unit test and now some are breaking again. Could you please investigate on this Rastislav as you were on that topic a few days ago ? Many thanks in advances.