### PR TITLE
Fix the installation of netCDF4 on MacOS CI/CD

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -211,7 +211,7 @@ jobs:
           sudo conda create -p ~/tempenv python=2.7
           sudo conda install -p ~/tempenv netcdf4
           sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/cftime $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
-          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4/ $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages/
+          sudo cp -rfv ~/tempenv/lib/python2.7/site-packages/netCDF4 $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
           sudo cp -rfv ~/tempenv/lib/libhdf5* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libnetcdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib
           sudo cp -rfv ~/tempenv/lib/libmfhdf* $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -223,11 +223,6 @@ jobs:
           brew install netcdf
           sudo cp -r /usr/local/include/netcdf $RUNNER_TOOL_CACHE/Python/2.7.18/x64/include
 
-      - run: |
-          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
-          ls
-          python2 -c "import netCDF4"
-
       - name: Install ScientificPython
         run: |
           cd $HOME

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -223,6 +223,11 @@ jobs:
           brew install netcdf
           sudo cp -r /usr/local/include/netcdf $RUNNER_TOOL_CACHE/Python/2.7.18/x64/include
 
+      - run: |
+          cd $RUNNER_TOOL_CACHE/Python/2.7.18/x64/lib/python2.7/site-packages
+          ls
+          python2 -c "import netCDF4"
+
       - name: Install ScientificPython
         run: |
           cd $HOME


### PR DESCRIPTION
**Description of work.**

Fixes #89 

Due to incorrect syntax in the MacOS CI part of the CI.yml, the netCDF4 python package was copied incorrectly, such that the insides of the netCDF4 folder were copied directly to site-packages. This has been fixed by correcting the copy syntax, so that the netCDF4 folder is created, and thus the package can be imported.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. 