### PR TITLE
Add path information to NetCDFInputData

### DIFF
--- a/Src/Framework/InputData/NetCDFInputData.py
+++ b/Src/Framework/InputData/NetCDFInputData.py
@@ -20,7 +20,7 @@ import netCDF4
 from MDANSE import REGISTRY
 from MDANSE.Framework.InputData.IInputData import InputDataError
 from MDANSE.Framework.InputData.InputFileData import InputFileData
-from MDANSE.IO.IOUtils import netcdf_find_numeric_variables
+from MDANSE.IO.IOUtils import netcdf_find_numeric_variables, load_variables
 
 
 class NetCDFInputData(InputFileData):
@@ -47,21 +47,9 @@ class NetCDFInputData(InputFileData):
             raise InputDataError("The data stored in %r filename could not be loaded properly." % self._name)
 
         else:
-            self._data = collections.OrderedDict()
             variables = netcdf_find_numeric_variables(collections.OrderedDict(), self._netcdf)
 
-            for name, (path, var) in variables.items():
-                self._data[name]={}
-                try :
-                    if vars[name].axis:
-                        self._data[name]['axis'] =  var.axis.split('|')
-                    else:
-                        self._data[name]['axis'] = []
-                except:
-                    self._data[name]['axis'] = []
-                self._data[name]['path'] = path
-                self._data[name]['data'] = var[:]
-                self._data[name]['units'] = getattr(var, 'units', 'au')
+            self._data = load_variables(variables)
 
     def close(self):
         self._netcdf.close()
@@ -70,5 +58,6 @@ class NetCDFInputData(InputFileData):
     def netcdf(self):
         
         return self._netcdf
+
 
 REGISTRY["netcdf_data"] = NetCDFInputData

--- a/Src/Framework/InputData/NetCDFInputData.py
+++ b/Src/Framework/InputData/NetCDFInputData.py
@@ -20,6 +20,8 @@ import netCDF4
 from MDANSE import REGISTRY
 from MDANSE.Framework.InputData.IInputData import InputDataError
 from MDANSE.Framework.InputData.InputFileData import InputFileData
+from MDANSE.IO.IOUtils import netcdf_find_numeric_variables
+
 
 class NetCDFInputData(InputFileData):
         
@@ -46,18 +48,20 @@ class NetCDFInputData(InputFileData):
 
         else:
             self._data = collections.OrderedDict()
-            variables = self._netcdf.variables
-            for k in variables:
-                self._data[k]={}
+            variables = netcdf_find_numeric_variables(collections.OrderedDict(), self._netcdf)
+
+            for name, (path, var) in variables.items():
+                self._data[name]={}
                 try :
-                    if vars[k].axis:
-                        self._data[k]['axis'] =  variables[k].axis.split('|')
+                    if vars[name].axis:
+                        self._data[name]['axis'] =  var.axis.split('|')
                     else:
-                        self._data[k]['axis'] = []
+                        self._data[name]['axis'] = []
                 except:
-                    self._data[k]['axis'] = []
-                self._data[k]['data'] = variables[k][:]
-                self._data[k]['units'] = getattr(variables[k], 'units', 'au')
+                    self._data[name]['axis'] = []
+                self._data[name]['path'] = path
+                self._data[name]['data'] = var[:]
+                self._data[name]['units'] = getattr(var, 'units', 'au')
 
     def close(self):
         self._netcdf.close()

--- a/Src/Framework/InputData/NetCDFInputData.py
+++ b/Src/Framework/InputData/NetCDFInputData.py
@@ -20,7 +20,8 @@ import netCDF4
 from MDANSE import REGISTRY
 from MDANSE.Framework.InputData.IInputData import InputDataError
 from MDANSE.Framework.InputData.InputFileData import InputFileData
-from MDANSE.IO.IOUtils import netcdf_find_numeric_variables, load_variables
+from MDANSE.IO.IOUtils import load_variables
+from MDANSE.IO.NetCDF import find_numeric_variables
 
 
 class NetCDFInputData(InputFileData):
@@ -47,7 +48,7 @@ class NetCDFInputData(InputFileData):
             raise InputDataError("The data stored in %r filename could not be loaded properly." % self._name)
 
         else:
-            variables = netcdf_find_numeric_variables(collections.OrderedDict(), self._netcdf)
+            variables = find_numeric_variables(collections.OrderedDict(), self._netcdf)
 
             self._data = load_variables(variables)
 

--- a/Src/GUI/Plugins/PlotterData.py
+++ b/Src/GUI/Plugins/PlotterData.py
@@ -8,88 +8,7 @@ import netCDF4
 import h5py
 
 from MDANSE.Core.Decorators import compatibleabstractproperty
-from MDANSE.IO.IOUtils import netcdf_find_numeric_variables
-
-
-class _IPlotterVariable:
-    """This is the base abstract class for plotter variable.
-
-    Basically, this class allows to have a common interface for the data supported by the plotter (netcdf currently,
-    hdf in the future, ...)
-    """
-
-    __metaclass__ = abc.ABCMeta
-
-    def __init__(self, variable):
-        self._variable = variable
-
-    def __getattr__(self, name):
-        return getattr(self._variable, name)
-
-    def __hasattr__(self, name):
-        return hasattr(self._variable, name)
-
-    @property
-    def variable(self):
-        return self._variable
-
-    @abc.abstractmethod
-    def get_array(self):
-        """Returns the actual data stored by the plotter data.
-
-        :return: the data
-        :rtype: numpy array
-        """
-        pass
-
-    @abc.abstractmethod
-    def get_attributes(self):
-        """Returns the attributes stored by the plotter data.
-
-        :return: the attributes
-        :rtype: dict
-        """
-        pass
-
-
-class NetCDFPlotterVariable(_IPlotterVariable):
-    """Wrapper for NetCDF plotter data."""
-
-    def get_array(self):
-        """Returns the actual data stored by the plotter data.
-
-        :return: the data
-        :rtype: numpy array
-        """
-        return self._variable[:]
-
-    def get_attributes(self):
-        """Returns the attributes stored by the plotter data.
-
-        :return: the attributes
-        :rtype: dict
-        """
-        return self._variable.__dict__
-
-
-class HDFPlotterVariable(_IPlotterVariable):
-    """Wrapper for HDF plotter data."""
-
-    def get_array(self):
-        """Returns the actual data stored by the plotter data.
-
-        :return: the data
-        :rtype: numpy array
-        """
-        return self._variable[:]
-
-    def get_attributes(self):
-        """Returns the attributes stored by the plotter data.
-
-        :return: the attributes
-        :rtype: dict
-        """
-        return self._variable.attrs
+from MDANSE.IO.IOUtils import HDFFileVariable, netcdf_find_numeric_variables
 
 
 class _IPlotterData:
@@ -129,8 +48,6 @@ class NetCDFPlotterData(_IPlotterData):
         self._file = netCDF4.Dataset(*args, **kwargs)
 
         self._variables = netcdf_find_numeric_variables(collections.OrderedDict(), self._file)
-        for name, (path, var) in self._variables.items():
-            self._variables[name] = (path, NetCDFPlotterVariable(var))
 
     @property
     def variables(self):
@@ -184,7 +101,7 @@ class HDFPlotterData(_IPlotterData):
                     var_key = '{:s}_{:d}'.format(var_key, comp)
                     comp += 1
 
-                var_dict[var_key] = (path,HDFPlotterVariable(var))
+                var_dict[var_key] = (path,HDFFileVariable(var))
 
 PLOTTER_DATA_TYPES = {
     '.nc': NetCDFPlotterData,

--- a/Src/GUI/Plugins/PlotterData.py
+++ b/Src/GUI/Plugins/PlotterData.py
@@ -8,7 +8,8 @@ import netCDF4
 import h5py
 
 from MDANSE.Core.Decorators import compatibleabstractproperty
-from MDANSE.IO.IOUtils import HDFFileVariable, netcdf_find_numeric_variables
+from MDANSE.IO.NetCDF import find_numeric_variables as netcdf_find_numeric_variables
+from MDANSE.IO.HDF5 import find_numeric_variables as hdf_find_numeric_variables
 
 
 class _IPlotterData:
@@ -64,44 +65,12 @@ class HDFPlotterData(_IPlotterData):
 
         self._variables = collections.OrderedDict()
 
-        HDFPlotterData.find_numeric_variables(self._variables, self._file)
+        hdf_find_numeric_variables(self._variables, self._file)
 
     @property
     def variables(self):
         return self._variables
 
-    @staticmethod
-    def find_numeric_variables(var_dict, group):
-        """This method retrieves all the numeric variables stored in the NetCDF file.
-
-        This is a recursive method.
-        """
-
-        for var_key, var in group.items():
-
-            if isinstance(var,h5py.Group):
-                HDFPlotterData.find_numeric_variables(var_dict,var)
-            else:
-
-                if var.parent.name == '/':
-                    path = '/{}'.format(var_key)
-                else:
-                    path = '{}/{}'.format(var.parent.name, var_key)
-
-                # Non numeric variables are not supported by the plotter
-                if not numpy.issubdtype(var.dtype, numpy.number):
-                    continue
-
-                # Variables with dimension higher than 3 are not supported by the plotter
-                if var.ndim > 3:
-                    continue
-
-                comp = 1
-                while var_key in var_dict:
-                    var_key = '{:s}_{:d}'.format(var_key, comp)
-                    comp += 1
-
-                var_dict[var_key] = (path,HDFFileVariable(var))
 
 PLOTTER_DATA_TYPES = {
     '.nc': NetCDFPlotterData,

--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -92,7 +92,8 @@ class MultiViewPanel(wx.Panel):
 
     def Update(self):
         self._mgr.Update()
-        
+
+
 class DataPanel(wx.Panel):
 
     def __init__(self, parent, *args,**kwds):
@@ -135,7 +136,8 @@ class DataPanel(wx.Panel):
         self.datalist.InsertColumn(1, 'Axis', width=50)
         self.datalist.InsertColumn(2, 'Dimension')
         self.datalist.InsertColumn(3, 'Size')
-        self.datalist.InsertColumn(4, 'Path', width=100)
+        if self.parent.standalone:
+            self.datalist.InsertColumn(4, 'Path', width=100)
         
         if self.standalone:
             splitterWindow.SplitHorizontally(self.datasetlist,self.datalist)
@@ -279,7 +281,10 @@ class DataPanel(wx.Panel):
             self.datalist.SetStringItem(i, 1,axis)
             self.datalist.SetStringItem(i, 2,str(self.dataproxy[var]['data'].ndim))
             self.datalist.SetStringItem(i, 3,str(self.dataproxy[var]['data'].shape))
-            self.datalist.SetStringItem(i, 4, self.dataproxy[var]['path'])
+            try:
+                self.datalist.SetStringItem(i, 4, self.dataproxy[var]['path'])
+            except KeyError:
+                pass
         self.datalist.Select(0, True)
             
     def on_select_variables(self, event = None):

--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -34,6 +34,7 @@ from MDANSE.GUI.Plugins.Plotter1D import Plotter1D
 from MDANSE.GUI.Plugins.Plotter2D import Plotter2D
 from MDANSE.GUI.Plugins.Plotter3D import Plotter3D
 from MDANSE.GUI.Icons import ICONS
+from MDANSE.IO.IOUtils import load_variables
 
 
 class PlotterError(Error):
@@ -479,24 +480,7 @@ class PlotterFrame(wx.Frame):
 
             ext = os.path.splitext(filename)[1]
             with PLOTTER_DATA_TYPES[ext](filename, 'r') as f:
-                data = collections.OrderedDict()
-                for vname, vinfo in f.variables.items():
-                    vpath, variable = vinfo
-                    arr = variable.get_array()
-                    attributes = variable.get_attributes()
-
-                    data[vname] = {}
-                    if 'axis' in attributes:
-                        axis = attributes['axis']
-                        if axis:
-                            data[vname]['axis'] = axis.split('|')
-                        else:
-                            data[vname]['axis'] = []
-                    else:
-                        data[vname]['axis'] = []
-                    data[vname]['path'] = vpath
-                    data[vname]['data'] = arr
-                    data[vname]['units'] = attributes.get('units', 'au')
+                data = load_variables(f.variables)
 
                 unique_name = self.unique(basename, self.plugin._dataDict)
 

--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -136,8 +136,7 @@ class DataPanel(wx.Panel):
         self.datalist.InsertColumn(1, 'Axis', width=50)
         self.datalist.InsertColumn(2, 'Dimension')
         self.datalist.InsertColumn(3, 'Size')
-        if self.parent.standalone:
-            self.datalist.InsertColumn(4, 'Path', width=100)
+        self.datalist.InsertColumn(4, 'Path', width=100)
         
         if self.standalone:
             splitterWindow.SplitHorizontally(self.datasetlist,self.datalist)
@@ -281,10 +280,7 @@ class DataPanel(wx.Panel):
             self.datalist.SetStringItem(i, 1,axis)
             self.datalist.SetStringItem(i, 2,str(self.dataproxy[var]['data'].ndim))
             self.datalist.SetStringItem(i, 3,str(self.dataproxy[var]['data'].shape))
-            try:
-                self.datalist.SetStringItem(i, 4, self.dataproxy[var]['path'])
-            except KeyError:
-                pass
+            self.datalist.SetStringItem(i, 4, self.dataproxy[var]['path'])
         self.datalist.Select(0, True)
             
     def on_select_variables(self, event = None):

--- a/Src/IO/HDF5.py
+++ b/Src/IO/HDF5.py
@@ -1,0 +1,77 @@
+# **************************************************************************
+#
+# MDANSE: Molecular Dynamics Analysis for Neutron Scattering Experiments
+#
+# @file      Src/Framework/InputData/IInputData.py
+# @brief     Implements module/class/test IInputData
+#
+# @homepage  https://mdanse.org
+# @license   GNU General Public License v3 or higher (see LICENSE)
+# @copyright Institut Laue Langevin 2013-now
+# @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now
+# @authors   Scientific Computing Group at ILL (see AUTHORS)
+#
+# **************************************************************************
+
+import h5py
+import numpy
+
+from MDANSE.IO.IOUtils import _IFileVariable
+
+
+class HDFFileVariable(_IFileVariable):
+    """Wrapper for HDF plotter data."""
+
+    def get_array(self):
+        """Returns the actual data stored by the plotter data.
+
+        :return: the data
+        :rtype: numpy array
+        """
+        return self._variable[:]
+
+    def get_attributes(self):
+        """Returns the attributes stored by the plotter data.
+
+        :return: the attributes
+        :rtype: dict
+        """
+        return self._variable.attrs
+
+
+def find_numeric_variables(var_dict, group):
+    """
+    Recursively retrieves all the numeric variables stored in an HDF5 file.
+
+    :param var_dict: The dictionary into which the variables are saved.
+    :type var_dict: dict
+
+    :param group: The file whose variables are to be retrieved.
+    :type group: h5py.File or h5py.Group
+    """
+
+    for var_key, var in group.items():
+
+        if isinstance(var, h5py.Group):
+            find_numeric_variables(var_dict, var)
+        else:
+
+            if var.parent.name == '/':
+                path = '/{}'.format(var_key)
+            else:
+                path = '{}/{}'.format(var.parent.name, var_key)
+
+            # Non-numeric variables are not supported by the plotter
+            if not numpy.issubdtype(var.dtype, numpy.number):
+                continue
+
+            # Variables with dimension higher than 3 are not supported by the plotter
+            if var.ndim > 3:
+                continue
+
+            comp = 1
+            while var_key in var_dict:
+                var_key = '{:s}_{:d}'.format(var_key, comp)
+                comp += 1
+
+            var_dict[var_key] = (path, HDFFileVariable(var))

--- a/Src/IO/IOUtils.py
+++ b/Src/IO/IOUtils.py
@@ -16,8 +16,6 @@
 import abc
 from collections import OrderedDict
 
-import numpy
-
 
 class _IFileVariable:
     """This is the abstract base class for file variable.
@@ -57,86 +55,6 @@ class _IFileVariable:
         :rtype: dict
         """
         pass
-
-
-class NetCDFFileVariable(_IFileVariable):
-    """Wrapper for NetCDF plotter data."""
-
-    def get_array(self):
-        """Returns the actual data stored by the plotter data.
-
-        :return: the data
-        :rtype: numpy array
-        """
-        return self._variable[:]
-
-    def get_attributes(self):
-        """Returns the attributes stored by the plotter data.
-
-        :return: the attributes
-        :rtype: dict
-        """
-        return self._variable.__dict__
-
-
-class HDFFileVariable(_IFileVariable):
-    """Wrapper for HDF plotter data."""
-
-    def get_array(self):
-        """Returns the actual data stored by the plotter data.
-
-        :return: the data
-        :rtype: numpy array
-        """
-        return self._variable[:]
-
-    def get_attributes(self):
-        """Returns the attributes stored by the plotter data.
-
-        :return: the attributes
-        :rtype: dict
-        """
-        return self._variable.attrs
-
-
-def netcdf_find_numeric_variables(var_dict, group):
-    """
-    This function recursively retrieves all the numeric variables stored in a NetCDF file.
-
-    :param var_dict: The dictionary into which the variables are saved.
-    :type var_dict: dict
-
-    :param group: The file whose variables are to be retrieved.
-    :type group: netCDF4.Dataset or netCDF4.Group
-
-    :return: All the variable objects in the provided file.
-    :rtype: collections.OrderedDict[str, (str, NetCDFFileVariable)]
-    """
-
-    for var_key, var in group.variables.items():
-        if group.path == '/':
-            path = '/{}'.format(var_key)
-        else:
-            path = '{}/{}'.format(group.path, var_key)
-
-        # Non-numeric variables are not supported
-        if not numpy.issubdtype(var.dtype, numpy.number):
-            continue
-        # Variables with dimension higher than 3 are not supported
-        if var.ndim > 3:
-            continue
-
-        comp = 1
-        while var_key in var_dict:
-            var_key = '{:s}_{:d}'.format(var_key, comp)
-            comp += 1
-
-        var_dict[var_key] = (path, NetCDFFileVariable(var))
-
-    for _, sub_group in group.groups.items():
-        var_dict.update(netcdf_find_numeric_variables(var_dict, sub_group))
-
-    return var_dict
 
 
 def load_variables(dictionary):

--- a/Src/IO/IOUtils.py
+++ b/Src/IO/IOUtils.py
@@ -13,14 +13,104 @@
 #
 # **************************************************************************
 
+import abc
+from collections import OrderedDict
+
 import numpy
+
+
+class _IFileVariable:
+    """This is the abstract base class for file variable.
+
+    Basically, this class allows to have a common interface for the data formats supported by MDANSE.
+    """
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, variable):
+        self._variable = variable
+
+    def __getattr__(self, name):
+        return getattr(self._variable, name)
+
+    def __hasattr__(self, name):
+        return hasattr(self._variable, name)
+
+    @property
+    def variable(self):
+        return self._variable
+
+    @abc.abstractmethod
+    def get_array(self):
+        """Returns the actual data stored by the plotter data.
+
+        :return: the data
+        :rtype: numpy array
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_attributes(self):
+        """Returns the attributes stored by the plotter data.
+
+        :return: the attributes
+        :rtype: dict
+        """
+        pass
+
+
+class NetCDFFileVariable(_IFileVariable):
+    """Wrapper for NetCDF plotter data."""
+
+    def get_array(self):
+        """Returns the actual data stored by the plotter data.
+
+        :return: the data
+        :rtype: numpy array
+        """
+        return self._variable[:]
+
+    def get_attributes(self):
+        """Returns the attributes stored by the plotter data.
+
+        :return: the attributes
+        :rtype: dict
+        """
+        return self._variable.__dict__
+
+
+class HDFFileVariable(_IFileVariable):
+    """Wrapper for HDF plotter data."""
+
+    def get_array(self):
+        """Returns the actual data stored by the plotter data.
+
+        :return: the data
+        :rtype: numpy array
+        """
+        return self._variable[:]
+
+    def get_attributes(self):
+        """Returns the attributes stored by the plotter data.
+
+        :return: the attributes
+        :rtype: dict
+        """
+        return self._variable.attrs
 
 
 def netcdf_find_numeric_variables(var_dict, group):
     """
     This function recursively retrieves all the numeric variables stored in a NetCDF file.
 
-    This is a recursive method.
+    :param var_dict: The dictionary into which the variables are saved.
+    :type var_dict: dict
+
+    :param group: The file whose variables are to be retrieved.
+    :type group: netCDF4.Dataset or netCDF4.Group
+
+    :return: All the variable objects in the provided file.
+    :rtype: collections.OrderedDict[str, (str, NetCDFFileVariable)]
     """
 
     for var_key, var in group.variables.items():
@@ -41,9 +131,42 @@ def netcdf_find_numeric_variables(var_dict, group):
             var_key = '{:s}_{:d}'.format(var_key, comp)
             comp += 1
 
-        var_dict[var_key] = (path, var)
+        var_dict[var_key] = (path, NetCDFFileVariable(var))
 
     for _, sub_group in group.groups.items():
         var_dict.update(netcdf_find_numeric_variables(var_dict, sub_group))
 
     return var_dict
+
+
+def load_variables(dictionary):
+    """
+    Processes the provided variables into a form usable by MDANSE. This is done by moving the various attributes and
+    properties of each variable into a dictionary.
+
+    :param dictionary: The variables to be processed.
+    :type dictionary: dict[str, (str, _IFileVariable)]
+
+    :return: The processed variables.
+    :rtype: collections.OrderedDict[str, dict]
+    """
+    data = OrderedDict()
+    for vname, vinfo in dictionary.items():
+        vpath, variable = vinfo
+        arr = variable.get_array()
+        attributes = variable.get_attributes()
+
+        data[vname] = {}
+        if 'axis' in attributes:
+            axis = attributes['axis']
+            if axis:
+                data[vname]['axis'] = axis.split('|')
+            else:
+                data[vname]['axis'] = []
+        else:
+            data[vname]['axis'] = []
+        data[vname]['path'] = vpath
+        data[vname]['data'] = arr
+        data[vname]['units'] = attributes.get('units', 'au')
+
+    return data

--- a/Src/IO/IOUtils.py
+++ b/Src/IO/IOUtils.py
@@ -1,0 +1,49 @@
+# **************************************************************************
+#
+# MDANSE: Molecular Dynamics Analysis for Neutron Scattering Experiments
+#
+# @file      Src/Framework/InputData/IInputData.py
+# @brief     Implements module/class/test IInputData
+#
+# @homepage  https://mdanse.org
+# @license   GNU General Public License v3 or higher (see LICENSE)
+# @copyright Institut Laue Langevin 2013-now
+# @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now
+# @authors   Scientific Computing Group at ILL (see AUTHORS)
+#
+# **************************************************************************
+
+import numpy
+
+
+def netcdf_find_numeric_variables(var_dict, group):
+    """
+    This function recursively retrieves all the numeric variables stored in a NetCDF file.
+
+    This is a recursive method.
+    """
+
+    for var_key, var in group.variables.items():
+        if group.path == '/':
+            path = '/{}'.format(var_key)
+        else:
+            path = '{}/{}'.format(group.path, var_key)
+
+        # Non-numeric variables are not supported
+        if not numpy.issubdtype(var.dtype, numpy.number):
+            continue
+        # Variables with dimension higher than 3 are not supported
+        if var.ndim > 3:
+            continue
+
+        comp = 1
+        while var_key in var_dict:
+            var_key = '{:s}_{:d}'.format(var_key, comp)
+            comp += 1
+
+        var_dict[var_key] = (path, var)
+
+    for _, sub_group in group.groups.items():
+        var_dict.update(netcdf_find_numeric_variables(var_dict, sub_group))
+
+    return var_dict

--- a/Src/IO/NetCDF.py
+++ b/Src/IO/NetCDF.py
@@ -1,0 +1,78 @@
+# **************************************************************************
+#
+# MDANSE: Molecular Dynamics Analysis for Neutron Scattering Experiments
+#
+# @file      Src/Framework/InputData/IInputData.py
+# @brief     Implements module/class/test IInputData
+#
+# @homepage  https://mdanse.org
+# @license   GNU General Public License v3 or higher (see LICENSE)
+# @copyright Institut Laue Langevin 2013-now
+# @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now
+# @authors   Scientific Computing Group at ILL (see AUTHORS)
+#
+# **************************************************************************
+
+import numpy
+
+from MDANSE.IO.IOUtils import _IFileVariable
+
+
+class NetCDFFileVariable(_IFileVariable):
+    """Wrapper for NetCDF plotter data."""
+
+    def get_array(self):
+        """Returns the actual data stored by the plotter data.
+
+        :return: the data
+        :rtype: numpy array
+        """
+        return self._variable[:]
+
+    def get_attributes(self):
+        """Returns the attributes stored by the plotter data.
+
+        :return: the attributes
+        :rtype: dict
+        """
+        return self._variable.__dict__
+
+
+def find_numeric_variables(var_dict, group):
+    """
+    This function recursively retrieves all the numeric variables stored in a NetCDF file.
+
+    :param var_dict: The dictionary into which the variables are saved.
+    :type var_dict: dict
+
+    :param group: The file whose variables are to be retrieved.
+    :type group: netCDF4.Dataset or netCDF4.Group
+
+    :return: All the variable objects in the provided file.
+    :rtype: collections.OrderedDict[str, (str, NetCDFFileVariable)]
+    """
+
+    for var_key, var in group.variables.items():
+        if group.path == '/':
+            path = '/{}'.format(var_key)
+        else:
+            path = '{}/{}'.format(group.path, var_key)
+
+        # Non-numeric variables are not supported
+        if not numpy.issubdtype(var.dtype, numpy.number):
+            continue
+        # Variables with dimension higher than 3 are not supported
+        if var.ndim > 3:
+            continue
+
+        comp = 1
+        while var_key in var_dict:
+            var_key = '{:s}_{:d}'.format(var_key, comp)
+            comp += 1
+
+        var_dict[var_key] = (path, NetCDFFileVariable(var))
+
+    for _, sub_group in group.groups.items():
+        var_dict.update(find_numeric_variables(var_dict, sub_group))
+
+    return var_dict

--- a/Src/IO/__init__.py
+++ b/Src/IO/__init__.py
@@ -1,0 +1,14 @@
+# **************************************************************************
+#
+# MDANSE: Molecular Dynamics Analysis for Neutron Scattering Experiments
+#
+# @file      Src/Framework/InputData/NetCDFInputData.py
+# @brief     Implements module/class/test NetCDFInputData
+#
+# @homepage  https://mdanse.org
+# @license   GNU General Public License v3 or higher (see LICENSE)
+# @copyright Institut Laue Langevin 2013-now
+# @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now
+# @authors   Scientific Computing Group at ILL (see AUTHORS)
+#
+# **************************************************************************


### PR DESCRIPTION
**Description of work.**

Fixes #113 

When abstraction was added to plotter in #86, a new column was added to the 'variable' part of the Data panel that shows the path of the variable in the file. However, this information is only available when the data is loaded via the `PlotterFrame` which uses the abstraction and the `netCDF4` or `h5py` package. In `MainFrame`, which loads in only MMTK NetCDF data and does so through the `MMTK` package, the path information does not exist.

Therefore, the `NetCDFInputData` class has been extended to also store path information. Further, the same recursive variable-searching pattern was applied to it as is used in the `NetCDFPlotterData` class. Lastly, refactoring was performed to make easier future work.

**To test:**

1. Open the result of analysis through the main window
2. In the Plugins panel, open the 2D/3D Plotter, and observe that there are no issues.
3. Open the standalone 2D/3D Plotter through the toolbar
4. Open .nc and .h5 files and observe that there are no issues