### PR TITLE
Fix version names in installers

### DIFF
--- a/BuildServer/Unix/setup_ci.sh
+++ b/BuildServer/Unix/setup_ci.sh
@@ -54,7 +54,7 @@ then
     "${SED_I_COMMAND[@]}" "s/.*__beta__.*/__beta__ = None/" ${PKG_INFO}
 else
     # Check if branch is release*
-	if [[ ${GITHUB_REF::7} == "release-next" ]]
+	if [[ $GITHUB_REF == "release-next" ]]
 	then
 	    VERSION_NAME=${MDANSE_VERSION}-rc-${CI_COMMIT_ID}
 	    "${SED_I_COMMAND[@]}" "s/.*__beta__.*/__beta__ = \"rc\"/" ${PKG_INFO}

--- a/BuildServer/Windows/setup_ci.bat
+++ b/BuildServer/Windows/setup_ci.bat
@@ -33,7 +33,7 @@ if "%MDANSE_GIT_BRANCH_NAME%" == "main" (
     move Src\\__pkginfo__.pybak Src\\__pkginfo__.py
 ) else (
     rem Check if branch is release*
-    if "%MDANSE_GIT_BRANCH_NAME:~0,7%" == "release-next" (
+    if "%MDANSE_GIT_BRANCH_NAME" == "release-next" (
         set VERSION_NAME=%MDANSE_VERSION%-rc-%MDANSE_GIT_CURRENT_COMMIT%
         sed "s/.*__beta__.*/__beta__ = \"rc\"/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
         move Src\\__pkginfo__.pybak Src\\__pkginfo__.py


### PR DESCRIPTION
The branch names are now different than they used to be in the ILL repo, causing the newly released MDANSE installers to say that it's a beta release even though it was a full release. This has been fixed by correcting the branch names in the CI/CD scripts.