### PR TITLE
Correct MacOS CI artifact upload mechanism

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -249,13 +249,13 @@ jobs:
 
       - name: Tar python
         if: |
-          (contains( github.ref, 'main' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'develop' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'release-' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'hotfix-' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'build-' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'tags' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'web' ) && ${{ (matrix.os == 'macos-10.15') }})
+          ${{ contains( github.ref, 'main' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'develop' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'release-' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'hotfix-' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'build-' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'tags' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'web' ) && (matrix.os == 'macos-10.15') }}
         run: |
           cd $RUNNER_TOOL_CACHE/Python/2.7.18
           mv x64 Resources
@@ -263,13 +263,13 @@ jobs:
 
       - name: Upload artifacts
         if: |
-          (contains( github.ref, 'main' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'develop' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'release-' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'hotfix-' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'build-' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'tags' ) && ${{ (matrix.os == 'macos-10.15') }}) ||
-          (contains( github.ref, 'web' ) && ${{ (matrix.os == 'macos-10.15') }})
+          ${{ contains( github.ref, 'main' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'develop' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'release-' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'hotfix-' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'build-' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'tags' ) && (matrix.os == 'macos-10.15') }} ||
+          ${{ contains( github.ref, 'web' ) && (matrix.os == 'macos-10.15') }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}_artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -248,14 +248,7 @@ jobs:
         run: $GITHUB_WORKSPACE/BuildServer/Unix/tests.sh
 
       - name: Tar python
-        if: |
-          ${{ contains( github.ref, 'main' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'develop' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'release-' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'hotfix-' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'build-' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'tags' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'web' ) && (matrix.os == 'macos-10.15') }}
+        if: ${{ (matrix.os == 'macos-10.15') && ( contains( github.ref, 'main' ) || contains( github.ref, 'develop' ) || contains( github.ref, 'release-' ) || contains( github.ref, 'hotfix-' ) || contains( github.ref, 'build-' ) || contains( github.ref, 'tags' ) || contains( github.ref, 'web' ) ) }}
         run: |
           cd $RUNNER_TOOL_CACHE/Python/2.7.18
           mv x64 Resources
@@ -263,13 +256,13 @@ jobs:
 
       - name: Upload artifacts
         if: |
-          ${{ contains( github.ref, 'main' ) && (matrix.os == 'macos-10.15') }} ||
+          (${{ contains( github.ref, 'main' ) && (matrix.os == 'macos-10.15') }} ||
           ${{ contains( github.ref, 'develop' ) && (matrix.os == 'macos-10.15') }} ||
           ${{ contains( github.ref, 'release-' ) && (matrix.os == 'macos-10.15') }} ||
           ${{ contains( github.ref, 'hotfix-' ) && (matrix.os == 'macos-10.15') }} ||
           ${{ contains( github.ref, 'build-' ) && (matrix.os == 'macos-10.15') }} ||
           ${{ contains( github.ref, 'tags' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'web' ) && (matrix.os == 'macos-10.15') }}
+          ${{ contains( github.ref, 'web' ) && (matrix.os == 'macos-10.15') }})
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}_artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -255,14 +255,7 @@ jobs:
           tar -czf python.tar.gz Resources
 
       - name: Upload artifacts
-        if: |
-          (${{ contains( github.ref, 'main' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'develop' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'release-' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'hotfix-' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'build-' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'tags' ) && (matrix.os == 'macos-10.15') }} ||
-          ${{ contains( github.ref, 'web' ) && (matrix.os == 'macos-10.15') }})
+        if: ${{ (matrix.os == 'macos-10.15') && ( contains( github.ref, 'main' ) || contains( github.ref, 'develop' ) || contains( github.ref, 'release-' ) || contains( github.ref, 'hotfix-' ) || contains( github.ref, 'build-' ) || contains( github.ref, 'tags' ) || contains( github.ref, 'web' ) ) }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}_artifacts


### PR DESCRIPTION
Fixes #91 

MacOS CI was uploading artifacts even when the CD was not run, which shouldn't happen. This has been fixed by correcting the yaml syntax of the if statement such that now the artifacts are uploaded only when CD is run, just as it works in Ubuntu pipeline.