### PR TITLE
Fix ListenerMismatchError

### DIFF
--- a/Src/GUI/Widgets/AtomsListWidget.py
+++ b/Src/GUI/Widgets/AtomsListWidget.py
@@ -29,7 +29,7 @@ class AtomListWidget(UserDefinitionWidget):
         
         dlg.ShowModal()
         
-    def msg_set_ud(self, message=None):
+    def msg_set_ud(self, message):
          
         uds = UD_STORE.filter(self._basename, self._type)
                                 


### PR DESCRIPTION
**Description of work.**

Fixes #21 

Until now, after an analysis that implements `AtomsListWidget` was opened, whenever any other analysis was attempted to be opened, a `ListenerMismatchError` would be returned, meaning that MDANSE had to be restarted to restore its functionality. This has been fixed by changing the arguments of the `AtomsListWidget.msg_set_ud()` method from `(self, message=None)` to `(self, message)`, which is the way that the method is implemented in the base class of `AtomsListWidget`, `UserDefinitionWidget`, and all of the base class's subclasses.

**To test:**

1. Open Angular correlation analysis
2. Open any other analysis
3. Observe that no error occurred

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?


Does everything look good? Mark the review as **Approve**.