### PR TITLE
Fix windows installer version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -342,10 +342,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: |
-          call "%GITHUB_WORKSPACE%\BuildServer\Windows\setup_ci.bat"
-        shell: cmd
-
       - name: Restore VS2008 from cache
         id: vs2008-cache
         uses: actions/cache@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -342,6 +342,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - run: |
+          call "%GITHUB_WORKSPACE%\BuildServer\Windows\setup_ci.bat"
+
       - name: Restore VS2008 from cache
         id: vs2008-cache
         uses: actions/cache@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -344,6 +344,7 @@ jobs:
 
       - run: |
           call "%GITHUB_WORKSPACE%\BuildServer\Windows\setup_ci.bat"
+        shell: cmd
 
       - name: Restore VS2008 from cache
         id: vs2008-cache

--- a/BuildServer/Windows/setup_ci.bat
+++ b/BuildServer/Windows/setup_ci.bat
@@ -27,7 +27,7 @@ set cmd="sed -n "s/__version__.*=.*\"\(.*\)\"/\1/p" Src/__pkginfo__.py"
 for /F %%i in (' %cmd% ') do set MDANSE_VERSION=%%i
 
 rem Check if branch is main, tag as draft otherwise
-if %MDANSE_GIT_BRANCH_NAME% == refs/heads/hotfix-windows-installer-version (
+if %MDANSE_GIT_BRANCH_NAME% == refs/heads/main (
     set VERSION_NAME=%MDANSE_VERSION%
     sed "s/.*__beta__.*/__beta__ = None/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
     move /Y Src\\__pkginfo__.pybak Src\\__pkginfo__.py

--- a/BuildServer/Windows/setup_ci.bat
+++ b/BuildServer/Windows/setup_ci.bat
@@ -27,13 +27,13 @@ set cmd="sed -n "s/__version__.*=.*\"\(.*\)\"/\1/p" Src/__pkginfo__.py"
 for /F %%i in (' %cmd% ') do set MDANSE_VERSION=%%i
 
 rem Check if branch is main, tag as draft otherwise
-if "%MDANSE_GIT_BRANCH_NAME%" == "refs/heads/hotfix-windows-installer-version" (
+if "%MDANSE_GIT_BRANCH_NAME%" == refs/heads/hotfix-windows-installer-version (
     set VERSION_NAME=%MDANSE_VERSION%
     sed "s/.*__beta__.*/__beta__ = None/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
     move /Y Src\\__pkginfo__.pybak Src\\__pkginfo__.py
 ) else (
     rem Check if branch is release*
-    if "%MDANSE_GIT_BRANCH_NAME" == "refs/heads/release-next" (
+    if "%MDANSE_GIT_BRANCH_NAME" == refs/heads/release-next (
         set VERSION_NAME=%MDANSE_VERSION%-rc-%MDANSE_GIT_CURRENT_COMMIT%
         sed "s/.*__beta__.*/__beta__ = \"rc\"/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
         move /Y Src\\__pkginfo__.pybak Src\\__pkginfo__.py

--- a/BuildServer/Windows/setup_ci.bat
+++ b/BuildServer/Windows/setup_ci.bat
@@ -27,13 +27,13 @@ set cmd="sed -n "s/__version__.*=.*\"\(.*\)\"/\1/p" Src/__pkginfo__.py"
 for /F %%i in (' %cmd% ') do set MDANSE_VERSION=%%i
 
 rem Check if branch is main, tag as draft otherwise
-if "%MDANSE_GIT_BRANCH_NAME%" == refs/heads/hotfix-windows-installer-version (
+if %MDANSE_GIT_BRANCH_NAME% == refs/heads/hotfix-windows-installer-version (
     set VERSION_NAME=%MDANSE_VERSION%
     sed "s/.*__beta__.*/__beta__ = None/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
     move /Y Src\\__pkginfo__.pybak Src\\__pkginfo__.py
 ) else (
-    rem Check if branch is release*
-    if "%MDANSE_GIT_BRANCH_NAME" == refs/heads/release-next (
+    rem Check if branch is release-next
+    if %MDANSE_GIT_BRANCH_NAME% == refs/heads/release-next (
         set VERSION_NAME=%MDANSE_VERSION%-rc-%MDANSE_GIT_CURRENT_COMMIT%
         sed "s/.*__beta__.*/__beta__ = \"rc\"/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
         move /Y Src\\__pkginfo__.pybak Src\\__pkginfo__.py

--- a/BuildServer/Windows/setup_ci.bat
+++ b/BuildServer/Windows/setup_ci.bat
@@ -20,26 +20,27 @@ echo "Branch name %MDANSE_GIT_BRANCH_NAME%"
 rem sed -i unfortunately creates backup file, see https://stackoverflow.com/questions/1823591/sed-creates-un-deleteable-files-in-windows
 rem so we do not use the -i option
 sed "s/.*__commit__.*/__commit__ = \"%MDANSE_GIT_CURRENT_COMMIT%\"/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
-move Src\\__pkginfo__.pybak Src\\__pkginfo__.py
+move /Y Src\\__pkginfo__.pybak Src\\__pkginfo__.py
 
 rem Get MDANSE version
 set cmd="sed -n "s/__version__.*=.*\"\(.*\)\"/\1/p" Src/__pkginfo__.py"
 for /F %%i in (' %cmd% ') do set MDANSE_VERSION=%%i
 
 rem Check if branch is main, tag as draft otherwise
-if "%MDANSE_GIT_BRANCH_NAME%" == "refs/heads/main" (
+if "%MDANSE_GIT_BRANCH_NAME%" == "refs/heads/fix_windows_installer_version" (
     set VERSION_NAME=%MDANSE_VERSION%
     sed "s/.*__beta__.*/__beta__ = None/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
-    move Src\\__pkginfo__.pybak Src\\__pkginfo__.py
+    move /Y Src\\__pkginfo__.pybak Src\\__pkginfo__.py
 ) else (
     rem Check if branch is release*
     if "%MDANSE_GIT_BRANCH_NAME" == "refs/heads/release-next" (
         set VERSION_NAME=%MDANSE_VERSION%-rc-%MDANSE_GIT_CURRENT_COMMIT%
         sed "s/.*__beta__.*/__beta__ = \"rc\"/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
-        move Src\\__pkginfo__.pybak Src\\__pkginfo__.py
+        move /Y Src\\__pkginfo__.pybak Src\\__pkginfo__.py
     ) else (
         set VERSION_NAME=%MDANSE_VERSION%-beta-%MDANSE_GIT_CURRENT_COMMIT%
         sed "s/.*__beta__.*/__beta__ = \"beta\"/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
-        move Src\\__pkginfo__.pybak Src\\__pkginfo__.py
+        move /Y Src\\__pkginfo__.pybak Src\\__pkginfo__.py
     )
 )
+echo %VERSION_NAME%

--- a/BuildServer/Windows/setup_ci.bat
+++ b/BuildServer/Windows/setup_ci.bat
@@ -27,7 +27,7 @@ set cmd="sed -n "s/__version__.*=.*\"\(.*\)\"/\1/p" Src/__pkginfo__.py"
 for /F %%i in (' %cmd% ') do set MDANSE_VERSION=%%i
 
 rem Check if branch is main, tag as draft otherwise
-if "%MDANSE_GIT_BRANCH_NAME%" == "refs/heads/fix_windows_installer_version" (
+if "%MDANSE_GIT_BRANCH_NAME%" == "refs/heads/hotfix-windows-installer-version" (
     set VERSION_NAME=%MDANSE_VERSION%
     sed "s/.*__beta__.*/__beta__ = None/" Src\\__pkginfo__.py >> Src\\__pkginfo__.pybak
     move /Y Src\\__pkginfo__.pybak Src\\__pkginfo__.py


### PR DESCRIPTION
#122 did not fix the Windows name due to issues  unique to the Windows script. The syntax in it has been corrected and gives correct values.