### PR TITLE
Fix centre of masses calculation in Eccentricity

### DIFF
--- a/Src/Framework/Jobs/Eccentricity.py
+++ b/Src/Framework/Jobs/Eccentricity.py
@@ -129,8 +129,9 @@ class Eccentricity(IJob):
         
         # read frame atoms coordinates                                                                             
         series = self.configuration['trajectory']['instance'].universe.configuration().array
-        
-        com = center_of_mass(series,masses=self._masses)
+
+        com = center_of_mass(series[self.configuration['center_of_mass']['flatten_indexes']],
+                             masses=numpy.array(self.configuration['center_of_mass']['masses']).flatten())
 
         # calculate the inertia moments and the radius of gyration
         xx = xy = xz = yy = yz = zz = 0


### PR DESCRIPTION
**Description of work.**

Fixes #98 

When atom selection was used in the Eccentricity analysis, it would fail. However, the bigger issue is that the `centre_of_masses()` function is currently called using the positions and masses from the atom selection rather than the centre of masses selection. Thanks @eurydice76 for fixing this in protos and thus showing the solution for this! By using the coordinates and masses associated with the centre of masses selection, both issues should be fixed.

**To test:**

1. Run the Eccentricity analysis with various combinations of Atom selections and Centre of masses selections.
2. Observe no errors

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**.