### PR TITLE
Fix Toggle toolbar option

### DIFF
--- a/Src/GUI/MainFrame.py
+++ b/Src/GUI/MainFrame.py
@@ -421,13 +421,11 @@ Authors:
 
         self._prevSize = self.GetSize()
 
-        if self.GetToolBar():
+        if self._toolbar.IsShown():
             sizeH = self._prevSize[1] - self._toolbar.GetSize()[1]
             self._toolbar.Hide()
-            self.SetToolBar(None)
         else:
             sizeH = self._prevSize[1] + self._toolbar.GetSize()[1]
-            self.SetToolBar(self._toolbar)
             self._toolbar.Show()
             
         self.SetSize((-1,sizeH))

--- a/Src/GUI/MainFrame.py
+++ b/Src/GUI/MainFrame.py
@@ -418,17 +418,8 @@ Authors:
         self.toggle_window(pane)    
 
     def on_toggle_toolbar(self, event=None):
-
-        self._prevSize = self.GetSize()
-
-        if self._toolbar.IsShown():
-            sizeH = self._prevSize[1] - self._toolbar.GetSize()[1]
-            self._toolbar.Hide()
-        else:
-            sizeH = self._prevSize[1] + self._toolbar.GetSize()[1]
-            self._toolbar.Show()
-            
-        self.SetSize((-1,sizeH))
+        self.toggle_window(self._toolbar)
+        self.Layout()
             
     @property
     def panels(self):
@@ -442,7 +433,8 @@ Authors:
             window.Show()
 
         self._mgr.Update()
-        
+
+
 if __name__ == "__main__":
     
     from MDANSE.GUI.Apps import MainApplication


### PR DESCRIPTION
**Description of work.**

Fixes #48 

On Windows, the 'Toggle toolbar' button was hiding the wrong thing. This was likely caused by the removal of the `ToolBar` from the `MainFrame`. It has been fixed by using the `toggle_window()` method which is used by the other Toggle options, and then calling `self.Layout()`.


**To test:**

1. In the View menu, click on the 'Toggle toolbar' button and observe that the toolbar is hidden correctly
2. Click the same button again, and observe that everything is as it was before the button was clicked the first time.

@eurydice76, can you please check that everything still works correctly on Ubuntu? Thanks!

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**.