### PR TITLE
Improve the parsing error messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+version 1.5.1
+--------------
+* FIXED issue #126 The error messages are now helpful when incorrect input is provided in fields like DL_POLY's 'aliases' that take Python object-like input
+
 version 1.5.0
 --------------
 * ADDED issue #93 HDF5 format can now be used as output format of analyses as well as input for plotters

--- a/Src/Framework/Configurators/PythonObjectConfigurator.py
+++ b/Src/Framework/Configurators/PythonObjectConfigurator.py
@@ -16,7 +16,7 @@
 import ast
 
 from MDANSE import REGISTRY
-from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
+from MDANSE.Framework.Configurators.IConfigurator import IConfigurator, ConfiguratorError
         
 class PythonObjectConfigurator(IConfigurator):
     """
@@ -30,16 +30,18 @@ class PythonObjectConfigurator(IConfigurator):
     _default = '""'
 
     def configure(self, value):
-        '''
-        Configure a python object. 
-                
-        :param configuration: the current configuration.
-        :type configuration: a MDANSE.Framework.Configurable.Configurable object
+        """
+        Configure a python object.
+
         :param value: the python object to be configured and evaluated.
         :type value: strings, numbers, tuples, lists, dicts, booleans or None type.
-        '''
-        
-        value = ast.literal_eval(repr(value))
+        """
+
+        try:
+            value = ast.literal_eval(repr(value))
+        except SyntaxError as e:
+            raise ConfiguratorError('The inputted python code could not be parsed due to the following error:\n\n'
+                                    'SyntaxError: %s' % e, self)
                                 
         self['value'] = value
 

--- a/Src/GUI/Widgets/PythonObjectWidgets.py
+++ b/Src/GUI/Widgets/PythonObjectWidgets.py
@@ -20,6 +20,8 @@ import wx
 from MDANSE import REGISTRY
 
 from MDANSE.GUI.Widgets.IWidget import IWidget
+from MDANSE.Framework.Configurators.IConfigurator import ConfiguratorError
+
 
 class PythonObjectWidget(IWidget):
     
@@ -37,6 +39,11 @@ class PythonObjectWidget(IWidget):
                 
         val = self._string.GetValue()
 
-        return ast.literal_eval(val)
+        try:
+            return ast.literal_eval(val)
+        except SyntaxError as e:
+            raise ConfiguratorError('The inputted python code could not be parsed due to the following error:\n\n'
+                                    'SyntaxError: %s' % e, self)
+
 
 REGISTRY["python_object"] = PythonObjectWidget


### PR DESCRIPTION
**Description of work**
Fixes #126 

The error messages when incorrect Python syntax is inputted in the parts of MDANSE that use `PythonObjectConfigurator` are currently very unhelpful. This has been improved by catching the `SyntaxError` returned by `ast.parse` and adding additional information.

**To test**

1. Open e.g. DL_POLY converter
2. Type a syntactically incorrect input into the 'aliases' field (e.g. `{"}`)
3. Observe that the error is helpful
