### PR TITLE
Fix AtomsListPlugin

### DIFF
--- a/Src/GUI/Plugins/AtomsListPlugin.py
+++ b/Src/GUI/Plugins/AtomsListPlugin.py
@@ -136,7 +136,7 @@ class AtomsListPlugin(UserDefinitionPlugin):
         
     def enable_natoms_selection(self,state):
         
-        self._nAtomsSelectionSizer.ShowItems(state)
+        self._nAtomsSpinCtrl.Enable(state)
 
     def set_natoms(self,nAtoms):
         

--- a/Src/GUI/Widgets/AtomsListWidget.py
+++ b/Src/GUI/Widgets/AtomsListWidget.py
@@ -17,14 +17,15 @@ from MDANSE import REGISTRY
 from MDANSE.Framework.UserDefinitionStore import UD_STORE
 from MDANSE.GUI.Widgets.UserDefinitionWidget import UserDefinitionWidget, UserDefinitionDialog
 
+
 class AtomListWidget(UserDefinitionWidget):
     
-    def on_new_user_definition(self,event):
+    def on_new_definition(self, event):
 
-        dlg = UserDefinitionDialog(self,self._trajectory,self._type)
-        
+        dlg = UserDefinitionDialog(self, self._trajectory, self._type)
+
         dlg.plugin.set_natoms(self._configurator._nAtoms)
-                
+
         dlg.plugin.enable_natoms_selection(False)
         
         dlg.ShowModal()
@@ -33,9 +34,10 @@ class AtomListWidget(UserDefinitionWidget):
          
         uds = UD_STORE.filter(self._basename, self._type)
                                 
-        uds = [v for v in uds if UD_STORE.get_definition(self._basename, self._type,v)["natoms"]==self._configurator._nAtoms] 
+        uds = [v for v in uds if UD_STORE.get_definition(self._basename, self._type,v)["natoms"]==self._configurator._nAtoms]
         
         self._availableUDs.SetItems(uds)
+
 
 REGISTRY["atoms_list"] = AtomListWidget
     


### PR DESCRIPTION
**Description of work.**

*There is no associated issue.*

Currently, when `AtomsListPlugin` is opened through a 'New definition' button in 'Axis selection' or 'Reference basis' section, the nAtoms value, which controls the number of atoms that must be selected for the definition to be valid for use in the analysis from which the plugin was opened, is always set to 1. The reason for this was that the method handling the opening of this plugin in `AtomsListWidget` had a name that did not overwrite the name in the base class (`UserDefinitionWidget`), and therefore wasn't called anywhere to the best of my knowledge. By changing the name, the `AtomsListPlugin` is now created with `nAtoms` set to the value that is expected by the analysis.

However, further change was made to disable the input field for `nAtoms` instead of hiding it completely, as it achieves similar purpose while also showing the user how many atoms they have to select for the analysis to work.

**To test:**

1. Open Angular correlation analysis
2. In the Axis selection window, click on 'New definition'
3. Observe that the 'Number of atoms' field is greyed out and is set to 2

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?


Does everything look good? Mark the review as **Approve**.