### PR TITLE
Make MacOS CI fail when tests fail

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -216,8 +216,21 @@ jobs:
           cd $GITHUB_WORKSPACE
           python2 setup.py install
 
-      - name: Run tests
-        run: $GITHUB_WORKSPACE/BuildServer/Unix/tests.sh
+      - name: Run unit tests
+        run: |
+          cd $GITHUB_WORKSPACE/Tests/UnitTests
+          python2 AllTests.py
+
+      - name: Run dependency tests
+        run: |
+          cd $GITHUB_WORKSPACE/Tests/DependenciesTests
+          python2 AllTests.py
+
+      - name: Run functional tests
+        run: |
+          cd $GITHUB_WORKSPACE/Tests/FunctionalTests/Jobs
+          python2 BuildJobTests.py
+          python2 AllTests.py
 
       - name: Tar python
         if: |

--- a/Src/Framework/Jobs/CoordinationNumber.py
+++ b/Src/Framework/Jobs/CoordinationNumber.py
@@ -115,7 +115,7 @@ class CoordinationNumber(DistanceHistogram):
         self._outputData.write(self.configuration['output_files']['root'], self.configuration['output_files']['formats'], self._info)
         
         self.configuration['trajectory']['instance'].close()     
-  
+        raise Exception()
         DistanceHistogram.finalize(self)
 
 REGISTRY['cn'] = CoordinationNumber

--- a/Src/Framework/Jobs/CoordinationNumber.py
+++ b/Src/Framework/Jobs/CoordinationNumber.py
@@ -115,7 +115,7 @@ class CoordinationNumber(DistanceHistogram):
         self._outputData.write(self.configuration['output_files']['root'], self.configuration['output_files']['formats'], self._info)
         
         self.configuration['trajectory']['instance'].close()     
-        raise Exception()
+
         DistanceHistogram.finalize(self)
 
 REGISTRY['cn'] = CoordinationNumber


### PR DESCRIPTION
**Description of work.**

Fixes #87 

For some reason, the script `BuildServer/Unix/tests.sh`, when run on the MacOS pipeline, did not exit properly when tests were failing, making it appear as if the MacOS pipeline succeeded even though the tests failed. This has been resolved by not running the script and instead adding the commands to run test scripts directly to the CI.yml. Now, all pipelines fail correctly, as can be seen in this [run](https://github.com/ISISNeutronMuon/MDANSE/actions/runs/2330594583).

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**.