### PR TITLE
Fix the version name in fully released installers

### DIFF
--- a/BuildServer/Unix/setup_ci.sh
+++ b/BuildServer/Unix/setup_ci.sh
@@ -48,13 +48,13 @@ PKG_INFO=$GITHUB_WORKSPACE/Src/__pkginfo__.py
 MDANSE_VERSION=`sed -n 's/__version__.*=.*\"\(.*\)\"/\1/p' ${PKG_INFO}`
 
 # Check if branch is main
-if [[ $GITHUB_REF == "main" ]]
+if [[ $GITHUB_REF == "refs/heads/main" ]]
 then
     VERSION_NAME=${MDANSE_VERSION}
     "${SED_I_COMMAND[@]}" "s/.*__beta__.*/__beta__ = None/" ${PKG_INFO}
 else
     # Check if branch is release*
-	if [[ $GITHUB_REF == "release-next" ]]
+	if [[ $GITHUB_REF == "refs/heads/release-next" ]]
 	then
 	    VERSION_NAME=${MDANSE_VERSION}-rc-${CI_COMMIT_ID}
 	    "${SED_I_COMMAND[@]}" "s/.*__beta__.*/__beta__ = \"rc\"/" ${PKG_INFO}

--- a/BuildServer/Windows/setup_ci.bat
+++ b/BuildServer/Windows/setup_ci.bat
@@ -27,13 +27,13 @@ set cmd="sed -n "s/__version__.*=.*\"\(.*\)\"/\1/p" Src/__pkginfo__.py"
 for /F %%i in (' %cmd% ') do set MDANSE_VERSION=%%i
 
 rem Check if branch is main, tag as draft otherwise
-if "%MDANSE_GIT_BRANCH_NAME%" == "main" (
+if "%MDANSE_GIT_BRANCH_NAME%" == "refs/heads/main" (
     set VERSION_NAME=%MDANSE_VERSION%
     sed "s/.*__beta__.*/__beta__ = None/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
     move Src\\__pkginfo__.pybak Src\\__pkginfo__.py
 ) else (
     rem Check if branch is release*
-    if "%MDANSE_GIT_BRANCH_NAME" == "release-next" (
+    if "%MDANSE_GIT_BRANCH_NAME" == "refs/heads/release-next" (
         set VERSION_NAME=%MDANSE_VERSION%-rc-%MDANSE_GIT_CURRENT_COMMIT%
         sed "s/.*__beta__.*/__beta__ = \"rc\"/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
         move Src\\__pkginfo__.pybak Src\\__pkginfo__.py


### PR DESCRIPTION
#121 did not fix the issue because the name that was used for checking the branch names was just <branch_name>, but the GitHub actions environment variable returns the branch name as refs/heads/<branch_name>. This has been fixed by using the correct format.