### PR TITLE
Set .nc and .h5 file browsing by default in plotter

### DIFF
--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -466,7 +466,8 @@ class PlotterFrame(wx.Frame):
                 
     def on_load_data(self, event=None):
         
-        filters = 'NetCDF file (*.nc)|*.nc|HDF file (*.h5)|*.h5|All files (*.*)|*.*'
+        filters = 'NetCDF and HDF files (*.nc;*.netcdf;*.h5;*.hdf)|*.nc;*.netcdf;*.h5;*.hdf|' \
+                  'NetCDF file (*.nc)|*.nc|HDF file (*.h5)|*.h5|All files (*.*)|*.*'
         dialog = wx.FileDialog ( self, message = 'Open file...', wildcard=filters, style=wx.MULTIPLE)
         if dialog.ShowModal() == wx.ID_CANCEL:
             return


### PR DESCRIPTION
A small quality of life improvement that sets the file browser in 2D/3D Plotter (when loading data into plotter) to show both NetCDF and HDF5 files by default. I noticed that it's quite annoying to plot stuff at the moment since the default output file format of analyses is HDF5, but the default format of the plotter is NetCDF. Therefore, every time I load a file into the 2D/3D Plotter, I have to switch the file formats displayed from .nc to .h5. Now, both are visible, while the options to only see NetCDF or only HDF5 still exist. What do you think, @sanghamitra-mukhopadhyay?

Before:
![image](https://user-images.githubusercontent.com/78977041/175345689-d5f9e637-c7ce-4e90-be0b-19e640e66182.png)
Now:
![image](https://user-images.githubusercontent.com/78977041/175345878-c704ca52-4485-4a4e-941f-9cd5330822b7.png)
