### PR TITLE
Add unit tests for ChemicalEntity.py

### DIFF
--- a/Extensions/.gitignore
+++ b/Extensions/.gitignore
@@ -1,6 +1,12 @@
+/atomic_trajectory.c
+/atoms_in_shell.c
+/change_coordinates.c
+/com_trajectory.c
+/contiguous_coordinates.c
 /mic_fast_calc.cpp
 /distance_histogram.c
 /fast_calculation.c
+/fold_coordinates.c
 /mt_fast_calc.c
 /qhull.c
 /sas_fast_calc.c

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -1,4 +1,5 @@
 import abc
+from ast import literal_eval
 import collections
 import copy
 from typing import Union
@@ -482,7 +483,7 @@ class Atom(_ChemicalEntity):
 
         self._symbol = symbol
 
-    def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+    def serialize(self, h5_contents: dict[str, list[list[str]]]) -> tuple[str, int]:
         """
         Serializes the Atom object into a string in preparation of the object being stored on disk.
 
@@ -493,10 +494,7 @@ class Atom(_ChemicalEntity):
             provided dictionary.
         :rtype: tuple
         """
-        atom_str = 'H5Atom(self._h5_file,h5_contents,symbol="{}", name="{}", ghost={})'.format(self.symbol, self.name,
-                                                                                               self.ghost)
-
-        h5_contents.setdefault('atoms', []).append(atom_str)
+        h5_contents.setdefault('atoms', []).append([repr(self.symbol), repr(self.name), str(self.ghost)])
 
         return 'atoms', len(h5_contents['atoms']) - 1
 
@@ -671,7 +669,7 @@ class AtomCluster(_ChemicalEntity):
 
         self._atoms = reordered_atoms
 
-    def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+    def serialize(self, h5_contents: dict[str, list[list[str]]]) -> tuple[str, int]:
         """
         Serializes the AtomCluster object and its contents into strings in preparation of the object being stored on
         disk.
@@ -688,9 +686,7 @@ class AtomCluster(_ChemicalEntity):
         else:
             at_indexes = list(range(len(self._atoms)))
 
-        ac_str = 'H5AtomCluster(self._h5_file,h5_contents,{},name="{}")'.format(at_indexes, self._name)
-
-        h5_contents.setdefault('atom_clusters', []).append(ac_str)
+        h5_contents.setdefault('atom_clusters', []).append([str(at_indexes), repr(self._name)])
 
         for at in self._atoms:
             at.serialize(h5_contents)
@@ -808,7 +804,7 @@ class Molecule(_ChemicalEntity):
 
         self._atoms = reordered_atoms
 
-    def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+    def serialize(self, h5_contents: dict[str, list[list[str]]]) -> tuple[str, int]:
         """
         Serializes the Molecule object and its contents into strings in preparation of the object being stored on
         disk.
@@ -825,10 +821,7 @@ class Molecule(_ChemicalEntity):
         else:
             at_indexes = list(range(len(self._atoms)))
 
-        mol_str = 'H5Molecule(self._h5_file,h5_contents,{},code="{}",name="{}")'.format(at_indexes, self._code,
-                                                                                        self._name)
-
-        h5_contents.setdefault('molecules', []).append(mol_str)
+        h5_contents.setdefault('molecules', []).append([str(at_indexes), repr(self._code), repr(self._name)])
 
         for at in self._atoms.values():
             at.serialize(h5_contents)
@@ -991,7 +984,7 @@ class Residue(_ChemicalEntity):
     def variant(self):
         return self._variant
 
-    def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+    def serialize(self, h5_contents: dict[str, list[list[str]]]) -> tuple[str, int]:
         """
         Serializes the Residue object and its contents into strings in preparation of the object being stored on
         disk.
@@ -1008,12 +1001,8 @@ class Residue(_ChemicalEntity):
         else:
             at_indexes = list(range(len(self._atoms)))
 
-        res_str = 'H5Residue(self._h5_file,h5_contents,{},code="{}",name="{}",variant={})'.format(at_indexes,
-                                                                                                  self._code,
-                                                                                                  self._name,
-                                                                                                  repr(self._variant))
-
-        h5_contents.setdefault('residues', []).append(res_str)
+        h5_contents.setdefault('residues', []).append([str(at_indexes), repr(self._code), repr(self._name),
+                                                       repr(self._variant)])
 
         for at in self._atoms.values():
             at.serialize(h5_contents)
@@ -1165,7 +1154,7 @@ class Nucleotide(_ChemicalEntity):
     def variant(self):
         return self._variant
 
-    def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+    def serialize(self, h5_contents: dict[str, list[list[str]]]) -> tuple[str, int]:
         """
         Serializes the Nucleotide object and its contents into strings in preparation of the object being stored on
         disk.
@@ -1182,13 +1171,8 @@ class Nucleotide(_ChemicalEntity):
         else:
             at_indexes = list(range(len(self._atoms)))
 
-        res_str = 'H5Nucleotide(self._h5_file,h5_contents,{},code="{}",name="{}",variant={})'.format(at_indexes,
-                                                                                                     self._code,
-                                                                                                     self._name,
-                                                                                                     repr(
-                                                                                                         self._variant))
-
-        h5_contents.setdefault('nucleotides', []).append(res_str)
+        h5_contents.setdefault('nucleotides', []).append([str(at_indexes), repr(self._code), repr(self._name),
+                                                          repr(self._variant)])
 
         for at in self._atoms.values():
             at.serialize(h5_contents)
@@ -1360,7 +1344,7 @@ class NucleotideChain(_ChemicalEntity):
             number_of_atoms += nucleotide.total_number_of_atoms
         return number_of_atoms
 
-    def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+    def serialize(self, h5_contents: dict[str, list[list[str]]]) -> tuple[str, int]:
         """
         Serializes the NucleotideChain object and its contents into strings in preparation of the object being stored on
         disk.
@@ -1378,12 +1362,10 @@ class NucleotideChain(_ChemicalEntity):
         else:
             res_indexes = list(range(len(self._nucleotides)))
 
-        pc_str = 'H5NucleotideChain(self._h5_file,h5_contents,"{}",{})'.format(self._name, res_indexes)
-
         for nucl in self._nucleotides:
             nucl.serialize(h5_contents)
 
-        h5_contents.setdefault('nucleotide_chains', []).append(pc_str)
+        h5_contents.setdefault('nucleotide_chains', []).append([repr(self._name), str(res_indexes)])
 
         return 'nucleotide_chains', len(h5_contents['nucleotide_chains']) - 1
 
@@ -1594,7 +1576,7 @@ class PeptideChain(_ChemicalEntity):
         """The list of amino acid Residues that make up this PeptideChain."""
         return self._residues
 
-    def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+    def serialize(self, h5_contents: dict[str, list[list[str]]]) -> tuple[str, int]:
         """
         Serializes the PeptideChain object and its contents into strings in preparation of the object being stored on
         disk.
@@ -1611,12 +1593,10 @@ class PeptideChain(_ChemicalEntity):
         else:
             res_indexes = list(range(len(self._residues)))
 
-        pc_str = 'H5PeptideChain(self._h5_file,h5_contents,"{}",{})'.format(self._name, res_indexes)
-
         for res in self._residues:
             res.serialize(h5_contents)
 
-        h5_contents.setdefault('peptide_chains', []).append(pc_str)
+        h5_contents.setdefault('peptide_chains', []).append([repr(self._name), str(res_indexes)])
 
         return 'peptide_chains', len(h5_contents['peptide_chains']) - 1
 
@@ -1765,7 +1745,7 @@ class Protein(_ChemicalEntity):
 
         return residues
 
-    def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+    def serialize(self, h5_contents: dict[str, list[list[str]]]) -> tuple[str, int]:
         """
         Serializes the Protein object and its contents into strings in preparation of the object being stored on disk.
 
@@ -1782,9 +1762,7 @@ class Protein(_ChemicalEntity):
         else:
             pc_indexes = list(range(len(self._peptide_chains)))
 
-        prot_str = 'H5Protein(self._h5_file,h5_contents,"{}",{})'.format(self._name, pc_indexes)
-
-        h5_contents.setdefault('proteins', []).append(prot_str)
+        h5_contents.setdefault('proteins', []).append([repr(self._name), str(pc_indexes)])
 
         for pc in self._peptide_chains:
             pc.serialize(h5_contents)
@@ -1976,11 +1954,17 @@ class ChemicalSystem(_ChemicalEntity):
 
         from MDANSE.Chemistry.H5ChemicalEntity import H5Atom, H5AtomCluster, H5Molecule, H5Nucleotide, \
             H5NucleotideChain, H5Residue, H5PeptideChain, H5Protein
+        h5_classes = {'atoms': H5Atom, 'atom_clusters': H5AtomCluster, 'molecules': H5Molecule,
+                      'nucleotides': H5Nucleotide, 'nucleotide_chain': H5NucleotideChain, 'residue': H5Residue,
+                      'peptide_chains': H5PeptideChain, 'proteins': H5Protein}
 
         try:
             h5_file = h5py.File(h5_filename, 'r', libver='latest')
+            close_file = True
         except TypeError:
             h5_file = h5_filename
+            close_file = False
+
         grp = h5_file['/chemical_system']
         self._chemical_entities = []
 
@@ -1994,28 +1978,46 @@ class ChemicalSystem(_ChemicalEntity):
                 continue
             h5_contents[entity_type] = v[:]
 
-        for entity_type, entity_index in skeleton:
+        for i, (entity_type, entity_index) in enumerate(skeleton):
             entity_index = int(entity_index)
-            code = h5_contents[entity_type.decode('utf-8')][entity_index].replace('self._', '')
+            entity_type = entity_type.decode('utf-8')
+
             try:
-                h5_chemical_entity_instance = eval(code, {'__builtins__': {}},
-                                                   {'H5Atom': H5Atom, 'H5AtomCluster': H5AtomCluster,
-                                                    'H5Molecule': H5Molecule, 'H5Nucleotide': H5Nucleotide,
-                                                    'H5NucleotideChain': H5NucleotideChain, 'H5Residue': H5Residue,
-                                                    'H5PeptideChain': H5PeptideChain, 'H5Protein': H5Protein,
-                                                    'h5_contents': h5_contents, 'h5_file': h5_file})
-            except (NameError, TypeError):
+                entity_class = h5_classes[entity_type]
+            except KeyError:
                 h5_file.close()
-                raise CorruptedFileError('The provided HDF5 file could not be parsed because the chemical entity of '
-                                         f'type "{entity_type}" with index {entity_index} (located in the HDF5 file at '
-                                         f'/chemical_system/{entity_type}) contains invalid data. A string containing '
-                                         'the constructor for a sublcass of MDANSE.Chemistry.H5ChemicalEntity.'
-                                         f'_H5ChemicalEntity is expected, but instead the following value is present:'
-                                         f'{repr(code)}')
+                raise CorruptedFileError(f'Could not create a chemical entity of type {entity_type}. The entity listed'
+                                         f' in the chemical system contents (located at /chemical_system/contents in '
+                                         f'the HDF5 file) at index {i} is not recognised as valid entity; {entity_type}'
+                                         f' should be one of: atoms, atom_clusters, molecules, nucleotides, nucleotide'
+                                         f'_chains, residues, residue_chains, or proteins.')
+            try:
+                arguments = [literal_eval(arg) for arg in h5_contents[entity_type][entity_index]]
+            except KeyError:
+                raise CorruptedFileError(f'Could not find chemical entity {entity_type}, listed in chemical system '
+                                         f'contents (/chemical_system/contents) at index {i}, in the chemical system '
+                                         f'itself (/chemical_system). The chemical_system group in the HDF5 file '
+                                         f'contains only the following datasets: {h5_contents.keys()}.')
+            except IndexError:
+                raise CorruptedFileError(f'The chemical entity {entity_type}, listed in chemical system contents '
+                                         f'(/chemical_system/contents) at index {i}, could not be found in the '
+                                         f'{entity_type} dataset (/chemical_system/{entity_type}) because the '
+                                         f'index registered in contents, {entity_index}, is out of range of the dataset'
+                                         f', which contains only {len(h5_contents[entity_type])} elements.')
+            except (ValueError, SyntaxError, RuntimeError) as e:
+                raise CorruptedFileError(f'The data used for reconstructing the chemical system could not be parsed '
+                                         f'from the HDF5 file. The data located at /checmical_system/{entity_type}['
+                                         f'{entity_index}] is corrupted.\nThe provided data is: '
+                                         f'{h5_contents[entity_type][entity_index]}\nThe original error is: {e}')
+            finally:
+                h5_file.close()
+
+            h5_chemical_entity_instance = entity_class(h5_file, h5_contents, *arguments)
             ce = h5_chemical_entity_instance.build()
             self.add_chemical_entity(ce)
 
-        h5_file.close()
+        if close_file:
+            h5_file.close()
 
         self._h5_file = None
 

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -1,21 +1,24 @@
+from __future__ import annotations
+
 import abc
 from ast import literal_eval
 import collections
 import copy
-from typing import Union
+from typing import Union, TYPE_CHECKING
 
+import h5py
 import numpy as np
 from numpy.typing import NDArray
 
-import h5py
-
-from MDANSE.Chemistry import ATOMS_DATABASE, MOLECULES_DATABASE, NUCLEOTIDES_DATABASE, RESIDUES_DATABASE, \
-    MoleculesDatabase, NucleotidesDatabase, ResiduesDatabase
+from MDANSE.Chemistry import ATOMS_DATABASE, MOLECULES_DATABASE, NUCLEOTIDES_DATABASE, RESIDUES_DATABASE
 from MDANSE.Chemistry.Databases import ResiduesDatabaseError, NucleotidesDatabaseError
 from MDANSE.Mathematics.Geometry import superposition_fit
 from MDANSE.Mathematics.LinearAlgebra import delta, Quaternion, Tensor, Vector
 from MDANSE.Mathematics.Transformation import Rotation, RotationTranslation, Translation
-from MDANSE.MolecularDynamics.Configuration import _Configuration
+
+if TYPE_CHECKING:
+    from MDANSE.Chemistry.Databases import MoleculesDatabase, NucleotidesDatabase, ResiduesDatabase
+    from MDANSE.MolecularDynamics.Configuration import _Configuration
 
 
 class UnknownAtomError(Exception):

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -309,7 +309,8 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
 class Atom(_ChemicalEntity):
     """A representation of atom in a trajectory."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, symbol: str = 'H', name: str = None, bonds: list['Atom'] = None, groups: list[str] = None,
+                 ghost: bool = False, **kwargs):
         """
         :param kwargs: Keyword arguments used to instantiate the Atom class. Any key-value pair provided is saved as an
             attribute of the Atom instance, but the following are expected:
@@ -322,18 +323,18 @@ class Atom(_ChemicalEntity):
 
         super(Atom, self).__init__()
 
-        self._symbol = kwargs.get('symbol', 'H')
+        self._symbol = symbol
 
         if self._symbol not in ATOMS_DATABASE:
             raise UnknownAtomError('The atom {} is unknown'.format(self.symbol))
 
-        self._name = kwargs.pop('name', self.symbol)
+        self._name = name if name else symbol
 
-        self._bonds = kwargs.pop('bonds', [])
+        self._bonds = bonds if bonds else []
 
-        self._groups = kwargs.pop('groups', [])
+        self._groups = groups if groups else []
 
-        self._ghost = kwargs.pop('ghost', False)
+        self._ghost = ghost
 
         self._index = None
 

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -1,12 +1,14 @@
 import abc
 import collections
 import copy
+from typing import Union
 
 import numpy as np
 
 import h5py
 
-from MDANSE.Chemistry import ATOMS_DATABASE, MOLECULES_DATABASE, NUCLEOTIDES_DATABASE, RESIDUES_DATABASE
+from MDANSE.Chemistry import ATOMS_DATABASE, MOLECULES_DATABASE, NUCLEOTIDES_DATABASE, RESIDUES_DATABASE, \
+    MoleculesDatabase, NucleotidesDatabase, ResiduesDatabase
 from MDANSE.Chemistry.Databases import ResiduesDatabaseError, NucleotidesDatabaseError
 from MDANSE.Mathematics.Geometry import superposition_fit
 from MDANSE.Mathematics.LinearAlgebra import delta, Tensor, Vector
@@ -1602,7 +1604,25 @@ class Protein(_ChemicalEntity):
         return atoms
 
 
-def translate_atom_names(database, molname, atoms):
+def translate_atom_names(database: Union[MoleculesDatabase, ResiduesDatabase, NucleotidesDatabase],
+                         molname: str, atoms: list[str]) -> list[str]:
+    """
+    Changes the names of all atoms in a given compound to the default names used in MDANSE. The names provided to this
+    function must be registered in the database provided in the database parameter, either as the default name or in the
+    'alternatives'.
+
+    :param database: Database of compounds in which the compound and its constituent atoms are registered.
+    :type database: one of MOLECULES_DATABASE, RESIDUES_DATABASE, or NUCLEOTIDES_DATABASE
+
+    :param molname: The name of the chemical compound registered in the provided database whose atoms are to be renamed.
+    :type molname: str
+
+    :param atoms: A list of atom names to be renamed. All of them must be part of the molname chemical compound.
+    :type atoms: list
+
+    :return: The list of renamed atoms.
+    :rtype: list
+    """
     if not molname in database:
         raise UnknownMoleculeError('The molecule {} is unknown'.format(molname))
 

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -177,7 +177,7 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
         """
         coords = configuration['coordinates']
 
-        com = np.zeros((3,), dtype=np.float)
+        com = np.zeros((3,), dtype=np.float64)
         sum_masses = 0.0
         for at in self.atom_list:
             m = ATOMS_DATABASE[at.symbol]['atomic_weight']

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -524,12 +524,6 @@ class AtomGroup(_ChemicalEntity):
 
         self._chemical_system = list(s)[0]
 
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.__dict__ = state
-
     def __repr__(self):
         contents = ''
         for key, value in self.__dict__.items():
@@ -604,12 +598,6 @@ class AtomCluster(_ChemicalEntity):
             if not parentless:
                 at._parent = self
             self._atoms.append(at)
-
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.__dict__ = state
 
     def __getitem__(self, item: int) -> Atom:
         return self._atoms[item]
@@ -742,12 +730,6 @@ class Molecule(_ChemicalEntity):
 
     def __getitem__(self, item: str) -> Atom:
         return self._atoms[item]
-
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.__dict__ = state
 
     def __repr__(self):
         contents = ''
@@ -913,12 +895,6 @@ class Residue(_ChemicalEntity):
 
     def __getitem__(self, item: str) -> Atom:
         return self._atoms[item]
-
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.__dict__ = state
 
     def __repr__(self):
         contents = ''
@@ -1091,12 +1067,6 @@ class Nucleotide(_ChemicalEntity):
     def __getitem__(self, item: str) -> Atom:
         return self._atoms[item]
 
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.__dict__ = state
-
     def __repr__(self):
         contents = ''
         for key, value in self.__dict__.items():
@@ -1244,12 +1214,6 @@ class NucleotideChain(_ChemicalEntity):
 
     def __getitem__(self, item: int):
         return self._nucleotides[item]
-
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.__dict__ = state
 
     def __str__(self):
         return 'NucleotideChain of {} nucleotides'.format(len(self._nucleotides))
@@ -1547,12 +1511,6 @@ class PeptideChain(_ChemicalEntity):
     def __getitem__(self, item: int):
         return self._residues[item]
 
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.__dict__ = state
-
     def __str__(self):
         return 'PeptideChain of {} residues'.format(len(self._residues))
 
@@ -1704,12 +1662,6 @@ class Protein(_ChemicalEntity):
         self._name = name
 
         self._peptide_chains = []
-
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.__dict__ = state
 
     def __getitem__(self, item: int) -> PeptideChain:
         return self._peptide_chains[item]
@@ -1905,12 +1857,6 @@ class ChemicalSystem(_ChemicalEntity):
         self._name = name
 
         self._atoms = None
-
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.__dict__ = state
 
     def __repr__(self):
         contents = ', '.join([f'{key[1:] if key[0] == "_" else key}={repr(value)}'

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -310,6 +310,15 @@ class Atom(_ChemicalEntity):
     """A representation of atom in a trajectory."""
 
     def __init__(self, **kwargs):
+        """
+        :param kwargs: Keyword arguments used to instantiate the Atom class. Any key-value pair provided is saved as an
+            attribute of the Atom instance, but the following are expected:
+            symbol: (str) The chemical symbol of the Atom. It has to be registered in the ATOMS_DATABASE.
+            name: (str) The name of the Atom.
+            bonds: (list) List of Atom objects that this Atom is chemically bonded to.
+            groups: (list) List of groups that this Atom is a part of, e.g. sidechain.
+            ghost: (bool)
+        """
 
         super(Atom, self).__init__()
 
@@ -384,8 +393,7 @@ class Atom(_ChemicalEntity):
     def atom_list(self) -> list['Atom']:
         return [self] if not self.ghost else []
 
-    @staticmethod
-    def total_number_of_atoms() -> int:
+    def total_number_of_atoms(self) -> int:
         return 1
 
     def number_of_atoms(self) -> int:
@@ -413,7 +421,7 @@ class Atom(_ChemicalEntity):
 
     @property
     def groups(self) -> list[str]:
-        """A list of groups to which this atom belongs."""
+        """A list of groups to which this atom belongs, e.g. sidechain."""
         return self._groups
 
     @property
@@ -439,7 +447,7 @@ class Atom(_ChemicalEntity):
 
     @property
     def symbol(self) -> str:
-        """The chemical symbol of the atom. Must be in the atoms database."""
+        """The chemical symbol of the atom. The symbol must be registered in ATOMS_DATABASE."""
         return self._symbol
 
     @symbol.setter
@@ -545,7 +553,17 @@ class AtomCluster(_ChemicalEntity):
     """A cluster of atoms."""
 
     def __init__(self, name: str, atoms: list[Atom], parentless: bool = False):
+        """
+        :param name: The name of the AtomCluster.
+        :type name: str
 
+        :param atoms: List of atoms that this AtomCluster consists of.
+        :type atoms: list
+
+        :param parentless: Determines whether the AtomCluster is the parent of its constituent Atoms. It is if
+            parentless is False.
+        :type parentless: bool
+        """
         super(AtomCluster, self).__init__()
 
         self._name = name
@@ -584,11 +602,15 @@ class AtomCluster(_ChemicalEntity):
         return f'AtomCluster consisting of {self.total_number_of_atoms()} atoms'
 
     def atom_list(self) -> list[Atom]:
-        """A list of atoms in the cluster which are not ghosts."""
+        """A list of all non-ghost atoms in the AtomCluster."""
         return list([at for at in self._atoms if not at.ghost])
 
     def copy(self) -> 'AtomCluster':
-        """Copies the instance of AtomCluster into a new, identical instance."""
+        """
+        Copies the instance of AtomCluster into a new, identical instance.
+        :return: An identical copy of the AtomCluster instance.
+        :rtype: MDANSE.Chemistry.ChemicalEntity.AtomCluster
+        """
         atoms = [atom.copy() for atom in self._atoms]
 
         ac = AtomCluster(self._name, atoms, self._parentless)
@@ -608,7 +630,12 @@ class AtomCluster(_ChemicalEntity):
         return len(self._atoms)
 
     def reorder_atoms(self, atoms: list[str]) -> None:
+        """
+        Change the order in which the atoms in this cluster are stored.
 
+        :param atoms: A list of atoms. The atoms in the AtomCluster will be reordered to be in the same order as provided.
+        :type atoms: list of strings
+        """
         if set(atoms) != set([at.name for at in self._atoms]) or len(atoms) != len(self._atoms):
             raise InconsistentAtomNamesError('The set of atoms to reorder is inconsistent with molecular contents: '
                                              f'the provided atoms ({atoms}) are different from the atoms in the '

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -510,6 +510,9 @@ class AtomGroup(_ChemicalEntity):
 
         return f'MDANSE.MolecularDynamics.ChemicalEntity.AtomGroup({contents[:-2]})'
 
+    def __str__(self):
+        return f'AtomGroup consisting of {self.total_number_of_atoms()} atoms'
+
     def atom_list(self) -> list[Atom]:
         """The list of all non-ghost atoms in the AtomGroup."""
         return list([at for at in self._atoms if not at.ghost])
@@ -576,6 +579,9 @@ class AtomCluster(_ChemicalEntity):
             contents += ', '
 
         return f'MDANSE.MolecularDynamics.ChemicalEntity.AtomCluster({contents[:-2]})'
+
+    def __str__(self):
+        return f'AtomCluster consisting of {self.total_number_of_atoms()} atoms'
 
     def atom_list(self) -> list[Atom]:
         """A list of atoms in the cluster which are not ghosts."""
@@ -696,6 +702,9 @@ class Molecule(_ChemicalEntity):
             contents += ', '
 
         return f'MDANSE.MolecularDynamics.ChemicalEntity.Molecule({contents[:-2]})'
+
+    def __str__(self):
+        return f'Molecule of {self.name} (database code "{self.code}")'
 
     def _set_bonds(self) -> None:
 
@@ -861,6 +870,9 @@ class Residue(_ChemicalEntity):
             contents += ', '
 
         return f'MDANSE.MolecularDynamics.ChemicalEntity.Residue({contents[:-2]})'
+
+    def __str__(self):
+        return f'Amino acid Residue {self.name} (database code "{self.code}")'
 
     def set_atoms(self, atoms: list[str]) -> None:
         """
@@ -1032,6 +1044,9 @@ class Nucleotide(_ChemicalEntity):
             contents += ', '
 
         return f'MDANSE.MolecularDynamics.ChemicalEntity.Nucleotide({contents[:-2]})'
+
+    def __str__(self):
+        return f'Nucleotide {self.name} (database code "{self.code}")'
 
     def copy(self) -> 'Nucleotide':
         """Copies the instance of Nucleotide into a new, identical instance."""
@@ -1637,6 +1652,9 @@ class Protein(_ChemicalEntity):
 
         return f'MDANSE.MolecularDynamics.ChemicalEntity.Protein({contents[:-2]})'
 
+    def __str__(self):
+        return f'Protein {self.name} consisting of {len(self.peptide_chains)} peptide chains'
+
     def atom_list(self) -> list[Atom]:
         """List of all non-ghost atoms in the Protein."""
         atom_list = []
@@ -1820,6 +1838,9 @@ class ChemicalSystem(_ChemicalEntity):
                               for key, value in self.__dict__.items()])
 
         return f'MDANSE.MolecularDynamics.ChemicalEntity.ChemicalSystem({contents})'
+
+    def __str__(self):
+        return f'ChemicalSystem {self.name} consisting of {len(self._chemical_entities)} chemical entities'
 
     def add_chemical_entity(self, chemical_entity: _ChemicalEntity) -> None:
         """

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -450,7 +450,16 @@ class Atom(_ChemicalEntity):
         self._symbol = symbol
 
     def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+        """
+        Serializes the Atom object into a string in preparation of the object being stored on disk.
 
+        :param h5_contents: A dictionary that stores all serialized information for the whole ChemicalSystem.
+        :type h5_contents: dict
+
+        :return: A tuple containing the string 'atoms' and the index of the serialization data of this Atom in the
+            provided dictionary.
+        :rtype: tuple
+        """
         atom_str = 'H5Atom(self._h5_file,h5_contents,symbol="{}", name="{}", ghost={})'.format(self.symbol, self.name,
                                                                                                self.ghost)
 
@@ -557,7 +566,17 @@ class AtomCluster(_ChemicalEntity):
         self._atoms = reordered_atoms
 
     def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+        """
+        Serializes the AtomCluster object and its contents into strings in preparation of the object being stored on
+        disk.
 
+        :param h5_contents: A dictionary that stores all serialized information for the whole ChemicalSystem.
+        :type h5_contents: dict
+
+        :return: A tuple containing the string 'atom_clusters' and the index of the serialization data of this
+            AtomCluster in the provided dictionary.
+        :rtype: tuple
+        """
         if 'atoms' in h5_contents:
             at_indexes = list(range(len(h5_contents['atoms']), len(h5_contents['atoms']) + len(self._atoms)))
         else:
@@ -684,7 +703,17 @@ class Molecule(_ChemicalEntity):
         self._atoms = reordered_atoms
 
     def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+        """
+        Serializes the Molecule object and its contents into strings in preparation of the object being stored on
+        disk.
 
+        :param h5_contents: A dictionary that stores all serialized information for the whole ChemicalSystem.
+        :type h5_contents: dict
+
+        :return: A tuple containing the string 'molecules' and the index of the serialization data of this Molecule
+            in the provided dictionary.
+        :rtype: tuple
+        """
         if 'atoms' in h5_contents:
             at_indexes = list(range(len(h5_contents['atoms']), len(h5_contents['atoms']) + len(self._atoms)))
         else:
@@ -857,7 +886,17 @@ class Residue(_ChemicalEntity):
         return self._variant
 
     def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+        """
+        Serializes the Residue object and its contents into strings in preparation of the object being stored on
+        disk.
 
+        :param h5_contents: A dictionary that stores all serialized information for the whole ChemicalSystem.
+        :type h5_contents: dict
+
+        :return: A tuple containing the string 'residues' and the index of the serialization data of this Residue
+            in the provided dictionary.
+        :rtype: tuple
+        """
         if 'atoms' in h5_contents:
             at_indexes = list(range(len(h5_contents['atoms']), len(h5_contents['atoms']) + len(self._atoms)))
         else:
@@ -1021,7 +1060,17 @@ class Nucleotide(_ChemicalEntity):
         return self._variant
 
     def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+        """
+        Serializes the Nucleotide object and its contents into strings in preparation of the object being stored on
+        disk.
 
+        :param h5_contents: A dictionary that stores all serialized information for the whole ChemicalSystem.
+        :type h5_contents: dict
+
+        :return: A tuple containing the string 'nucleotides' and the index of the serialization data of this Nucleotide
+            in the provided dictionary.
+        :rtype: tuple
+        """
         if 'atoms' in h5_contents:
             at_indexes = list(range(len(h5_contents['atoms']), len(h5_contents['atoms']) + len(self._atoms)))
         else:
@@ -1209,7 +1258,17 @@ class NucleotideChain(_ChemicalEntity):
         return number_of_atoms
 
     def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+        """
+        Serializes the NucleotideChain object and its contents into strings in preparation of the object being stored on
+        disk.
 
+        :param h5_contents: A dictionary that stores all serialized information for the whole ChemicalSystem.
+        :type h5_contents: dict
+
+        :return: A tuple containing the string 'nucleotide_chains' and the index of the serialization data of this
+            NucleotideChain in the provided dictionary.
+        :rtype: tuple
+        """
         if 'nucleotides' in h5_contents:
             res_indexes = list(
                 range(len(h5_contents['nucleotides']), len(h5_contents['nucleotides']) + len(self._nucleotides)))
@@ -1435,7 +1494,17 @@ class PeptideChain(_ChemicalEntity):
         return self._residues
 
     def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+        """
+        Serializes the PeptideChain object and its contents into strings in preparation of the object being stored on
+        disk.
 
+        :param h5_contents: A dictionary that stores all serialized information for the whole ChemicalSystem.
+        :type h5_contents: dict
+
+        :return: A tuple containing the string 'peptide_chains' and the index of the serialization data of this
+            PeptideChain in the provided dictionary.
+        :rtype: tuple
+        """
         if 'residues' in h5_contents:
             res_indexes = list(range(len(h5_contents['residues']), len(h5_contents['residues']) + len(self._residues)))
         else:
@@ -1582,6 +1651,16 @@ class Protein(_ChemicalEntity):
         return residues
 
     def serialize(self, h5_contents: dict[str, list[str]]) -> tuple[str, int]:
+        """
+        Serializes the Protein object and its contents into strings in preparation of the object being stored on disk.
+
+        :param h5_contents: A dictionary that stores all serialized information for the whole ChemicalSystem.
+        :type h5_contents: dict
+
+        :return: A tuple containing the string 'proteins' and the index of the serialization data of this Protein in the
+            provided dictionary.
+        :rtype: tuple
+        """
         if 'peptide_chains' in h5_contents:
             pc_indexes = list(range(len(h5_contents['peptide_chains']),
                                     len(h5_contents['peptide_chains']) + len(self._peptide_chains)))

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -20,7 +20,6 @@ class UnknownAtomError(Exception):
 class InvalidMoleculeError(Exception):
 
     def __init__(self, code):
-
         self._message = 'The atom {} is unknown'.format(code)
 
     def __str__(self):
@@ -30,7 +29,6 @@ class InvalidMoleculeError(Exception):
 class UnknownMoleculeError(Exception):
 
     def __init__(self, code):
-
         self._message = 'The molecule {} is unknown'.format(code)
 
     def __str__(self):
@@ -48,7 +46,6 @@ class InvalidResidueError(Exception):
 class UnknownResidueError(Exception):
 
     def __init__(self, code):
-
         self._message = 'The residue {} is unknown'.format(code)
 
     def __str__(self):
@@ -60,6 +57,10 @@ class InvalidVariantError(Exception):
 
 
 class InvalidNucleotideChainError(Exception):
+    pass
+
+
+class InvalidPeptideChainError(Exception):
     pass
 
 
@@ -83,11 +84,11 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
         self._parent = None
 
         self._name = ''
-    
+
     def __getstate__(self):
         return self.__dict__
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
         self.__dict__ = state
 
     @abc.abstractmethod
@@ -103,9 +104,9 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
         full_name = self.name
         parent = self._parent
         while parent is not None:
-            full_name = '{}.{}'.format(parent.name,full_name)
+            full_name = '{}.{}'.format(parent.name, full_name)
             parent = parent.parent
-            
+
         return full_name
 
     @abc.abstractmethod
@@ -117,7 +118,7 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
         return self._parent
 
     @parent.setter
-    def parent(self,parent):
+    def parent(self, parent):
         self._parent = parent
 
     @property
@@ -125,7 +126,7 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
         return self._name
 
     @name.setter
-    def name(self,name):
+    def name(self, name):
         self._name = name
 
     @abc.abstractmethod
@@ -136,7 +137,7 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
 
         selected_atoms = []
         for at in self.atom_list():
-            if not hasattr(at,'groups'):
+            if not hasattr(at, 'groups'):
                 continue
 
             if name in at.groups:
@@ -148,11 +149,11 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
 
         coords = configuration['coordinates']
 
-        com = np.zeros((3,),dtype=np.float)
+        com = np.zeros((3,), dtype=np.float)
         sum_masses = 0.0
         for at in self.atom_list():
             m = ATOMS_DATABASE[at.symbol]['atomic_weight']
-            com += m*coords[at.index,:]
+            com += m * coords[at.index, :]
             sum_masses += m
 
         com /= sum_masses
@@ -177,7 +178,7 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
 
         return masses
 
-    def find_transformation_as_quaternion(self, conf1, conf2 = None):
+    def find_transformation_as_quaternion(self, conf1, conf2=None):
 
         chemical_system = self.root_chemical_system()
         if chemical_system.configuration.is_periodic:
@@ -198,10 +199,10 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
         return superposition_fit([
             (
                 weights[a.index],
-                Vector(*conf1['coordinates'][a.index,:]),
-                Vector(*conf2['coordinates'][a.index,:])) for a in self.atom_list()])
+                Vector(*conf1['coordinates'][a.index, :]),
+                Vector(*conf2['coordinates'][a.index, :])) for a in self.atom_list()])
 
-    def find_transformation(self, conf1, conf2 = None):
+    def find_transformation(self, conf1, conf2=None):
         """
         :param conf1: a configuration object
         :type conf1: :class:`~MDANSE.MolecularDynamics.Configuration.Configuration`
@@ -226,19 +227,19 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
         :returns: the center of mass and the moment of inertia tensor
                   in the given configuration
         """
-        
+
         m = 0.0
-        mr = Vector(0.0,0.0,0.0)
-        t = Tensor(3*[3*[0.0]])
+        mr = Vector(0.0, 0.0, 0.0)
+        t = Tensor(3 * [3 * [0.0]])
         for atom in self.atom_list():
             ma = ATOMS_DATABASE[atom.symbol]['atomic_weight']
-            r = Vector(configuration['coordinates'][atom.index,:])
+            r = Vector(configuration['coordinates'][atom.index, :])
             m += ma
-            mr += ma*r
-            t += ma*r.dyadic_product(r)
-        cm = mr/m
-        t -= m*cm.dyadic_product(cm)
-        t = t.trace()*delta - t
+            mr += ma * r
+            t += ma * r.dyadic_product(r)
+        cm = mr / m
+        t -= m * cm.dyadic_product(cm)
+        t = t.trace() * delta - t
         return cm, t
 
     def normalizing_transformation(self, configuration, repr=None):
@@ -277,18 +278,18 @@ class _ChemicalEntity(metaclass=abc.ABCMeta):
             elif repr == 'IIIl':
                 seq[0:2] = np.array([seq[1], seq[0]])
             diag = np.take(diag, seq)
-        return Rotation(diag)*Translation(-cm)
+        return Rotation(diag) * Translation(-cm)
 
     def root_chemical_system(self):
 
-        if isinstance(self,ChemicalSystem):
+        if isinstance(self, ChemicalSystem):
             return self
         else:
             return self._parent.root_chemical_system()
 
     def top_level_chemical_entity(self):
 
-        if isinstance(self._parent,ChemicalSystem):
+        if isinstance(self._parent, ChemicalSystem):
             return self
         else:
             return self._parent.top_level_chemical_entity()
@@ -299,7 +300,7 @@ class Atom(_ChemicalEntity):
 
     def __init__(self, **kwargs):
 
-        super(Atom,self).__init__()
+        super(Atom, self).__init__()
 
         self._symbol = kwargs.get('symbol', 'H')
 
@@ -318,8 +319,8 @@ class Atom(_ChemicalEntity):
 
         self._parent = None
 
-        for k,v in kwargs.items():
-            setattr(self,k,v)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
     def copy(self) -> 'Atom':
         """
@@ -345,12 +346,12 @@ class Atom(_ChemicalEntity):
     def __getstate__(self):
         return self.__dict__
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
 
         self.__dict__ = state
 
     def __str__(self):
-        
+
         return self.full_name()
 
     def __repr__(self):
@@ -442,17 +443,16 @@ class Atom(_ChemicalEntity):
         atom_str = 'H5Atom(self._h5_file,h5_contents,symbol="{}", name="{}", ghost={})'.format(self.symbol, self.name,
                                                                                                self.ghost)
 
-        h5_contents.setdefault('atoms',[]).append(atom_str)
+        h5_contents.setdefault('atoms', []).append(atom_str)
 
-        return 'atoms', len(h5_contents['atoms'])-1
+        return 'atoms', len(h5_contents['atoms']) - 1
 
 
 class AtomGroup(_ChemicalEntity):
     """A selection of atoms that belong to the same chemical system."""
 
     def __init__(self, atoms: list):
-
-        super(AtomGroup,self).__init__()
+        super(AtomGroup, self).__init__()
 
         s = set([at.root_chemical_system() for at in atoms])
         if len(s) != 1:
@@ -465,7 +465,7 @@ class AtomGroup(_ChemicalEntity):
     def __getstate__(self):
         return self.__dict__
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
         self.__dict = state
 
     def atom_list(self):
@@ -478,7 +478,6 @@ class AtomGroup(_ChemicalEntity):
         return len([at for at in self._atoms if not at.ghost])
 
     def root_chemical_system(self):
-
         return self._chemical_system
 
     def serialize(self, h5_file):
@@ -526,7 +525,7 @@ class AtomCluster(_ChemicalEntity):
         """Copies the instance of AtomCluster into a new, identical instance."""
         atoms = [atom.copy() for atom in self._atoms.values()]
 
-        ac = AtomCluster(self._name,atoms,self._parentless)
+        ac = AtomCluster(self._name, atoms, self._parentless)
 
         for at in ac._atoms:  # TODO: Are you actually sure that we want to ignore parentless here?
             at._parent = ac
@@ -549,29 +548,29 @@ class AtomCluster(_ChemicalEntity):
         reordered_atoms = collections.OrderedDict()
         for at in atoms:
             reordered_atoms[at] = self._atoms[at]
-        
+
         self._atoms = reordered_atoms
 
     def serialize(self, h5_contents: dict) -> tuple[str, int]:
 
         if 'atoms' in h5_contents:
-            at_indexes = list(range(len(h5_contents['atoms']),len(h5_contents['atoms'])+len(self._atoms)))
+            at_indexes = list(range(len(h5_contents['atoms']), len(h5_contents['atoms']) + len(self._atoms)))
         else:
             at_indexes = list(range(len(self._atoms)))
 
-        ac_str = 'H5AtomCluster(self._h5_file,h5_contents,{},name="{}")'.format(at_indexes,self._name)
+        ac_str = 'H5AtomCluster(self._h5_file,h5_contents,{},name="{}")'.format(at_indexes, self._name)
 
-        h5_contents.setdefault('atom_clusters',[]).append(ac_str)
-        
+        h5_contents.setdefault('atom_clusters', []).append(ac_str)
+
         for at in self._atoms:
             at.serialize(h5_contents)
 
-        return ('atom_clusters',len(h5_contents['atom_clusters'])-1)
+        return ('atom_clusters', len(h5_contents['atom_clusters']) - 1)
 
 
 class Molecule(_ChemicalEntity):
     """A group of atoms that form a molecule."""
-    
+
     def __init__(self, code: str, name: str):
 
         super(Molecule, self).__init__()
@@ -590,7 +589,7 @@ class Molecule(_ChemicalEntity):
             if code == molname or code in molinfo['alternatives']:
                 for at, atinfo in molinfo['atoms'].items():
                     info = copy.deepcopy(atinfo)
-                    atom = Atom(name=at,**info)
+                    atom = Atom(name=at, **info)
                     atom.parent = self
                     self._atoms[at] = atom
 
@@ -645,7 +644,7 @@ class Molecule(_ChemicalEntity):
         m = Molecule(self._code, self._name)
 
         atom_names = [at for at in self._atoms]
-        
+
         m.reorder_atoms(atom_names)
 
         for atname, at in m._atoms.items():
@@ -676,13 +675,13 @@ class Molecule(_ChemicalEntity):
         reordered_atoms = collections.OrderedDict()
         for at in atoms:
             reordered_atoms[at] = self._atoms[at]
-        
+
         self._atoms = reordered_atoms
 
     def serialize(self, h5_contents: dict) -> tuple[str, int]:
 
         if 'atoms' in h5_contents:
-            at_indexes = list(range(len(h5_contents['atoms']), len(h5_contents['atoms'])+len(self._atoms)))
+            at_indexes = list(range(len(h5_contents['atoms']), len(h5_contents['atoms']) + len(self._atoms)))
         else:
             at_indexes = list(range(len(self._atoms)))
 
@@ -690,11 +689,11 @@ class Molecule(_ChemicalEntity):
                                                                                         self._name)
 
         h5_contents.setdefault('molecules', []).append(mol_str)
-        
+
         for at in self._atoms.values():
             at.serialize(h5_contents)
 
-        return 'molecules', len(h5_contents['molecules'])-1
+        return 'molecules', len(h5_contents['molecules']) - 1
 
 
 def is_molecule(name: str) -> bool:
@@ -712,7 +711,7 @@ def is_molecule(name: str) -> bool:
 
 class Residue(_ChemicalEntity):
     """A group of atoms that make up an amino acid."""
-    
+
     def __init__(self, code: str, name: str, variant: str = None):
         """
 
@@ -796,7 +795,7 @@ class Residue(_ChemicalEntity):
         res_atoms.difference_update(replaced_atoms)
         if self._selected_variant is not None:
             res_atoms.update(self._selected_variant['atoms'])
-        
+
         if res_atoms != set(atoms):
             raise InconsistentAtomNamesError('The set of atoms to reorder is inconsistent with residue contents')
 
@@ -806,12 +805,12 @@ class Residue(_ChemicalEntity):
 
         self._atoms.clear()
         for at in atoms:
-            self._atoms[at] = Atom(name=at,**d[at])
+            self._atoms[at] = Atom(name=at, **d[at])
             self._atoms[at].parent = self
-        
+
         for at, atom in self._atoms.items():
 
-            for i in range(len(atom.bonds)-1,-1,-1):
+            for i in range(len(atom.bonds) - 1, -1, -1):
                 if atom.bonds[i] in replaced_atoms:
                     del atom.bonds[i]
 
@@ -838,7 +837,7 @@ class Residue(_ChemicalEntity):
 
     def copy(self) -> 'Residue':
         """Copies the instance of Residue into a new, identical instance."""
-        r  = Residue(self._code, self._name, self._variant)
+        r = Residue(self._code, self._name, self._variant)
         atoms = [at for at in self._atoms]
         r.set_atoms(atoms)
 
@@ -848,26 +847,33 @@ class Residue(_ChemicalEntity):
 
         return r
 
+    @property
+    def variant(self):
+        return self._variant
+
     def serialize(self, h5_contents: dict) -> tuple[str, int]:
 
         if 'atoms' in h5_contents:
-            at_indexes = list(range(len(h5_contents['atoms']), len(h5_contents['atoms'])+len(self._atoms)))
+            at_indexes = list(range(len(h5_contents['atoms']), len(h5_contents['atoms']) + len(self._atoms)))
         else:
             at_indexes = list(range(len(self._atoms)))
 
-        res_str = 'H5Residue(self._h5_file,h5_contents,{},code="{}",name="{}",variant={})'.format(at_indexes,self._code,self._name,repr(self._variant))
+        res_str = 'H5Residue(self._h5_file,h5_contents,{},code="{}",name="{}",variant={})'.format(at_indexes,
+                                                                                                  self._code,
+                                                                                                  self._name,
+                                                                                                  repr(self._variant))
 
-        h5_contents.setdefault('residues',[]).append(res_str)
-        
+        h5_contents.setdefault('residues', []).append(res_str)
+
         for at in self._atoms.values():
             at.serialize(h5_contents)
 
-        return 'residues', len(h5_contents['residues'])-1
+        return 'residues', len(h5_contents['residues']) - 1
 
 
 class Nucleotide(_ChemicalEntity):
     """A group of atoms that make up a nucleotide."""
-    
+
     def __init__(self, code: str, name: str, variant: str = None):
         """
         :param code: A code corresponding to a nucleotide in the nucleotide database.
@@ -932,7 +938,7 @@ class Nucleotide(_ChemicalEntity):
 
     def copy(self) -> 'Nucleotide':
         """Copies the instance of Nucleotide into a new, identical instance."""
-        n  = Nucleotide(self._code, self._name, self._variant)
+        n = Nucleotide(self._code, self._name, self._variant)
         atoms = [at for at in self._atoms]
         n.set_atoms(atoms)
 
@@ -974,12 +980,12 @@ class Nucleotide(_ChemicalEntity):
 
         self._atoms.clear()
         for at in atoms:
-            self._atoms[at] = Atom(name=at,**d[at])
+            self._atoms[at] = Atom(name=at, **d[at])
             self._atoms[at].parent = self
-        
+
         for at, atom in self._atoms.items():
 
-            for i in range(len(atom.bonds)-1, -1, -1):
+            for i in range(len(atom.bonds) - 1, -1, -1):
                 if atom.bonds[i] in replaced_atoms:
                     del atom.bonds[i]
                     continue
@@ -1012,21 +1018,22 @@ class Nucleotide(_ChemicalEntity):
     def serialize(self, h5_contents: dict) -> tuple[str, int]:
 
         if 'atoms' in h5_contents:
-            at_indexes = list(range(len(h5_contents['atoms']),len(h5_contents['atoms'])+len(self._atoms)))
+            at_indexes = list(range(len(h5_contents['atoms']), len(h5_contents['atoms']) + len(self._atoms)))
         else:
             at_indexes = list(range(len(self._atoms)))
 
         res_str = 'H5Nucleotide(self._h5_file,h5_contents,{},code="{}",name="{}",variant={})'.format(at_indexes,
                                                                                                      self._code,
                                                                                                      self._name,
-                                                                                                     repr(self._variant))
+                                                                                                     repr(
+                                                                                                         self._variant))
 
-        h5_contents.setdefault('nucleotides',[]).append(res_str)
-        
+        h5_contents.setdefault('nucleotides', []).append(res_str)
+
         for at in self._atoms.values():
             at.serialize(h5_contents)
 
-        return 'nucleotides', len(h5_contents['nucleotides'])-1
+        return 'nucleotides', len(h5_contents['nucleotides']) - 1
 
 
 class NucleotideChain(_ChemicalEntity):
@@ -1076,7 +1083,7 @@ class NucleotideChain(_ChemicalEntity):
                                    getattr(at, 'o5prime_connected', False)]
         if len(ratoms_in_first_residue) == 0:
             raise InvalidNucleotideChainError('The first nucleotide in the chain must contain an atom that is connected'
-                                              'to the 5\' terminal oxygen (O5\'). This is signified by an atom having'
+                                              ' to the 5\' terminal oxygen (O5\'). This is signified by an atom having'
                                               'the "o5prime_connected" property set to True, and happens automatically'
                                               'if the nucleotide was created with variant="5T1", and the set_atoms()'
                                               ' method was called with the correct atoms.\nThe provided first '
@@ -1099,7 +1106,7 @@ class NucleotideChain(_ChemicalEntity):
                                   getattr(at, 'o3prime_connected', False)]
         if len(ratoms_in_last_residue) == 0:
             raise InvalidNucleotideChainError('The last nucleotide in the chain must contain an atom that is connected'
-                                              'to the 3\' terminal oxygen (O3\'). This is signified by an atom having'
+                                              ' to the 3\' terminal oxygen (O3\'). This is signified by an atom having'
                                               'the "o3prime_connected" property set to True, and happens automatically'
                                               'if the nucleotide was created with variant="3T1", and the set_atoms()'
                                               ' method was called with the correct atoms.\nThe provided first '
@@ -1120,7 +1127,7 @@ class NucleotideChain(_ChemicalEntity):
         c_atom_in_last_residue.bonds.extend(ratoms_in_last_residue)
 
         for i, current_residue in enumerate(self._nucleotides[:-1]):
-            next_residue = self._nucleotides[i+1]
+            next_residue = self._nucleotides[i + 1]
 
             for atom in current_residue.atom_list():
                 if '+R' in atom.bonds:
@@ -1138,9 +1145,10 @@ class NucleotideChain(_ChemicalEntity):
                     next_atom = atom
                     break
             else:
-                raise InvalidResidueError(f'The provided nucleotide with index {i+1}, {next_residue.name}, is invalid '
-                                          f'because it does not contain an atom bonded to "R+", i.e. another nucleo'
-                                          f'tide.\nThe full info on this nucleotide is {repr(next_residue)}')
+                raise InvalidResidueError(
+                    f'The provided nucleotide with index {i + 1}, {next_residue.name}, is invalid '
+                    f'because it does not contain an atom bonded to "R+", i.e. another nucleo'
+                    f'tide.\nThe full info on this nucleotide is {repr(next_residue)}')
 
             current_atom.bonds[current_idx] = next_atom
             next_atom.bonds[next_idx] = current_atom
@@ -1196,20 +1204,21 @@ class NucleotideChain(_ChemicalEntity):
         return number_of_atoms
 
     def serialize(self, h5_contents: dict) -> tuple[str, int]:
-        
+
         if 'nucleotides' in h5_contents:
-            res_indexes = list(range(len(h5_contents['nucleotides']),len(h5_contents['nucleotides'])+len(self._nucleotides)))
+            res_indexes = list(
+                range(len(h5_contents['nucleotides']), len(h5_contents['nucleotides']) + len(self._nucleotides)))
         else:
             res_indexes = list(range(len(self._nucleotides)))
 
-        pc_str = 'H5NucleotideChain(self._h5_file,h5_contents,"{}",{})'.format(self._name,res_indexes)
-        
+        pc_str = 'H5NucleotideChain(self._h5_file,h5_contents,"{}",{})'.format(self._name, res_indexes)
+
         for nucl in self._nucleotides:
             nucl.serialize(h5_contents)
 
-        h5_contents.setdefault('nucleotide_chains',[]).append(pc_str)
+        h5_contents.setdefault('nucleotide_chains', []).append(pc_str)
 
-        return 'nucleotide_chains', len(h5_contents['nucleotide_chains'])-1
+        return 'nucleotide_chains', len(h5_contents['nucleotide_chains']) - 1
 
     def set_nucleotides(self, nucleotides: list[Nucleotide]) -> None:
         """
@@ -1240,43 +1249,99 @@ class NucleotideChain(_ChemicalEntity):
 
 
 class PeptideChain(_ChemicalEntity):
+    """A peptide chain composed of bonded amino acid residues."""
 
-    def __init__(self, name):
+    def __init__(self, name: str):
+        """
+        The PeptideChain is instantiated empty. To set its component Residues, the set_residues() method must be called.
 
-        super(PeptideChain,self).__init__()
+        :param name: The name of this PeptideChain
+        :type name: str
+        """
+
+        super(PeptideChain, self).__init__()
 
         self._name = name
 
         self._residues = []
 
-    def _connect_residues(self):
-                
-        ratoms_in_first_residue = [at for at in self._residues[0].atom_list() if getattr(at,'nter_connected',False)]
-        n_atom_in_first_residue = self._residues[0]['N']
+    def _connect_residues(self) -> None:
+        # Process the first atom
+        ratoms_in_first_residue = [at for at in self._residues[0].atom_list() if getattr(at, 'nter_connected', False)]
+        if not ratoms_in_first_residue:
+            raise InvalidPeptideChainError('The first residue in the chain must contain an atom that is connected to '
+                                           'the terminal nitrogen. This is signified by an atom having the '
+                                           '"nter_connected" property set to True, and happens automatically if the '
+                                           'residue was created with variant="NT1", and the set_atoms() method was '
+                                           'called with the correct atoms.\nThe provided first residue is '
+                                           f'{self._residues[0].name}, its variant is {self._residues[0].variant} and '
+                                           f'it contains the following atoms: '
+                                           f'{[at.name for at in self._residues[0].atom_list()]}. The full info on the '
+                                           f'first residue is {repr(self._residues[0])}.')
+        try:
+            n_atom_in_first_residue = self._residues[0]['N']
+        except KeyError:
+            raise InvalidPeptideChainError('The first residue in the chain must contain the terminal nitrogen atom. '
+                                           f'However, the first residue that was provided is {self._residues[0].name} '
+                                           f'and contains only the following atoms: '
+                                           f'{[at.name for at in self._residues[0].atom_list()]}.\nThe full info'
+                                           f' on the first nucleotide is {repr(self._residues[0])}.')
         idx = n_atom_in_first_residue.bonds.index('-R')
         del n_atom_in_first_residue.bonds[idx]
         n_atom_in_first_residue.bonds.extend(ratoms_in_first_residue)
 
-        ratoms_in_last_residue = [at for at in self._residues[-1].atom_list() if getattr(at,'cter_connected',False)]
-        c_atom_in_last_residue = self._residues[-1]['C']
+        # Process the last atom
+        ratoms_in_last_residue = [at for at in self._residues[-1].atom_list() if getattr(at, 'cter_connected', False)]
+        if not ratoms_in_last_residue:
+            raise InvalidPeptideChainError('The last residue in the chain must contain an atom that is connected to '
+                                           'the terminal carbon. This is signified by an atom having the '
+                                           '"cter_connected" property set to True, and happens automatically if the '
+                                           'residue was created with variant="CT1", and the set_atoms() method was '
+                                           'called with the correct atoms.\nThe provided last residue is '
+                                           f'{self._residues[-1].name}, its variant is {self._residues[-1].variant} and'
+                                           f' it contains the following atoms: '
+                                           f'{[at.name for at in self._residues[-1].atom_list()]}. The full info on the'
+                                           f' last residue is {repr(self._residues[-1])}.')
+        try:
+            c_atom_in_last_residue = self._residues[-1]['C']
+        except KeyError:
+            raise InvalidPeptideChainError('The last residue in the chain must contain the terminal carbon atom. '
+                                           f'However, the last residue that was provided is {self._residues[-1].name} '
+                                           f'and contains only the following atoms: '
+                                           f'{[at.name for at in self._residues[-1].atom_list()]}.\nThe full info'
+                                           f' on the last nucleotide is {repr(self._residues[-1])}.')
         idx = c_atom_in_last_residue.bonds.index('+R')
         del c_atom_in_last_residue.bonds[idx]
         c_atom_in_last_residue.bonds.extend(ratoms_in_last_residue)
 
-        for i in range(len(self._residues)-1):
-            current_residue = self._residues[i]
-            next_residue = self._residues[i+1]
+        # Create bonds
+        for i, current_residue in enumerate(self._residues[:-1]):
+            next_residue = self._residues[i + 1]
 
-            ratoms_in_current_residue = [at for at in current_residue.atom_list() if '+R' in at.bonds][0]
-            ratoms_in_next_residue = [at for at in next_residue.atom_list() if '-R' in at.bonds][0]
+            for atom in current_residue.atom_list():
+                if '+R' in atom.bonds:
+                    current_atom = atom
+                    current_index = atom.bonds.index('+R')
+                    break
+            else:
+                raise InvalidResidueError(f'The provided residue with index {i}, {current_residue.name}, is invalid '
+                                          f'because it does not contain an atom bonded to "R+", i.e. another residue.'
+                                          f'\nThe full info on this residue is {repr(current_residue)}')
 
-            idx = ratoms_in_current_residue.bonds.index('+R')
-            ratoms_in_current_residue.bonds[idx] = ratoms_in_next_residue
+            for atom in next_residue.atom_list():
+                if '-R' in atom.bonds:
+                    next_atom = atom
+                    next_index = atom.bonds.index('-R')
+                    break
+            else:
+                raise InvalidResidueError(f'The provided residue with index {i+1}, {next_residue.name}, is invalid '
+                                          f'because it does not contain an atom bonded to "R+", i.e. another residue.'
+                                          f'\nThe full info on this residue is {repr(next_residue)}')
 
-            idx = ratoms_in_next_residue.bonds.index('-R')
-            ratoms_in_next_residue.bonds[idx] = ratoms_in_current_residue
+            current_atom.bonds[current_index] = next_atom
+            next_atom.bonds[next_index] = current_atom
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: int):
         return self._residues[item]
 
     def __getstate__(self):
@@ -1288,23 +1353,36 @@ class PeptideChain(_ChemicalEntity):
     def __str__(self):
         return 'PeptideChain of {} residues'.format(len(self._residues))
 
-    def atom_list(self):
+    def __repr__(self):
+        contents = ''
+        for key, value in self.__dict__.items():
+            key = key[1:] if key[0] == "_" else key
+            if isinstance(value, _ChemicalEntity) and not isinstance(value, Residue):
+                class_name = str(type(value)).replace('<class \'', '').replace('\'>', '')
+                contents += f'{key}={class_name}(name={value.name})'
+            else:
+                contents += f'{key}={repr(value)}'
+            contents += ', '
 
+        return f'MDANSE.MolecularDynamics.ChemicalEntity.PeptideChain({contents[:-2]})'
+
+    def atom_list(self) -> list[Atom]:
+        """A list of all non-ghost atoms in the PeptideChain."""
         atoms = []
         for res in self._residues:
             atoms.extend(res.atom_list())
         return atoms
 
-    def backbone(self):
-
+    def backbone(self) -> list[Atom]:
+        """A list of all atoms in the PeptideChain that are a part of the backbone."""
         atoms = []
         for at in self.atom_list():
             if 'backbone' in at.groups:
                 atoms.append(at)
         return atoms
 
-    def copy(self):
-
+    def copy(self) -> 'PeptideChain':
+        """Copies the instance of NucleotideChain into a new, identical instance."""
         pc = PeptideChain(self._name)
 
         residues = [res.copy() for res in self._residues]
@@ -1318,26 +1396,28 @@ class PeptideChain(_ChemicalEntity):
 
         return pc
 
-    def number_of_atoms(self):
-
+    def number_of_atoms(self) -> int:
+        """The number of non-ghost in the PeptideChain."""
         number_of_atoms = 0
         for residue in self._residues:
             number_of_atoms += residue.number_of_atoms()
         return number_of_atoms
 
-    def total_number_of_atoms(self):
-
+    def total_number_of_atoms(self) -> int:
+        """The total number of atoms in the PeptideChain, including ghosts."""
         number_of_atoms = 0
         for residue in self._residues:
             number_of_atoms += residue.total_number_of_atoms()
         return number_of_atoms
 
     @property
-    def peptide_chains(self):
+    def peptide_chains(self) -> list['PeptideChain']:
+        """The list of PeptideChains in this PeptideChain"""
         return [self]
 
     @property
-    def peptides(self):
+    def peptides(self) -> list[Atom]:
+        """The list of atoms in the PeptideChain that are a part of a peptide."""
         atoms = []
         for at in self.atom_list():
             if 'peptide' in at.groups:
@@ -1345,28 +1425,36 @@ class PeptideChain(_ChemicalEntity):
         return atoms
 
     @property
-    def residues(self):
-
+    def residues(self) -> list[Residue]:
+        """The list of amino acid Residues that make up this PeptideChain."""
         return self._residues
 
-    def serialize(self,h5_file, h5_contents):
-        
+    def serialize(self, h5_contents: dict) -> tuple[str, int]:
+
         if 'residues' in h5_contents:
-            res_indexes = list(range(len(h5_contents['residues']),len(h5_contents['residues'])+len(self._residues)))
+            res_indexes = list(range(len(h5_contents['residues']), len(h5_contents['residues']) + len(self._residues)))
         else:
             res_indexes = list(range(len(self._residues)))
 
-        pc_str = 'H5PeptideChain(self._h5_file,h5_contents,"{}",{})'.format(self._name,res_indexes)
-        
+        pc_str = 'H5PeptideChain(self._h5_file,h5_contents,"{}",{})'.format(self._name, res_indexes)
+
         for res in self._residues:
-            res.serialize(h5_file,h5_contents)
+            res.serialize(h5_contents)
 
-        h5_contents.setdefault('peptide_chains',[]).append(pc_str)
+        h5_contents.setdefault('peptide_chains', []).append(pc_str)
 
-        return ('peptide_chains',len(h5_contents['peptide_chains'])-1)
+        return 'peptide_chains', len(h5_contents['peptide_chains']) - 1
 
-    def set_residues(self, residues):
+    def set_residues(self, residues: list[Residue]) -> None:
+        """
+        Populates the PeptideChain with amino acid Residues.
 
+        :param residues: List of residues that the PeptideChain consists of.
+        :type residues: list
+
+        :return: None
+        """
+        self._residues = []
         for residue in residues:
             residue.parent = self
             self._residues.append(residue)
@@ -1380,6 +1468,7 @@ class PeptideChain(_ChemicalEntity):
             if 'sidechain' in at.groups:
                 atoms.append(at)
         return atoms
+
 
 class Protein(_ChemicalEntity):
 
@@ -1465,20 +1554,21 @@ class Protein(_ChemicalEntity):
 
         return residues
 
-    def serialize(self,h5_file, h5_contents):
+    def serialize(self, h5_file, h5_contents):
         if 'peptide_chains' in h5_contents:
-            pc_indexes = list(range(len(h5_contents['pepide_chains']),len(h5_contents['pepide_chains'])+len(self._peptide_chains)))
+            pc_indexes = list(
+                range(len(h5_contents['pepide_chains']), len(h5_contents['pepide_chains']) + len(self._peptide_chains)))
         else:
             pc_indexes = list(range(len(self._peptide_chains)))
 
-        prot_str = 'H5Protein(self._h5_file,h5_contents,"{}",{})'.format(self._name,pc_indexes)
+        prot_str = 'H5Protein(self._h5_file,h5_contents,"{}",{})'.format(self._name, pc_indexes)
 
-        h5_contents.setdefault('proteins',[]).append(prot_str)
+        h5_contents.setdefault('proteins', []).append(prot_str)
 
         for pc in self._peptide_chains:
-            pc.serialize(h5_file,h5_contents)
+            pc.serialize(h5_file, h5_contents)
 
-        return ('proteins',len(h5_contents['proteins'])-1)
+        return ('proteins', len(h5_contents['proteins']) - 1)
 
     @property
     def sidechains(self):
@@ -1488,8 +1578,8 @@ class Protein(_ChemicalEntity):
                 atoms.append(at)
         return atoms
 
-def translate_atom_names(database, molname, atoms):
 
+def translate_atom_names(database, molname, atoms):
     if not molname in database:
         raise UnknownMoleculeError('The molecule {} is unknown'.format(molname))
 
@@ -1504,11 +1594,12 @@ def translate_atom_names(database, molname, atoms):
 
     return renamed_atoms
 
+
 class ChemicalSystem(_ChemicalEntity):
 
     def __init__(self, name=''):
 
-        super(ChemicalSystem,self).__init__()
+        super(ChemicalSystem, self).__init__()
 
         self._chemical_entities = []
 
@@ -1530,7 +1621,7 @@ class ChemicalSystem(_ChemicalEntity):
 
     def add_chemical_entity(self, chemical_entity):
 
-        if not isinstance(chemical_entity,_ChemicalEntity):
+        if not isinstance(chemical_entity, _ChemicalEntity):
             raise InvalidChemicalEntityError('Invalid type')
 
         for at in chemical_entity.atom_list():
@@ -1565,7 +1656,7 @@ class ChemicalSystem(_ChemicalEntity):
             self._atoms = sorted_atoms(self.atom_list())
 
         return self._atoms
-            
+
     @property
     def chemical_entities(self):
         return self._chemical_entities
@@ -1598,18 +1689,18 @@ class ChemicalSystem(_ChemicalEntity):
             ce._parent = cs
 
         if self._configuration is not None:
-            
             conf = self._configuration.clone(cs)
 
             cs._configuration = conf
 
         return cs
-        
+
     def load(self, h5_filename):
 
-        from MDANSE.Chemistry.H5ChemicalEntity import H5Atom, H5AtomCluster, H5Molecule, H5Nucleotide, H5NucleotideChain, H5Residue, H5PeptideChain, H5Protein
+        from MDANSE.Chemistry.H5ChemicalEntity import H5Atom, H5AtomCluster, H5Molecule, H5Nucleotide, \
+            H5NucleotideChain, H5Residue, H5PeptideChain, H5Protein
 
-        self._h5_file = h5py.File(h5_filename,'r',libver='latest')
+        self._h5_file = h5py.File(h5_filename, 'r', libver='latest')
         grp = self._h5_file['/chemical_system']
         self._chemical_entities = []
 
@@ -1619,7 +1710,7 @@ class ChemicalSystem(_ChemicalEntity):
 
         h5_contents = {}
         for k in grp.keys():
-            if k =='contents':
+            if k == 'contents':
                 continue
             h5_contents[k] = grp[k][:]
 
@@ -1628,7 +1719,7 @@ class ChemicalSystem(_ChemicalEntity):
             h5_chemical_entity_instance = eval(h5_contents[entity_type.decode('utf-8')][entity_index])
             ce = h5_chemical_entity_instance.build()
             self.add_chemical_entity(ce)
-        
+
         self._h5_file.close()
 
         self._h5_file = None
@@ -1654,9 +1745,8 @@ class ChemicalSystem(_ChemicalEntity):
         contents = []
         for ce in self._chemical_entities:
             entity_type, entity_index = ce.serialize(h5_file, h5_contents)
-            contents.append((entity_type,str(entity_index)))
+            contents.append((entity_type, str(entity_index)))
 
-        for k,v in h5_contents.items():
-            grp.create_dataset(k,data=v,dtype=string_dt)
+        for k, v in h5_contents.items():
+            grp.create_dataset(k, data=v, dtype=string_dt)
         grp.create_dataset('contents', data=contents, dtype=string_dt)
-

--- a/Src/Chemistry/ChemicalEntity.py
+++ b/Src/Chemistry/ChemicalEntity.py
@@ -352,14 +352,15 @@ class Atom(_ChemicalEntity):
     def __repr__(self):
         contents = ''
         for key, value in self.__dict__.items():
-            if key == "_bonds":
+            key = key[1:] if key[0] == "_" else key
+            if key == "bonds":
                 bonds = ', '.join([f'Atom({atom.name if hasattr(atom, "name") else atom})' for atom in self.bonds])
                 contents += f'bonds=[{bonds}]'
             elif isinstance(value, _ChemicalEntity):
                 class_name = str(type(value)).replace('<class \'', '').replace('\'>', '')
-                contents += f'{key.replace("_", "")}={class_name}({value.name})'
+                contents += f'{key}={class_name}({value.name})'
             else:
-                contents += f'{key.replace("_", "")}={repr(value)}'
+                contents += f'{key}={repr(value)}'
             contents += ', '
 
         return f'MDANSE.Chemistry.ChemicalEntity.Atom({contents[:-2]})'
@@ -601,11 +602,12 @@ class Molecule(_ChemicalEntity):
     def __repr__(self):
         contents = ''
         for key, value in self.__dict__.items():
+            key = key[1:] if key[0] == "_" else key
             if isinstance(value, _ChemicalEntity) and not isinstance(value, Atom):
                 class_name = str(type(value)).replace('<class \'', '').replace('\'>', '')
-                contents += f'{key.replace("_", "")}={class_name}({value.name})'
+                contents += f'{key}={class_name}({value.name})'
             else:
-                contents += f'{key.replace("_", "")}={repr(value)}'
+                contents += f'{key}={repr(value)}'
             contents += ', '
 
         return f'MDANSE.MolecularDynamics.ChemicalEntity.Molecule({contents[:-2]})'
@@ -752,6 +754,19 @@ class Residue(_ChemicalEntity):
     def __setstate__(self, state):
         self.__dict__ = state
 
+    def __repr__(self):
+        contents = ''
+        for key, value in self.__dict__.items():
+            key = key[1:] if key[0] == "_" else key
+            if isinstance(value, _ChemicalEntity) and not isinstance(value, Atom):
+                class_name = str(type(value)).replace('<class \'', '').replace('\'>', '')
+                contents += f'{key}={class_name}({value.name})'
+            else:
+                contents += f'{key}={repr(value)}'
+            contents += ', '
+
+        return f'MDANSE.MolecularDynamics.ChemicalEntity.Residue({contents[:-2]})'
+
     def set_atoms(self, atoms: list[str]) -> None:
         """
         Populates the Residue with the provided atoms using the data from RESIDUES_DATABASE. The input must correspond
@@ -896,11 +911,12 @@ class Nucleotide(_ChemicalEntity):
     def __repr__(self):
         contents = ''
         for key, value in self.__dict__.items():
+            key = key[1:] if key[0] == "_" else key
             if isinstance(value, _ChemicalEntity) and not isinstance(value, Atom):
                 class_name = str(type(value)).replace('<class \'', '').replace('\'>', '')
-                contents += f'{key.replace("_", "")}={class_name}(name={value.name})'
+                contents += f'{key}={class_name}(name={value.name})'
             else:
-                contents += f'{key.replace("_", "")}={repr(value)}'
+                contents += f'{key}={repr(value)}'
             contents += ', '
 
         return f'MDANSE.MolecularDynamics.ChemicalEntity.Nucleotide({contents[:-2]})'

--- a/Src/Chemistry/H5ChemicalEntity.py
+++ b/Src/Chemistry/H5ChemicalEntity.py
@@ -78,7 +78,7 @@ class H5Molecule(_H5ChemicalEntity):
         atom_names = [at.name for at in atoms]
         mol.reorder_atoms(atom_names)
 
-        for i, at in enumerate(mol.atom_list()):
+        for i, at in enumerate(mol.atom_list):
             at.ghost = atoms[i].ghost
 
         return mol

--- a/Src/Framework/Configurators/AtomSelectionConfigurator.py
+++ b/Src/Framework/Configurators/AtomSelectionConfigurator.py
@@ -87,7 +87,7 @@ class AtomSelectionConfigurator(IConfigurator):
 
         trajConfig = self._configurable[self._dependencies['trajectory']]
 
-        atoms = sorted(trajConfig['instance'].chemical_system.atom_list(), key = operator.attrgetter('index'))
+        atoms = sorted(trajConfig['instance'].chemical_system.atom_list, key = operator.attrgetter('index'))
         selectedAtoms = [atoms[idx] for idx in self["flatten_indexes"]]
 
         self["selection_length"] = len(self["flatten_indexes"])

--- a/Src/Framework/Selectors/All.py
+++ b/Src/Framework/Selectors/All.py
@@ -21,7 +21,7 @@ class All(ISelector):
     section = "miscellaneous"
                     
     def select(self, *args):
-        return set(self._chemicalSystem.atom_list())
+        return set(self._chemicalSystem.atom_list)
 
 REGISTRY["all"] = All
                     

--- a/Src/Framework/Selectors/Amine.py
+++ b/Src/Framework/Selectors/Amine.py
@@ -29,13 +29,13 @@ class Amine(ISelector):
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            nitrogens = [at for at in ce.atom_list() if at.element.strip().lower() == 'nitrogen']
+            nitrogens = [at for at in ce.atom_list if at.element.strip().lower() == 'nitrogen']
                     
             for nitro in nitrogens:
                 neighbours = nitro.bonds
-                hydrogens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
+                hydrogens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
                 if len(hydrogens) == 2:
-                    self._choices.extend([nitro.full_name().strip()] + sorted(hydrogens))
+                    self._choices.extend([nitro.full_name.strip()] + sorted(hydrogens))
 
 
     def select(self, names):
@@ -48,7 +48,7 @@ class Amine(ISelector):
             names = self._choices[1:]
 
         vals = set(names)
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
 
         return sel
 

--- a/Src/Framework/Selectors/Ammonium.py
+++ b/Src/Framework/Selectors/Ammonium.py
@@ -14,8 +14,10 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
-                    
+
+
 class Ammonium(ISelector):
     '''
     Returns the amine atoms.
@@ -23,19 +25,19 @@ class Ammonium(ISelector):
 
     section = "chemical groups"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
-        ISelector.__init__(self,chemicalSystem)
+        ISelector.__init__(self, chemicalSystem)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            nitrogens = [at for at in ce.atom_list() if at.element.strip().lower() == 'nitrogen']
+            nitrogens = [at for at in ce.atom_list if at.element.strip().lower() == 'nitrogen']
             
             for nitro in nitrogens:
                 neighbours = nitro.bonds
-                hydrogens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
+                hydrogens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
                 if len(hydrogens) >= 3:
-                    self._choices.extend([nitro.full_name().strip()] + sorted(hydrogens))
+                    self._choices.extend([nitro.full_name.strip()] + sorted(hydrogens))
 
 
     def select(self, names):
@@ -48,7 +50,7 @@ class Ammonium(ISelector):
             names = self._choices[1:]
 
         vals = set(names)
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
 
         return sel
 

--- a/Src/Framework/Selectors/AtomElement.py
+++ b/Src/Framework/Selectors/AtomElement.py
@@ -14,17 +14,18 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class AtomElement(ISelector):
 
     section = "atoms"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
                 
-        self._choices.extend(sorted(set([at.element.lower() for at in self._chemicalSystem.atom_list()])))
+        self._choices.extend(sorted(set([at.element.lower() for at in self._chemicalSystem.atom_list])))
 
     def select(self, elements):
         '''Returns the atoms that matches a given list of elements.
@@ -37,7 +38,7 @@ class AtomElement(ISelector):
                 
         if '*' in elements:
 
-            sel.update([at for at in self._chemicalSystem.atom_list()])
+            sel.update([at for at in self._chemicalSystem.atom_list])
         
         else:
             
@@ -51,7 +52,7 @@ class AtomElement(ISelector):
                 
             vals = set(vals)
             
-            sel.update([at for at in self._chemicalSystem.atom_list() if at.element.strip().lower() in vals])
+            sel.update([at for at in self._chemicalSystem.atom_list if at.element.strip().lower() in vals])
 
         return sel
 

--- a/Src/Framework/Selectors/AtomFullName.py
+++ b/Src/Framework/Selectors/AtomFullName.py
@@ -14,17 +14,18 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
                 
 class AtomFullName(ISelector):
 
     section = "atoms"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
                 
-        self._choices.extend(sorted(set([at.full_name().strip() for at in self._chemicalSystem.atom_list()])))
+        self._choices.extend(sorted(set([at.full_name.strip() for at in self._chemicalSystem.atom_list])))
 
     def select(self, names):
         '''Returns the atoms that matches a given list of atom names.
@@ -37,12 +38,12 @@ class AtomFullName(ISelector):
 
         if '*' in names:
 
-            sel.update([at for at in self._chemicalSystem.atom_list()])
+            sel.update([at for at in self._chemicalSystem.atom_list])
             
         else:
             
             vals = set([v for v in names])
-            sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+            sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
         
         return sel
 

--- a/Src/Framework/Selectors/AtomIndex.py
+++ b/Src/Framework/Selectors/AtomIndex.py
@@ -14,17 +14,18 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class AtomIndex(ISelector):
 
     section = "atoms"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
                 
-        self._choices.extend(sorted([at.index for at in self._chemicalSystem.atom_list()]))
+        self._choices.extend(sorted([at.index for at in self._chemicalSystem.atom_list]))
 
     def select(self, indexes):
         '''Returns the atoms that matches a given list of indexes.
@@ -37,11 +38,11 @@ class AtomIndex(ISelector):
         
         if '*' in indexes:
 
-            sel.update([at for at in self._chemicalSystem.atom_list()])
+            sel.update([at for at in self._chemicalSystem.atom_list])
         
         else:
             vals = set([int(v) for v in indexes])
-            sel.update([at for at in self._chemicalSystem.atom_list() if at.index in vals])
+            sel.update([at for at in self._chemicalSystem.atom_list if at.index in vals])
             
         return sel        
 

--- a/Src/Framework/Selectors/AtomName.py
+++ b/Src/Framework/Selectors/AtomName.py
@@ -14,17 +14,18 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class AtomName(ISelector):
 
     section = "atoms"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
                 
-        self._choices.extend(sorted(set([at.name.strip() for at in self._chemicalSystem.atom_list()])))
+        self._choices.extend(sorted(set([at.name.strip() for at in self._chemicalSystem.atom_list])))
 
 
     def select(self, names):
@@ -38,12 +39,12 @@ class AtomName(ISelector):
 
         if '*' in names:
 
-            sel.update([at for at in self._chemicalSystem.atom_list()])
+            sel.update([at for at in self._chemicalSystem.atom_list])
 
         else:
 
             vals = set([v for v in names])
-            sel.update([at for at in self._chemicalSystem.atom_list() if at.name.strip() in vals])
+            sel.update([at for at in self._chemicalSystem.atom_list if at.name.strip() in vals])
         
         return sel
 

--- a/Src/Framework/Selectors/AtomSymbol.py
+++ b/Src/Framework/Selectors/AtomSymbol.py
@@ -14,17 +14,18 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class AtomSymbol(ISelector):
 
     section = "atoms"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
                 
-        self._choices.extend(sorted(set([at.symbol.strip() for at in self._chemicalSystem.atom_list()])))
+        self._choices.extend(sorted(set([at.symbol.strip() for at in self._chemicalSystem.atom_list])))
 
     def select(self, symbols):
         '''Returns the atoms that matches a given list of atom types.
@@ -37,12 +38,12 @@ class AtomSymbol(ISelector):
 
         if '*' in symbols:
 
-            sel.update([at for at in self._chemicalSystem.atom_list()])
+            sel.update([at for at in self._chemicalSystem.atom_list])
 
         else:
 
             vals = set([v for v in symbols])
-            sel.update([at for at in self._chemicalSystem.atom_list() if at.symbol.strip() in vals])
+            sel.update([at for at in self._chemicalSystem.atom_list if at.symbol.strip() in vals])
         
         return sel
 

--- a/Src/Framework/Selectors/Backbone.py
+++ b/Src/Framework/Selectors/Backbone.py
@@ -14,14 +14,14 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein
+from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class Backbone(ISelector):
 
     section = "proteins"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
                 
@@ -40,12 +40,12 @@ class Backbone(ISelector):
         if '*' in names:
             for ce in self._chemicalSystem.chemical_entities:
                 if isinstance(ce, (PeptideChain, Protein)):
-                    sel.update([at for at in ce.backbone()])
+                    sel.update([at for at in ce.backbone])
         else:            
             vals = set(names)
             for ce in self._chemicalSystem.chemical_entities:
                 if isinstance(ce, (PeptideChain, Protein)) and ce.name in vals:
-                    sel.update([at for at in ce.backbone()])
+                    sel.update([at for at in ce.backbone])
             
         return sel
 

--- a/Src/Framework/Selectors/CarboHydrogen.py
+++ b/Src/Framework/Selectors/CarboHydrogen.py
@@ -14,25 +14,25 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
     
 class CarboHydrogen(ISelector):
         
     section = "hydrogens"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            carbons = [at for at in ce.atom_list() if at.element.strip().lower() == 'carbon']
+            carbons = [at for at in ce.atom_list if at.element.strip().lower() == 'carbon']
 
             for car in carbons:
                 neighbours = car.bonds
-                hydrogens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
+                hydrogens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
                 self._choices.extend(sorted(hydrogens))
-
 
     def select(self, names):
     
@@ -44,7 +44,7 @@ class CarboHydrogen(ISelector):
             names = self._choices[1:]
             
         vals = set([v for v in names])
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
         
         return sel
     

--- a/Src/Framework/Selectors/CarbonAlpha.py
+++ b/Src/Framework/Selectors/CarbonAlpha.py
@@ -30,7 +30,7 @@ class CarbonAlpha(ISelector):
         
         for ce in self._chemicalSystem.chemical_entities:            
             try:            
-                sel.update([at for at in ce.atom_list() if at.name.strip() == 'CA'])
+                sel.update([at for at in ce.atom_list if at.name.strip() == 'CA'])
             except AttributeError:
                 pass
 

--- a/Src/Framework/Selectors/ChainName.py
+++ b/Src/Framework/Selectors/ChainName.py
@@ -14,14 +14,14 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein
+from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class ChainName(ISelector):
 
     section = "proteins"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
                 
@@ -43,7 +43,7 @@ class ChainName(ISelector):
             for ce in self._chemicalSystem.chemical_entities:
                 try:
                     for pc in ce.peptide_chains:
-                        sel.update([at for at in pc.atom_list()])
+                        sel.update([at for at in pc.atom_list])
                 except AttributeError:
                     pass
         
@@ -56,7 +56,7 @@ class ChainName(ISelector):
                     for chain in ce.peptide_chains:
                         chainName = chain.name.strip()
                         if chainName in vals:
-                            sel.update([at for at in chain.atom_list()])
+                            sel.update([at for at in chain.atom_list])
                 except (AttributeError,TypeError):
                     continue
                 

--- a/Src/Framework/Selectors/HeteroHydrogen.py
+++ b/Src/Framework/Selectors/HeteroHydrogen.py
@@ -14,23 +14,24 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class HeteroHydrogen(ISelector):
         
     section = "hydrogens"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            heteroatoms = [at for at in ce.atom_list() if at.element.strip().lower() not in ['carbon','hydrogen']]
+            heteroatoms = [at for at in ce.atom_list if at.element.strip().lower() not in ['carbon','hydrogen']]
             
             for het in heteroatoms:
                 neighbours = het.bonds
-                hydrogens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
+                hydrogens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
                 self._choices.extend(sorted(hydrogens))
 
 
@@ -44,7 +45,7 @@ class HeteroHydrogen(ISelector):
             names = self._choices[1:]
             
         vals = set([v for v in names])
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
         
         return sel
     

--- a/Src/Framework/Selectors/Hydroxyl.py
+++ b/Src/Framework/Selectors/Hydroxyl.py
@@ -14,25 +14,26 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
        
 class Hydroxyl(ISelector):
 
     section = "chemical groups"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            oxygens = [at for at in ce.atom_list() if at.element.strip().lower() == 'oxygen']
+            oxygens = [at for at in ce.atom_list if at.element.strip().lower() == 'oxygen']
             
             for oxy in oxygens:
                 neighbours = oxy.bonds
-                hydrogens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
+                hydrogens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
                 if len(hydrogens) >= 1:
-                    self._choices.extend([oxy.full_name().strip()] + sorted(hydrogens))
+                    self._choices.extend([oxy.full_name.strip()] + sorted(hydrogens))
 
 
     def select(self, names):
@@ -47,7 +48,7 @@ class Hydroxyl(ISelector):
             names = self._choices[1:]
             
         vals = set(names)
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
   
         return sel
     

--- a/Src/Framework/Selectors/ISelector.py
+++ b/Src/Framework/Selectors/ISelector.py
@@ -16,6 +16,7 @@
 import abc
 
 from MDANSE.Core.Error import Error
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 
 class SelectorError(Error):
     pass
@@ -24,7 +25,7 @@ class ISelector(object):
     
     _registry = "selector"
         
-    def __init__(self,chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         self._chemicalSystem = chemicalSystem
                 

--- a/Src/Framework/Selectors/Macromolecule.py
+++ b/Src/Framework/Selectors/Macromolecule.py
@@ -14,7 +14,7 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import NucleotideChain, PeptideChain, Protein
+from MDANSE.Chemistry.ChemicalEntity import NucleotideChain, PeptideChain, Protein, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class Macromolecule(ISelector):
@@ -23,7 +23,7 @@ class Macromolecule(ISelector):
     
     lookup = {NucleotideChain:"nucleotide_chain",PeptideChain:"peptide_chain",Protein:"protein"}
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
                 
@@ -41,7 +41,7 @@ class Macromolecule(ISelector):
         if '*' in macromolecules:
             for ce in self._chemicalSystem.chemical_entities:
                 if isinstance(ce, (NucleotideChain,PeptideChain,Protein)):
-                    sel.update([at for at in ce.atom_list()])
+                    sel.update([at for at in ce.atom_list])
         
         else:
             for ce in self._chemicalSystem.chemical_entities:

--- a/Src/Framework/Selectors/Methyl.py
+++ b/Src/Framework/Selectors/Methyl.py
@@ -14,23 +14,24 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class Methyl(ISelector):
 
     section = "chemical groups"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            carbons = [at for at in ce.atom_list() if at.element.strip().lower() == 'carbon']
+            carbons = [at for at in ce.atom_list if at.element.strip().lower() == 'carbon']
             
             for car in carbons:
                 neighbours = car.bonds
-                hydrogens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
+                hydrogens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
                 if len(hydrogens) >= 3:
                     self._choices.extend([car] + sorted(hydrogens))
 
@@ -47,7 +48,7 @@ class Methyl(ISelector):
             names = self._choices[1:]
 
         vals = set([v for v in names])
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
 
         return sel
 

--- a/Src/Framework/Selectors/MoleculeIndex.py
+++ b/Src/Framework/Selectors/MoleculeIndex.py
@@ -14,13 +14,14 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class MoleculeIndex(ISelector):
 
     section = "molecules"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
                 
@@ -37,7 +38,7 @@ class MoleculeIndex(ISelector):
 
         if '*' in values:
 
-            sel.update([at for at in self._chemicalSystem.atom_list()])
+            sel.update([at for at in self._chemicalSystem.atom_list])
 
         else:
 
@@ -45,7 +46,7 @@ class MoleculeIndex(ISelector):
 
             ceList = self._chemicalSystem.chemical_entities
         
-            sel.update([at for v in vals for at in ceList[v].atom_list()])
+            sel.update([at for v in vals for at in ceList[v].atom_list])
         
         return sel
 

--- a/Src/Framework/Selectors/MoleculeName.py
+++ b/Src/Framework/Selectors/MoleculeName.py
@@ -14,13 +14,14 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class MoleculeName(ISelector):
 
     section = "molecules"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
         
@@ -36,13 +37,13 @@ class MoleculeName(ISelector):
         sel = set()
         
         if '*' in names:
-            sel.update([at for at in self._chemicalSystem.atom_list()])
+            sel.update([at for at in self._chemicalSystem.atom_list])
 
         else:
             vals = set(names)
             for ce in self._chemicalSystem.chemical_entities:
                 if ce.name.strip() in vals:
-                    sel.update([at for at in ce.atom_list()])
+                    sel.update([at for at in ce.atom_list])
                 
         return sel
     

--- a/Src/Framework/Selectors/NitroHydrogen.py
+++ b/Src/Framework/Selectors/NitroHydrogen.py
@@ -14,23 +14,24 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class NitroHydrogen(ISelector):
         
     section = "hydrogens"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            nitrogens = [at for at in ce.atom_list() if at.element.strip().lower() == 'nitrogen']
+            nitrogens = [at for at in ce.atom_list if at.element.strip().lower() == 'nitrogen']
             
             for nitro in nitrogens:
                 neighbours = nitro.bonds
-                hydrogens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
+                hydrogens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
                 self._choices.extend(sorted(hydrogens))
                 
     def select(self, names):
@@ -43,7 +44,7 @@ class NitroHydrogen(ISelector):
             names = self._choices[1:]
             
         vals = set([v for v in names])
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
         
         return sel
     

--- a/Src/Framework/Selectors/NucleotideBase.py
+++ b/Src/Framework/Selectors/NucleotideBase.py
@@ -14,14 +14,14 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import NucleotideChain
+from MDANSE.Chemistry.ChemicalEntity import NucleotideChain, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class NucleotideBase(ISelector):
 
     section = "nucleic acids"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
 

--- a/Src/Framework/Selectors/NucleotideName.py
+++ b/Src/Framework/Selectors/NucleotideName.py
@@ -14,14 +14,14 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import NucleotideChain
+from MDANSE.Chemistry.ChemicalEntity import NucleotideChain, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
     
 class NucleotideName(ISelector):
 
     section = "nucleic acids"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
 
@@ -42,7 +42,7 @@ class NucleotideName(ISelector):
         if '*' in names:
             for ce in self._chemicalSystem.chemical_entities:
                 if isinstance(ce, NucleotideChain):
-                    sel.update([at for at in ce.atom_list()])
+                    sel.update([at for at in ce.atom_list])
         
         else:
             vals = set([v for v in names])
@@ -51,7 +51,7 @@ class NucleotideName(ISelector):
                 try:
                     for nucl in ce.nucleotides:
                         if nucl.name in vals:
-                            sel.update([at for at in nucl.atom_list()])
+                            sel.update([at for at in nucl.atom_list])
                 except AttributeError:
                     pass
                        

--- a/Src/Framework/Selectors/NucleotideSugar.py
+++ b/Src/Framework/Selectors/NucleotideSugar.py
@@ -14,14 +14,14 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import NucleotideChain
+from MDANSE.Chemistry.ChemicalEntity import NucleotideChain, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class NucleotideSugar(ISelector):
 
     section = "nucleic acids"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
 

--- a/Src/Framework/Selectors/NucleotideType.py
+++ b/Src/Framework/Selectors/NucleotideType.py
@@ -14,14 +14,14 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import NucleotideChain
+from MDANSE.Chemistry.ChemicalEntity import NucleotideChain, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
                                          
 class NucleotideType(ISelector):
 
     section = "nucleic acids"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
 
@@ -44,7 +44,7 @@ class NucleotideType(ISelector):
         if '*' in types:
             for ce in self._chemicalSystem.chemical_entities:
                 if isinstance(ce, NucleotideChain):
-                    sel.update([at for at in ce.atom_list()])
+                    sel.update([at for at in ce.atom_list])
         
         else:
             vals = set([v for v in types])
@@ -54,7 +54,7 @@ class NucleotideType(ISelector):
                     for nucl in ce.nucleotides:
                         nuclType = nucl.code.strip()
                         if nuclType in vals:
-                            sel.update([at for at in nucl.atom_list()])
+                            sel.update([at for at in nucl.atom_list])
                 
         return sel
 

--- a/Src/Framework/Selectors/OxyHydrogen.py
+++ b/Src/Framework/Selectors/OxyHydrogen.py
@@ -14,23 +14,24 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class OxyHydrogen(ISelector):
         
     section = "hydrogens"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            oxygens = [at for at in ce.atom_list() if at.element.strip().lower() == 'oxygen']
+            oxygens = [at for at in ce.atom_list if at.element.strip().lower() == 'oxygen']
             
             for oxy in oxygens:
                 neighbours = oxy.bonds
-                hydrogens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
+                hydrogens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
                 self._choices.extend(sorted(hydrogens))
                 
     def select(self, names):
@@ -41,7 +42,7 @@ class OxyHydrogen(ISelector):
             names = self._choices[1:]
             
         vals = set(names)
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
         
         return sel
     

--- a/Src/Framework/Selectors/Peptide.py
+++ b/Src/Framework/Selectors/Peptide.py
@@ -14,14 +14,14 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein
+from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class Peptide(ISelector):
 
     section = "proteins"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
 

--- a/Src/Framework/Selectors/Phosphate.py
+++ b/Src/Framework/Selectors/Phosphate.py
@@ -14,23 +14,24 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
                                     
 class Phosphate(ISelector):
 
     section = "chemical groups"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            phosphorus = [at for at in ce.atom_list() if at.element.strip().lower() == 'phosphorus']
+            phosphorus = [at for at in ce.atom_list if at.element.strip().lower() == 'phosphorus']
             
             for phos in phosphorus:
                 neighbours = phos.bonds
-                oxygens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'oxygen']
+                oxygens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'oxygen']
                 if len(oxygens) == 4:
                     self._choices.extend([phos] + sorted(oxygens))
 
@@ -46,7 +47,7 @@ class Phosphate(ISelector):
             names = self._choices[1:]
 
         vals = set([v for v in names])
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
 
         return sel
     

--- a/Src/Framework/Selectors/PythonScript.py
+++ b/Src/Framework/Selectors/PythonScript.py
@@ -25,7 +25,7 @@ class PythonScript(ISelector):
         sel = set()
 
         if '*' in scripts:
-            sel.update([at for at in self._chemicalSystem.atom_list()])
+            sel.update([at for at in self._chemicalSystem.atom_list])
                                 
         for s in scripts:
             namespace = {"chemicalSystem" : self._chemicalSystem}

--- a/Src/Framework/Selectors/ResidueClass.py
+++ b/Src/Framework/Selectors/ResidueClass.py
@@ -14,7 +14,7 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein
+from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 # Dictionnary associating tuples of residue names (values) to their corresponding chemical family (key). 
@@ -31,7 +31,7 @@ class ResidueClass(ISelector):
 
     section = "proteins"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
                         
@@ -49,7 +49,7 @@ class ResidueClass(ISelector):
         if '*' in classes:
             for ce in self._chemicalSystem.chemical_entities:
                 if isinstance(ce, (PeptideChain,Protein)):
-                    sel.update([at for at in ce.atom_list()])
+                    sel.update([at for at in ce.atom_list])
         
         else:        
             vals = set(classes)
@@ -65,7 +65,7 @@ class ResidueClass(ISelector):
                     for r in res:
                         resName = r.code.strip()
                         if resName in selRes:
-                            sel.update([at for at in r.atom_list()])
+                            sel.update([at for at in r.atom_list])
                                                    
         return sel
     

--- a/Src/Framework/Selectors/ResidueName.py
+++ b/Src/Framework/Selectors/ResidueName.py
@@ -15,20 +15,20 @@
 
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein
+from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class ResidueName(ISelector):
 
     section = "proteins"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem:ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
                 
         for ce in self._chemicalSystem.chemical_entities:
             if isinstance(ce, (PeptideChain, Protein)):
-                self._choices.extend([r.full_name() for r in ce.residues])
+                self._choices.extend([r.full_name for r in ce.residues])
                         
     def select(self, names):
         '''Returns the atoms that matches a given list of peptide names.
@@ -42,7 +42,7 @@ class ResidueName(ISelector):
         if '*' in names:
             for ce in self._chemicalSystem.chemical_entities:
                 if isinstance(ce, (PeptideChain,Protein)):
-                    sel.update([at for at in ce.atom_list()])
+                    sel.update([at for at in ce.atom_list])
         
         else:            
             vals = set([v.strip() for v in names])
@@ -50,9 +50,9 @@ class ResidueName(ISelector):
             for ce in self._chemicalSystem.chemical_entities:
                 if isinstance(ce,(PeptideChain,Protein)):
                     for r in ce.residues:
-                        resName = r.full_name().strip()
+                        resName = r.full_name.strip()
                         if resName in vals: 
-                            sel.update([at for at in r.atom_list()])
+                            sel.update([at for at in r.atom_list])
                 
         return sel
     

--- a/Src/Framework/Selectors/ResidueType.py
+++ b/Src/Framework/Selectors/ResidueType.py
@@ -14,14 +14,14 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
-from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein
+from MDANSE.Chemistry.ChemicalEntity import PeptideChain, Protein, ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
         
 class ResidueType(ISelector):
 
     section = "proteins"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
 
         ISelector.__init__(self,chemicalSystem)
                                 
@@ -42,7 +42,7 @@ class ResidueType(ISelector):
         if '*' in types:
             for ce in self._chemicalSystem.chemical_entities:
                 if isinstance(ce, (PeptideChain,Protein)):
-                    sel.update([at for at in ce.atom_list()])
+                    sel.update([at for at in ce.atom_list])
         
         else:                
             vals = set([v.strip() for v in types])
@@ -52,7 +52,7 @@ class ResidueType(ISelector):
                     for r in ce.residues:
                         resType = r.code.strip()
                         if resType in vals:
-                            sel.update([at for at in r.atom_list()])
+                            sel.update([at for at in r.atom_list])
                 
         return sel
     

--- a/Src/Framework/Selectors/Sulphate.py
+++ b/Src/Framework/Selectors/Sulphate.py
@@ -14,23 +14,24 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
         
 class Sulphate(ISelector):
 
     section = "chemical groups"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            sulfur = [at for at in ce.atom_list() if at.element.strip().lower() in ['sulphur', 'sulfur']]
+            sulfur = [at for at in ce.atom_list if at.element.strip().lower() in ['sulphur', 'sulfur']]
             
             for sulf in sulfur:
                 neighbours = sulf.bonds
-                oxygens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'oxygen']
+                oxygens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'oxygen']
                 if len(oxygens) == 4:
                     self._choices.extend([sulf] + sorted(oxygens))
 
@@ -46,7 +47,7 @@ class Sulphate(ISelector):
             names = self._choices[1:]
         
         vals = set([v for v in names])
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
                 
         return sel
     

--- a/Src/Framework/Selectors/SulphurHydrogen.py
+++ b/Src/Framework/Selectors/SulphurHydrogen.py
@@ -14,23 +14,24 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
 
 class SulphurHydrogen(ISelector):
         
     section = "hydrogens"
 
-    def __init__(self, trajectory):
+    def __init__(self, chemical_system: ChemicalSystem):
         
-        ISelector.__init__(self,trajectory)
+        ISelector.__init__(self, chemical_system)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            sulphurs = [at for at in ce.atom_list() if at.element.strip().lower() in ['sulphur', 'sulfur']]
+            sulphurs = [at for at in ce.atom_list if at.element.strip().lower() in ['sulphur', 'sulfur']]
             
             for sul in sulphurs:
                 neighbours = sul.bonds
-                hydrogens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
+                hydrogens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
                 self._choices.extend(sorted(hydrogens))
                 
     def select(self, names):
@@ -43,7 +44,7 @@ class SulphurHydrogen(ISelector):
             names = self._choices[1:]
             
         vals = set([v.lower() for v in names])
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
         
         return sel
     

--- a/Src/Framework/Selectors/Thiol.py
+++ b/Src/Framework/Selectors/Thiol.py
@@ -14,23 +14,24 @@
 # **************************************************************************
 
 from MDANSE import REGISTRY
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 from MDANSE.Framework.Selectors.ISelector import ISelector
     
 class Thiol(ISelector):
 
     section = "chemical groups"
 
-    def __init__(self, chemicalSystem):
+    def __init__(self, chemicalSystem: ChemicalSystem):
         
         ISelector.__init__(self,chemicalSystem)
 
         for ce in self._chemicalSystem.chemical_entities:
                                         
-            sulfur = [at for at in ce.atom_list() if at.element.strip().lower() in ['sulphur', 'sulfur']]
+            sulfur = [at for at in ce.atom_list if at.element.strip().lower() in ['sulphur', 'sulfur']]
             
             for sulf in sulfur:
                 neighbours = sulf.bonds
-                hydrogens = [neigh.full_name().strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
+                hydrogens = [neigh.full_name.strip() for neigh in neighbours if neigh.element.strip().lower() == 'hydrogen']
                 if len(hydrogens) >= 1:
                     self._choices.extend([sulf] + sorted(hydrogens))
 
@@ -46,7 +47,7 @@ class Thiol(ISelector):
             names = self._choices[1:]
         
         vals = set([v for v in names])
-        sel.update([at for at in self._chemicalSystem.atom_list() if at.full_name().strip() in vals])
+        sel.update([at for at in self._chemicalSystem.atom_list if at.full_name.strip() in vals])
                 
         return sel
     

--- a/Src/Mathematics/Geometry.py
+++ b/Src/Mathematics/Geometry.py
@@ -104,7 +104,7 @@ def generate_sphere_points(n):
 
 def random_points_on_sphere(radius=1.0, nPoints=100):
 
-    points = numpy.zeros((3,nPoints),dtype=numpy.float)
+    points = numpy.zeros((3,nPoints),dtype=numpy.float64)
     
     theta = 2.0*numpy.pi*numpy.random.uniform(nPoints)
     u = numpy.random.uniform(-1.0,1.0,nPoints)
@@ -195,14 +195,14 @@ def superposition_fit(confs):
               and the RMS distance after the optimal superposition
     """
     w_sum = 0.
-    wr_sum = numpy.zeros((3,), numpy.float)
+    wr_sum = numpy.zeros((3,), numpy.float64)
     for w, r_ref, r in confs:
         w_sum += w
         wr_sum += w*r_ref.array
     ref_cms = wr_sum/w_sum
-    pos = numpy.zeros((3,), numpy.float)
+    pos = numpy.zeros((3,), numpy.float64)
     possq = 0.
-    cross = numpy.zeros((3, 3), numpy.float)
+    cross = numpy.zeros((3, 3), numpy.float64)
     for w, r_ref, r in confs:
         w = w/w_sum
         r_ref = r_ref.array-ref_cms
@@ -211,7 +211,7 @@ def superposition_fit(confs):
         possq = possq + w*numpy.add.reduce(r*r) \
                       + w*numpy.add.reduce(r_ref*r_ref)
         cross = cross + w*r[:, numpy.newaxis]*r_ref[numpy.newaxis, :]
-    k = numpy.zeros((4, 4), numpy.float)
+    k = numpy.zeros((4, 4), numpy.float64)
     k[0, 0] = -cross[0, 0]-cross[1, 1]-cross[2, 2]
     k[0, 1] = cross[1, 2]-cross[2, 1]
     k[0, 2] = cross[2, 0]-cross[0, 2]

--- a/Src/Mathematics/LinearAlgebra.py
+++ b/Src/Mathematics/LinearAlgebra.py
@@ -3,6 +3,7 @@ import numpy as np
 def cmp(a, b):
     return (a > b) - (a < b) 
 
+
 class Vector:
 
     """Vector in 3D space
@@ -54,8 +55,7 @@ class Vector:
     __deepcopy__ = __copy__
 
     def __repr__(self):
-        return 'Vector(%s,%s,%s)' % (repr(self.array[0]),\
-                                     repr(self.array[1]),repr(self.array[2]))
+        return 'Vector(%s,%s,%s)' % (repr(self.array[0]), repr(self.array[1]), repr(self.array[2]))
 
     def __str__(self):
         return repr(list(self.array))
@@ -118,6 +118,12 @@ class Vector:
 
     def __getitem__(self, index):
         return self.array[index]
+
+    def __eq__(self, other):
+        if isinstance(other, Vector):
+            return np.all(self.array == other.array)
+        else:
+            return False
 
     def x(self):
         """
@@ -276,6 +282,12 @@ class Quaternion:
     def __repr__(self):
         return 'Quaternion(' + str(list(self.array)) + ')'
 
+    def __eq__(self, other):
+        if isinstance(other, Quaternion):
+            return np.all(self.array == other.array)
+        else:
+            return False
+
     def dot(self, other):
         return np.add.reduce(self.array*other.array)
 
@@ -332,7 +344,7 @@ class Quaternion:
         @rtype: L{Scientific.Geometry.Transformation.Rotation}
         @raises ValueError: if the quaternion is not normalized
         """
-        from Transformation import Rotation
+        from MDANSE.Mathematics.Transformation import Rotation
         if np.fabs(self.norm()-1.) > 1.e-5:
             raise ValueError('Quaternion not normalized')
         d = np.dot(np.dot(self._rot, self.array), self.array)
@@ -462,6 +474,12 @@ class Tensor:
             return Tensor(elements)
         else:
             return elements
+
+    def __eq__(self, other):
+        if isinstance(other, Tensor):
+            return np.all(self.array == other.array)
+        else:
+            return False
 
     def asVector(self):
         """

--- a/Src/MolecularDynamics/Configuration.py
+++ b/Src/MolecularDynamics/Configuration.py
@@ -5,10 +5,13 @@ import numpy as np
 
 from MDANSE.Extensions import atoms_in_shell, contiguous_coordinates
 
+
 class ConfigurationError(Exception):
     pass
 
+
 class _Configuration(metaclass=abc.ABCMeta):
+    is_periodic: bool
 
     def __init__(self, chemical_system,coordinates,**variables):
         """Constructor.

--- a/Src/MolecularDynamics/Configuration.py
+++ b/Src/MolecularDynamics/Configuration.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
 import abc
 import copy
+from typing import TYPE_CHECKING
 
 import numpy as np
 
+if TYPE_CHECKING:
+    from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem, _ChemicalEntity
 from MDANSE.Extensions import atoms_in_shell, contiguous_coordinates
 
 
@@ -13,7 +17,7 @@ class ConfigurationError(Exception):
 class _Configuration(metaclass=abc.ABCMeta):
     is_periodic: bool
 
-    def __init__(self, chemical_system,coordinates,**variables):
+    def __init__(self, chemical_system: ChemicalSystem,coordinates,**variables):
         """Constructor.
 
         Args:
@@ -26,7 +30,7 @@ class _Configuration(metaclass=abc.ABCMeta):
         self._variables = {}
 
         coordinates = np.array(coordinates)
-        if coordinates.shape != (self._chemical_system.number_of_atoms(),3):
+        if coordinates.shape != (self._chemical_system.number_of_atoms, 3):
             raise ValueError('Invalid coordinates dimensions')
 
         self['coordinates'] = coordinates
@@ -62,7 +66,7 @@ class _Configuration(metaclass=abc.ABCMeta):
         """
 
         item = np.array(value)
-        if item.shape != (self._chemical_system.number_of_atoms(),3):
+        if item.shape != (self._chemical_system.number_of_atoms, 3):
             raise ValueError('Invalid item dimensions')
 
         self._variables[name] = value
@@ -130,7 +134,7 @@ class _Configuration(metaclass=abc.ABCMeta):
 
 class _PeriodicConfiguration(_Configuration):
 
-    def __init__(self, chemical_system, coordinates, unit_cell, **variables):
+    def __init__(self, chemical_system: ChemicalSystem, coordinates, unit_cell, **variables):
         """Constructor.
 
         Args:
@@ -145,14 +149,14 @@ class _PeriodicConfiguration(_Configuration):
             raise ValueError('Invalid unit cell dimensions')
         self._unit_cell = unit_cell
 
-    def clone(self,chemical_system):
+    def clone(self, chemical_system: ChemicalSystem):
         """Clone this configuration.
 
         Args:
             chemical_system (MDANSE.Chemistry.ChemicalEntity.ChemicalSystem): the chemical system
         """
 
-        if chemical_system.total_number_of_atoms() != self.chemical_system.total_number_of_atoms():
+        if chemical_system.total_number_of_atoms != self.chemical_system.total_number_of_atoms:
             raise ConfigurationError('Mismatch between the chemical systems')
 
         unit_cell = copy.deepcopy(self._unit_cell)
@@ -267,7 +271,7 @@ class PeriodicBoxConfiguration(_PeriodicConfiguration):
                                                     mini,
                                                     maxi)
         
-        atom_list = self._chemical_system.atom_list()
+        atom_list = self._chemical_system.atom_list
 
         selected_atoms = [atom_list[idx] for idx in indexes]
 
@@ -293,7 +297,7 @@ class PeriodicBoxConfiguration(_PeriodicConfiguration):
         conf._variables['coordinates'] = contiguous_coords
         return conf
 
-    def contiguous_offsets(self,chemical_entities=None):
+    def contiguous_offsets(self, chemical_entities: list[_ChemicalEntity] = None):
         """Returns the contiguity offsets for a list of chemical entities.
 
         Args:
@@ -307,12 +311,12 @@ class PeriodicBoxConfiguration(_PeriodicConfiguration):
             chemical_entities = self._chemical_system.chemical_entities
         else:
             for ce in chemical_entities:
-                if ce.root_chemical_system() is not self._chemical_system:
+                if ce.root_chemical_system is not self._chemical_system:
                     raise ConfigurationError('One or more chemical entities comes from another chemical system')
 
         indexes = []
         for ce in chemical_entities:
-            indexes.append([at.index for at in ce.atom_list()])
+            indexes.append([at.index for at in ce.atom_list])
         
         offsets = contiguous_coordinates.contiguous_offsets_box(
             self._variables['coordinates'],
@@ -397,7 +401,7 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
             mini,
             maxi)
 
-        atom_list = self._chemical_system.atom_list()
+        atom_list = self._chemical_system.atom_list
 
         selected_atoms = [atom_list[idx] for idx in indexes]
 
@@ -441,7 +445,7 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
         conf._variables['coordinates'] = contiguous_coords
         return conf
 
-    def contiguous_offsets(self, chemical_entities=None):
+    def contiguous_offsets(self, chemical_entities: list[_ChemicalEntity] = None):
         """Returns the contiguity offsets for a list of chemical entities.
 
         Args:
@@ -455,12 +459,12 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
             chemical_entities = self._chemical_system.chemical_entities
         else:
             for ce in chemical_entities:
-                if ce.root_chemical_system() is not self._chemical_system:
+                if ce.root_chemical_system is not self._chemical_system:
                     raise ConfigurationError('One or more chemical entities comes from another chemical system')
 
         indexes = []
         for ce in chemical_entities:
-            indexes.append([at.index for at in ce.atom_list()])
+            indexes.append([at.index for at in ce.atom_list])
         
         offsets = contiguous_coordinates.contiguous_offsets_real(
             self._variables['coordinates'],
@@ -474,14 +478,14 @@ class RealConfiguration(_Configuration):
 
     is_periodic = False
 
-    def clone(self, chemical_system):
+    def clone(self, chemical_system: ChemicalSystem):
         """Clone this configuration.
 
         Args:
             chemical_system (MDANSE.Chemistry.ChemicalEntity.ChemicalSystem): the chemical system
         """
 
-        if chemical_system.total_number_of_atoms() != self.chemical_system.total_number_of_atoms():
+        if chemical_system.total_number_of_atoms != self.chemical_system.total_number_of_atoms:
             raise ConfigurationError('Mismatch between the chemical systems')
 
         variables = copy.deepcopy(self.variables)
@@ -518,7 +522,7 @@ class RealConfiguration(_Configuration):
             mini,
             maxi)
 
-        atom_list = self._chemical_system.atom_list()
+        atom_list = self._chemical_system.atom_list
 
         selected_atoms = [atom_list[idx] for idx in indexes]
 
@@ -540,7 +544,7 @@ class RealConfiguration(_Configuration):
         """
         return self
 
-    def contiguous_offsets(self, chemical_entities=None):
+    def contiguous_offsets(self, chemical_entities: list[_ChemicalEntity] = None):
         """Returns the contiguity offsets for a list of chemical entities.
 
         Args:
@@ -554,10 +558,10 @@ class RealConfiguration(_Configuration):
             chemical_entities = self._chemical_system.chemical_entities
         else:
             for ce in chemical_entities:
-                if ce.root_chemical_system() is not self._chemical_system:
+                if ce.root_chemical_system is not self._chemical_system:
                     raise ConfigurationError('One or more chemical entities comes from another chemical system')
 
-        offsets = np.zeros((self._chemical_system.number_of_atoms(),3))
+        offsets = np.zeros((self._chemical_system.number_of_atoms, 3))
 
         return offsets
 

--- a/Src/MolecularDynamics/Trajectory.py
+++ b/Src/MolecularDynamics/Trajectory.py
@@ -19,7 +19,7 @@ import numpy as np
 import h5py
 
 from MDANSE.Chemistry import ATOMS_DATABASE
-from MDANSE.Chemistry.ChemicalEntity import Atom, ChemicalSystem
+from MDANSE.Chemistry.ChemicalEntity import Atom, ChemicalSystem, _ChemicalEntity
 from MDANSE.Extensions import atomic_trajectory, com_trajectory, fold_coordinates
 from MDANSE.MolecularDynamics.Configuration import PeriodicRealConfiguration, RealConfiguration
 from MDANSE.MolecularDynamics.TrajectoryUtils import build_connectivity, resolve_undefined_molecules_name, sorted_atoms
@@ -380,7 +380,7 @@ class TrajectoryWriterError(Exception):
 
 class TrajectoryWriter:
 
-    def __init__(self, h5_filename, chemical_system, n_steps, selected_atoms=None):
+    def __init__(self, h5_filename, chemical_system: ChemicalSystem, n_steps, selected_atoms=None):
         """Constructor.
 
         :param h5_filename: the trajectory filename
@@ -400,16 +400,16 @@ class TrajectoryWriter:
         self._chemical_system = chemical_system.copy()
 
         if selected_atoms is None:
-            self._selected_atoms = self._chemical_system.atom_list()
+            self._selected_atoms = self._chemical_system.atom_list
         else:
             for at in selected_atoms:
-                if at.root_chemical_system() != chemical_system:
+                if at.root_chemical_system != chemical_system:
                     raise TrajectoryWriterError('One or more atoms of the selection comes from a different chemical system')
             self._selected_atoms = sorted_atoms(selected_atoms)
             
         self._selected_atoms = [at.index for at in self._selected_atoms]
 
-        all_atoms = self._chemical_system.atom_list()
+        all_atoms = self._chemical_system.atom_list
         for idx in self._selected_atoms:
             all_atoms[idx] = False
 
@@ -458,7 +458,7 @@ class TrajectoryWriter:
         if units is None:
             units = {}
 
-        n_atoms = self._chemical_system.total_number_of_atoms()
+        n_atoms = self._chemical_system.total_number_of_atoms
 
         # Write the configuration variables
         configuration_grp = self._h5_file['/configuration']
@@ -511,7 +511,7 @@ class RigidBodyTrajectoryGenerator:
        and a quaternion for the orientation)
     """
     
-    def __init__(self, trajectory, chemical_entity, reference, first=0, last=None, step=1):
+    def __init__(self, trajectory, chemical_entity: _ChemicalEntity, reference, first=0, last=None, step=1):
         """Constructor.
 
         :param trajectory: the input trajectory
@@ -533,7 +533,7 @@ class RigidBodyTrajectoryGenerator:
         if last is None:
             last = len(self._trajectory)
 
-        atoms = chemical_entity.atom_list()
+        atoms = chemical_entity.atom_list
 
         masses = [ATOMS_DATABASE[at.symbol]['atomic_weight'] for at in atoms]
 

--- a/Src/MolecularDynamics/TrajectoryUtils.py
+++ b/Src/MolecularDynamics/TrajectoryUtils.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from MDANSE.Core.Error import Error
 from MDANSE.Chemistry import ATOMS_DATABASE
-from MDANSE.Chemistry.ChemicalEntity import Atom, AtomCluster, AtomGroup
+from MDANSE.Chemistry.ChemicalEntity import Atom, AtomCluster, AtomGroup, ChemicalSystem, _ChemicalEntity
 from MDANSE.Extensions import fast_calculation
 
 class MolecularDynamicsError(Error):
@@ -27,7 +27,8 @@ class MolecularDynamicsError(Error):
 class UniverseAdapterError(Error):
     pass
 
-def atomindex_to_moleculeindex(chemicalSystem):
+
+def atomindex_to_moleculeindex(chemicalSystem: ChemicalSystem):
     """Returns a lookup between the index of the atoms of a chemical system and the index 
     of their corresponding chemical entity.
 
@@ -40,12 +41,13 @@ def atomindex_to_moleculeindex(chemicalSystem):
     
     lut = {}
     for i,ce in enumerate(chemicalSystem.chemical_entities):
-        for at in ce.atom_list():
+        for at in ce.atom_list:
             lut[at.index] = i
                 
     return lut
-    
-def brute_formula(chemicalEntity, sep='_'):
+
+
+def brute_formula(chemicalEntity: _ChemicalEntity, sep='_'):
     """Define the brute formula of a given chemical entity.
 
     Args:
@@ -58,12 +60,13 @@ def brute_formula(chemicalEntity, sep='_'):
     
     contents = {}
     
-    for at in chemicalEntity.atom_list():
+    for at in chemicalEntity.atom_list:
         contents[at.symbol] = str(int(contents.get(at.symbol,0)) + 1)
     
     return sep.join([''.join(v) for v in sorted(contents.items())])
 
-def build_connectivity(chemicalSystem ,tolerance=0.05):
+
+def build_connectivity(chemicalSystem: ChemicalSystem ,tolerance=0.05):
     """Build the connectivity of the AtomCluster of a given chemical system.
 
     Args:
@@ -83,14 +86,14 @@ def build_connectivity(chemicalSystem ,tolerance=0.05):
             singleAtomsObjects.append(ce)
         else:
             if ce.number_of_atoms() == 1:
-                singleAtomsObjects.extend(ce.atom_list())
+                singleAtomsObjects.extend(ce.atom_list)
 
     if singleAtomsObjects:
         scannedObjects.append(AtomCluster('',singleAtomsObjects, parentless=True))
 
     for ce in scannedObjects:
 
-        atoms = sorted(ce.atom_list(), key = operator.attrgetter('index'))
+        atoms = sorted(ce.atom_list, key = operator.attrgetter('index'))
 
         nAtoms = len(atoms)
         indexes = [at.index for at in atoms]
@@ -105,7 +108,8 @@ def build_connectivity(chemicalSystem ,tolerance=0.05):
             atoms[idx1].bonds.append(atoms[idx2])                  
             atoms[idx2].bonds.append(atoms[idx1])
 
-def find_atoms_in_molecule(chemicalSystem, ceName, atomNames, indexes=False):
+
+def find_atoms_in_molecule(chemicalSystem: ChemicalSystem, ceName, atomNames, indexes=False):
     """Find the atoms of a chemical system whose chemical entity match a given value 
     and atom names are within a given list.
 
@@ -128,7 +132,7 @@ def find_atoms_in_molecule(chemicalSystem, ceName, atomNames, indexes=False):
                     
     match = []
     for ce in chemicalEntities:
-        atoms = ce.atom_list()
+        atoms = ce.atom_list
         names = [at.name for at in atoms]
         l = [atoms[names.index(at_name)] for at_name in atomNames]
 
@@ -139,7 +143,8 @@ def find_atoms_in_molecule(chemicalSystem, ceName, atomNames, indexes=False):
         
     return match
 
-def get_chemical_objects_dict(chemical_system):
+
+def get_chemical_objects_dict(chemical_system: ChemicalSystem):
     """Return a dict of the chemical entities found in a chemical system.
 
     Args:
@@ -155,8 +160,9 @@ def get_chemical_objects_dict(chemical_system):
         d.setdefault(ce.name, []).append(ce)
         
     return d
-                                                                            
-def group_atoms(chemicalSystem,groups):
+
+
+def group_atoms(chemicalSystem: ChemicalSystem,groups):
     """Group the atoms of a chemical system.
 
     Args:
@@ -167,13 +173,14 @@ def group_atoms(chemicalSystem,groups):
         list: the list of AtomGroup
     """
     
-    atoms = sorted(chemicalSystem.atom_list(), key=operator.attrgetter('index'))
+    atoms = sorted(chemicalSystem.atom_list, key=operator.attrgetter('index'))
                                         
     groups = [AtomGroup([atoms[index] for index in gr]) for gr in groups]
 
     return groups
 
-def resolve_undefined_molecules_name(chemicalSystem):
+
+def resolve_undefined_molecules_name(chemicalSystem: ChemicalSystem):
     """Resolve the name of the chemical entities with no names by using their
     brute formula.
 
@@ -185,7 +192,8 @@ def resolve_undefined_molecules_name(chemicalSystem):
         if not ce.name.strip():
             ce.name = brute_formula(ce,sep="")
 
-def sorted_atoms(atoms,attribute=None):
+
+def sorted_atoms(atoms: list[Atom], attribute=None):
     """Sort a list of atoms according.
 
     Args:

--- a/Tests/UnitTests/TestAtomSelector.py
+++ b/Tests/UnitTests/TestAtomSelector.py
@@ -61,10 +61,10 @@ class TestAtomsSelector(unittest.TestCase):
         """
         super(TestAtomsSelector, cls).setUpClass()
 
-        reader = PDBReader('./Data/PDB/2vb1.pdb')
+        reader = PDBReader('../../Data/PDB/2vb1.pdb')
         cls._proteinChemicalSystem = reader.build_chemical_system()
 
-        reader = PDBReader('./Data/PDB/1gip.pdb')
+        reader = PDBReader('../../Data/PDB/1gip.pdb')
         cls._nucleicAcidChemicalSystem = reader.build_chemical_system()
 
     def test_all(self):

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -136,7 +136,7 @@ class TestAtom(unittest.TestCase):
         result = atom.serialize(dictionary)
 
         self.assertEqual(('atoms', 0), result)
-        self.assertEqual({'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)']}, dictionary)
+        self.assertEqual({'atoms': [[repr('H'), repr('H'), 'False']]}, dictionary)
 
 
 class TestAtomGroup(unittest.TestCase):
@@ -301,22 +301,18 @@ class TestAtomCluster(unittest.TestCase):
         result = cluster.serialize(dictionary)
 
         self.assertEqual(('atom_clusters', 0), result)
-        self.assertDictEqual({'atom_clusters': ['H5AtomCluster(self._h5_file,h5_contents,[0, 1],name="Cluster1")'],
-                              'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)']},
+        self.assertDictEqual({'atom_clusters': [['[0, 1]', repr('Cluster1')]],
+                              'atoms': [[repr('H'), repr('H'), 'False'], [repr('H'), repr('H'), 'False']]},
                              dictionary)
 
     def test_serialize_nonempty_dict(self):
         cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()], parentless=True)
-        dictionary = {'atom_clusters': ['', '', ''], 'atoms': ['', '', '']}
+        dictionary = {'atom_clusters': [[], [], []], 'atoms': [[], [], []]}
         result = cluster.serialize(dictionary)
 
         self.assertEqual(('atom_clusters', 3), result)
-        self.assertDictEqual({'atom_clusters': ['', '', '',
-                                                'H5AtomCluster(self._h5_file,h5_contents,[3, 4],name="Cluster1")'],
-                              'atoms': ['', '', '',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)']},
+        self.assertDictEqual({'atom_clusters': [[], [], [], ['[3, 4]', repr('Cluster1')]],
+                              'atoms': [[], [], [], [repr('H'), repr('H'), 'False'], [repr('H'), repr('H'), 'False']]},
                              dictionary)
 
 
@@ -434,22 +430,19 @@ class TestMolecule(unittest.TestCase):
         result = self.molecule.serialize(dictionary)
 
         self.assertEqual(('molecules', 0), result)
-        self.assertDictEqual({'molecules': ['H5Molecule(self._h5_file,h5_contents,[0, 1, 2],code="WAT",name="water")'],
-                              'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="O", name="OW", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HW2", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HW1", ghost=False)']},
+        self.assertDictEqual({'molecules': [['[0, 1, 2]', repr('WAT'), repr('water')]],
+                              'atoms': [[repr('O'), repr('OW'), 'False'], [repr('H'), repr('HW2'), 'False'],
+                                        [repr('H'), repr('HW1'), 'False']]},
                              dictionary)
 
     def test_serialize_from_nonempty_dict(self):
-        dictionary = {'atoms': ['', '']}
+        dictionary = {'atoms': [[], []], 'molecules': [[], []]}
         result = self.molecule.serialize(dictionary)
 
-        self.assertEqual(('molecules', 0), result)
-        self.assertDictEqual({'atoms': ['', '',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="O", name="OW", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HW2", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HW1", ghost=False)'],
-                             'molecules': ['H5Molecule(self._h5_file,h5_contents,[2, 3, 4],code="WAT",name="water")']},
+        self.assertEqual(('molecules', 2), result)
+        self.assertDictEqual({'atoms': [[], [], [repr('O'), repr('OW'), 'False'], [repr('H'), repr('HW2'), 'False'],
+                                        [repr('H'), repr('HW1'), 'False']],
+                             'molecules': [[], [], ['[2, 3, 4]', repr('WAT'), repr('water')]]},
                              dictionary)
 
 
@@ -696,35 +689,26 @@ class TestResidue(unittest.TestCase):
 
         self.maxDiff = None
         self.assertEqual(('residues', 0), result)
-        self.assertDictEqual({'residues': ['H5Residue(self._h5_file,h5_contents,[0, 1, 2, 3, 4, 5, 6],code="GLY",'
-                                           'name="glycine",variant=None)'],
-                              'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HA3", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="O", name="O", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="N", name="N", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="C", name="CA", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HA2", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="C", name="C", ghost=False)']},
+        self.assertDictEqual({'residues': [['[0, 1, 2, 3, 4, 5, 6]', repr('GLY'), repr('glycine'), 'None']],
+                              'atoms': [[repr('H'), repr('H'), 'False'], [repr('H'), repr('HA3'), 'False'],
+                                        [repr('O'), repr('O'), 'False'], [repr('N'), repr('N'), 'False'],
+                                        [repr('C'), repr('CA'), 'False'], [repr('H'), repr('HA2'), 'False'],
+                                        [repr('C'), repr('C'), 'False']]},
                              dictionary)
 
     def test_serialize_nonempty_dict(self):
         residue = ce.Residue('GLY', 'glycine', None)
         residue.set_atoms(['H', 'HA3', 'O', 'N', 'CA', 'HA2', 'C'])
-        dictionary = {'atoms': ['', '', '']}
+        dictionary = {'atoms': [[], [], []], 'residues': [[], [], []]}
         result = residue.serialize(dictionary)
 
         self.maxDiff = None
-        self.assertEqual(('residues', 0), result)
-        self.assertDictEqual({'residues': ['H5Residue(self._h5_file,h5_contents,[3, 4, 5, 6, 7, 8, 9],code="GLY",'
-                                           'name="glycine",variant=None)'],
-                              'atoms': ['', '', '',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HA3", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="O", name="O", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="N", name="N", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="C", name="CA", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HA2", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="C", name="C", ghost=False)']},
+        self.assertEqual(('residues', 3), result)
+        self.assertDictEqual({'residues': [[], [], [], ['[3, 4, 5, 6, 7, 8, 9]', repr('GLY'), repr('glycine'), 'None']],
+                              'atoms': [[], [], [], [repr('H'), repr('H'), 'False'], [repr('H'), repr('HA3'), 'False'],
+                                        [repr('O'), repr('O'), 'False'], [repr('N'), repr('N'), 'False'],
+                                        [repr('C'), repr('CA'), 'False'], [repr('H'), repr('HA2'), 'False'],
+                                        [repr('C'), repr('C'), 'False']]},
                              dictionary)
 
 
@@ -880,22 +864,19 @@ class TestNucleotide(unittest.TestCase):
         result = nucleotide.serialize(dictionary)
 
         self.assertEqual(('nucleotides', 0), result)
-        self.assertDictEqual({'nucleotides': ['H5Nucleotide(self._h5_file,h5_contents,[0],code="5T1",name="5T1",'
-                                              'variant=None)'],
-                              'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="H", name="HO5\'", ghost=False)']},
+        self.assertDictEqual({'nucleotides': [['[0]', repr('5T1'), repr('5T1'), 'None']],
+                              'atoms': [[repr('H'), repr('HO5\''), 'False']]},
                              dictionary)
 
     def test_serialize_nonempty_dict(self):
         nucleotide = ce.Nucleotide('5T1', '5T1', None)
         nucleotide.set_atoms(['HO5\''])
-        dictionary = {'atoms': ['', '', '']}
+        dictionary = {'atoms': [[], [], []], 'nucleotides': [[], [], []]}
         result = nucleotide.serialize(dictionary)
 
-        self.assertEqual(('nucleotides', 0), result)
-        self.assertDictEqual({'nucleotides': ['H5Nucleotide(self._h5_file,h5_contents,[3],code="5T1",name="5T1",'
-                                              'variant=None)'],
-                              'atoms': ['', '', '',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HO5\'", ghost=False)']},
+        self.assertEqual(('nucleotides', 3), result)
+        self.assertDictEqual({'nucleotides': [[], [], [], ['[3]', repr('5T1'), repr('5T1'), 'None']],
+                              'atoms': [[], [], [], [repr('H'), repr('HO5\''), 'False']]},
                              dictionary)
 
 
@@ -1056,40 +1037,28 @@ class TestNucleotideChain(unittest.TestCase):
 
         self.maxDiff = None
         self.assertEqual(('nucleotide_chains', 0), result)
-        self.assertDictEqual({'nucleotides': ['H5Nucleotide(self._h5_file,h5_contents,[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, '
-                                              '10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, '
-                                              '28, 29, 30],code="A",name="adenine",variant=\'5T1\')',
-                                              'H5Nucleotide(self._h5_file,h5_contents,[31, 32, 33, 34, 35, 36, 37, 38, '
-                                              '39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, '
-                                              '57, 58, 59, 60, 61, 62, 63, 64],code="A",name="adenine",'
-                                              'variant=\'3T1\')'],
-                              'atoms': [f'H5Atom(self._h5_file,h5_contents,symbol="{i}", name="{j}", ghost=False)'
-                                        for i, j in zip(['C', 'C', 'C', 'H', 'H', 'H', 'O', 'C', 'C', 'H', 'C', 'C',
-                                                         'C', 'H', 'H', 'N', 'C', 'C', 'O', 'N', 'N', 'N', 'N', 'H',
-                                                         'H', 'H', 'O', 'H', 'H', 'O', 'H', 'C', 'C', 'C', 'H', 'H',
-                                                         'H', 'O', 'C', 'C', 'H', 'C', 'C', 'C', 'H', 'H', 'N', 'C',
-                                                         'C', 'O', 'N', 'N', 'N', 'N', 'H', 'H', 'H', 'O', 'H', 'H',
-                                                         'O', 'H', 'O', 'O', 'P'],
-                                                        ['C3\'', 'C1\'', 'C5\'', 'H2\'', 'H5\'', 'H3\'', 'O4\'', 'C8',
-                                                         'C2', 'H1\'', 'C6', 'C5', 'C4', 'H5\'\'', 'HO2\'', 'N9',
-                                                         'C4\'', 'C2\'', 'O2\'', 'N1', 'N3', 'N6', 'N7', 'H4\'', 'H8',
-                                                         'H2', 'O5\'', 'H61', 'H62', 'O3\'', 'HO5\'', 'C3\'', 'C1\'',
-                                                         'C5\'', 'H2\'', 'H5\'', 'H3\'', 'O4\'', 'C8', 'C2', 'H1\'',
-                                                         'C6', 'C5', 'C4', 'H5\'\'', 'HO2\'', 'N9', 'C4\'', 'C2\'',
-                                                         'O2\'', 'N1', 'N3', 'N6', 'N7', 'H4\'', 'H8', 'H2', 'O5\'',
-                                                         'H61', 'H62', 'O3\'', 'HO3\'', 'OP1', 'OP2', 'P'])],
-                              'nucleotide_chains': ['H5NucleotideChain(self._h5_file,h5_contents,"name",[0, 1])']},
-                             dictionary)
+        self.assertEqual(['nucleotides', 'atoms', 'nucleotide_chains'], list(dictionary.keys()))
+        self.assertEqual([[repr('name'), '[0, 1]']], dictionary['nucleotide_chains'])
+        self.assertEqual([['[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, '
+                           '25, 26, 27, 28, 29, 30]', repr('A'), repr('adenine'), repr('5T1')],
+                          ['[31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, '
+                           '53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64]', repr('A'), repr('adenine'), repr('3T1')]],
+                         dictionary['nucleotides'])
 
     def test_serialize_nonempty_dict(self):
         n1, n2 = self.prepare_nucleotides()
         self.chain.set_nucleotides([n1, n2])
-        dictionary = {'nucleotides': ['', '', ''], 'nucleotide_chains': ['']}
+        dictionary = {'nucleotides': [[], [], []], 'nucleotide_chains': [[]]}
         result = self.chain.serialize(dictionary)
 
         self.assertEqual(('nucleotide_chains', 1), result)
-        self.assertEqual(['', 'H5NucleotideChain(self._h5_file,h5_contents,"name",[3, 4])'],
-                         dictionary['nucleotide_chains'])
+        self.assertEqual(['nucleotides', 'nucleotide_chains', 'atoms'], list(dictionary.keys()))
+        self.assertEqual([[], [repr('name'), '[3, 4]']], dictionary['nucleotide_chains'])
+        self.assertEqual([[], [], [], ['[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, '
+                                       '22, 23, 24, 25, 26, 27, 28, 29, 30]', repr('A'), repr('adenine'), repr('5T1')],
+                          ['[31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, '
+                           '53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64]', repr('A'), repr('adenine'), repr('3T1')]],
+                         dictionary['nucleotides'])
 
     def test_sugars(self):
         n1, n2 = self.prepare_nucleotides()
@@ -1252,38 +1221,23 @@ class TestPeptideChain(unittest.TestCase):
 
         self.maxDiff = None
         self.assertEqual(('peptide_chains', 0), result)
-        self.assertDictEqual({'residues': ['H5Residue(self._h5_file,h5_contents,[0, 1, 2, 3, 4, 5, 6, 7, 8],code="GLY",'
-                                           'name="glycine1",variant=\'NT1\')',
-                                           'H5Residue(self._h5_file,h5_contents,[9, 10, 11, 12, 13, 14, 15, 16],'
-                                           'code="GLY",name="glycine2",variant=\'CT1\')'],
-                              'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="H", name="HA3", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="O", name="O", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="N", name="N", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="C", name="CA", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HA2", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="C", name="C", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HT1", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HT2", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HT3", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HA3", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="O", name="O", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="N", name="N", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="C", name="CA", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HA2", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="C", name="C", ghost=False)',
-                                        'H5Atom(self._h5_file,h5_contents,symbol="O", name="OXT", ghost=False)'],
-                              'peptide_chains': ['H5PeptideChain(self._h5_file,h5_contents,"name",[0, 1])']},
-                             dictionary)
+        self.assertEqual(['residues', 'atoms', 'peptide_chains'], list(dictionary.keys()))
+        self.assertEqual([[repr('name'), '[0, 1]']], dictionary['peptide_chains'])
+        self.assertEqual([['[0, 1, 2, 3, 4, 5, 6, 7, 8]', repr('GLY'), repr('glycine1'), repr('NT1')],
+                          ['[9, 10, 11, 12, 13, 14, 15, 16]', repr('GLY'), repr('glycine2'), repr('CT1')]],
+                         dictionary['residues'])
 
     def test_serialize_nonempty_dict(self):
         self.populate_chain()
-        dictionary = {'residues': ['', '', ''], 'peptide_chains': ['', '', '']}
+        dictionary = {'residues': [[], [], []], 'peptide_chains': [[], [], []]}
         result = self.chain.serialize(dictionary)
 
         self.assertEqual(('peptide_chains', 3), result)
-        self.assertEqual(['', '', '', 'H5PeptideChain(self._h5_file,h5_contents,"name",[3, 4])'],
-                         dictionary['peptide_chains'])
+        self.assertEqual(['residues', 'peptide_chains', 'atoms'], list(dictionary.keys()))
+        self.assertEqual([[], [], [], [repr('name'), '[3, 4]']], dictionary['peptide_chains'])
+        self.assertEqual([[], [], [], ['[0, 1, 2, 3, 4, 5, 6, 7, 8]', repr('GLY'), repr('glycine1'), repr('NT1')],
+                          ['[9, 10, 11, 12, 13, 14, 15, 16]', repr('GLY'), repr('glycine2'), repr('CT1')]],
+                         dictionary['residues'])
 
     def test_sidechains(self):
         r1, r2 = self.populate_chain()
@@ -1390,20 +1344,22 @@ class TestProtein(unittest.TestCase):
     def test_serialize_empty_dict(self):
         self.populate_protein()
         dictionary = {}
-
         result = self.protein.serialize(dictionary)
 
         self.assertEqual(('proteins', 0), result)
-        self.assertEqual(['H5Protein(self._h5_file,h5_contents,"name",[0])'], dictionary['proteins'])
-        self.assertEqual(['H5PeptideChain(self._h5_file,h5_contents,"name",[0, 1])'], dictionary['peptide_chains'])
+        self.assertEqual(['proteins', 'residues', 'atoms', 'peptide_chains'], list(dictionary.keys()))
+        self.assertEqual([[repr('name'), '[0]']], dictionary['proteins'])
+        self.assertEqual([[repr('name'), '[0, 1]']], dictionary['peptide_chains'])
 
     def test_serialize_nonempty_dict(self):
         self.populate_protein()
-        dictionary = {'proteins': ['', '', ''], 'peptide_chains': ['', '', '']}
+        dictionary = {'proteins': [[], [], []], 'peptide_chains': [[], [], []]}
         result = self.protein.serialize(dictionary)
 
         self.assertEqual(('proteins', 3), result)
-        self.assertEqual(['', '', '', 'H5Protein(self._h5_file,h5_contents,"name",[3])'], dictionary['proteins'])
+        self.assertEqual(['proteins', 'peptide_chains', 'residues', 'atoms'], list(dictionary.keys()))
+        self.assertEqual([[], [], [], [repr('name'), '[3]']], dictionary['proteins'])
+        self.assertEqual([[], [], [], [repr('name'), '[0, 1]']], dictionary['peptide_chains'])
 
     def test_sidechains(self):
         chain = self.populate_protein()
@@ -1552,7 +1508,7 @@ class TestChemicalSystem(unittest.TestCase):
         file['/chemical_system'].attrs['name'] = 'new'
 
         file['/chemical_system/contents'] = [('atoms'.encode(encoding = 'UTF-8',errors = 'strict'), 0)]
-        file['/chemical_system']['atoms'] = ['H5Atom(self._h5_file,h5_contents,symbol="H", name="H1", ghost=False)']
+        file['/chemical_system']['atoms'] = [[repr('H'), repr('H1'), 'False']]
         self.system.load(file)
 
         self.assertEqual(None, self.system._h5_file)
@@ -1564,13 +1520,46 @@ class TestChemicalSystem(unittest.TestCase):
         self.assertEqual(1, self.system._total_number_of_atoms)
         self.assertEqual(None, self.system._atoms)
 
-    def test_load_corrupt_file_unexpected_eval_input(self):
+    def test_load_corrupt_file_skeleton_invalid_entity_type(self):
+        file = StubHDFFile()
+        file['/chemical_system'] = StubHDFFile()
+        file['/chemical_system'].attrs['name'] = 'new'
+
+        file['/chemical_system/contents'] = [('INVALID'.encode(encoding='UTF-8', errors='strict'), 0)]
+        file['/chemical_system']['atoms'] = [['H', 'H1', 'False']]
+
+        with self.assertRaises(ce.CorruptedFileError):
+            self.system.load(file)
+
+    def test_load_corrupt_file_skeleton_entity_not_in_system(self):
         file = StubHDFFile()
         file['/chemical_system'] = StubHDFFile()
         file['/chemical_system'].attrs['name'] = 'new'
 
         file['/chemical_system/contents'] = [('atoms'.encode(encoding='UTF-8', errors='strict'), 0)]
-        file['/chemical_system']['atoms'] = ['Atom(symbol="H", name="H1", ghost=False)']
+        file['/chemical_system']['INVALID'] = [['H', 'H1', 'False']]
+
+        with self.assertRaises(ce.CorruptedFileError):
+            self.system.load(file)
+
+    def test_load_corrupt_file_skeleton_index_out_of_range(self):
+        file = StubHDFFile()
+        file['/chemical_system'] = StubHDFFile()
+        file['/chemical_system'].attrs['name'] = 'new'
+
+        file['/chemical_system/contents'] = [('atoms'.encode(encoding='UTF-8', errors='strict'), 1)]
+        file['/chemical_system']['atoms'] = [['H', 'H1', 'False']]
+
+        with self.assertRaises(ce.CorruptedFileError):
+            self.system.load(file)
+
+    def test_load_corrupt_file_ast_error(self):
+        file = StubHDFFile()
+        file['/chemical_system'] = StubHDFFile()
+        file['/chemical_system'].attrs['name'] = 'new'
+
+        file['/chemical_system/contents'] = [('atoms'.encode(encoding='UTF-8', errors='strict'), 0)]
+        file['/chemical_system']['atoms'] = [['"', 'H1', 'False']]
 
         with self.assertRaises(ce.CorruptedFileError):
             self.system.load(file)
@@ -1582,12 +1571,10 @@ class TestChemicalSystem(unittest.TestCase):
         self.system.serialize(file)
 
         self.assertEqual('name', file['/chemical_system'].attrs['name'])
-        self.assertEqual(['H5Molecule(self._h5_file,h5_contents,[0, 1, 2],code="WAT",name="water")'],
+        self.assertEqual([['[0, 1, 2]', repr('WAT'), repr('water')]],
                          file['/chemical_system']['molecules'])
-        self.assertEqual(['H5Atom(self._h5_file,h5_contents,symbol="O", name="OW", ghost=False)',
-                          'H5Atom(self._h5_file,h5_contents,symbol="H", name="HW2", ghost=False)',
-                          'H5Atom(self._h5_file,h5_contents,symbol="H", name="HW1", ghost=False)'],
-                         file['/chemical_system']['atoms'])
+        self.assertEqual([[repr('O'), repr('OW'), 'False'], [repr('H'), repr('HW2'), 'False'],
+                          [repr('H'), repr('HW1'), 'False']], file['/chemical_system']['atoms'])
         self.assertEqual([('molecules', '0')], file['/chemical_system']['contents'])
 
 

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -37,7 +37,7 @@ class TestAtom(unittest.TestCase):
     def test_instantiation_overwriting_default_values(self):
         bond = ce.Atom()
         atom = ce.Atom(symbol='C', name='carbon12', bonds=[bond], groups=['backbone'], ghost=True,
-                       index=0, parent=bond, mass=12, random='12345')
+                       index=0, parent=bond, atomic_mass=12, random='12345')
 
         self.assertEqual('C', atom.symbol)
         self.assertEqual('carbon12', atom.name)
@@ -46,7 +46,7 @@ class TestAtom(unittest.TestCase):
         self.assertEqual(True, atom.ghost)
         self.assertEqual(0, atom.index)
         self.assertEqual(bond, atom.parent)
-        self.assertEqual(12, atom.mass)
+        self.assertEqual(12, atom.atomic_mass)
         self.assertEqual('12345', atom.random)
 
     def test_instantiation_undefined_element(self):
@@ -75,26 +75,26 @@ class TestAtom(unittest.TestCase):
 
     def test_atom_list_ghost_true(self):
         atom = ce.Atom(ghost=True)
-        atom_list = atom.atom_list()
+        atom_list = atom.atom_list
         self.assertEqual([], atom_list)
 
     def test_atom_list_ghost_false(self):
         atom = ce.Atom(ghost=False)
-        atom_list = atom.atom_list()
+        atom_list = atom.atom_list
         self.assertEqual([atom], atom_list)
 
     def test_total_number_of_atoms(self):
         atom = ce.Atom(ghost=False)
         ghost = ce.Atom(ghost=True)
-        self.assertEqual(1, atom.total_number_of_atoms())
-        self.assertEqual(1, ghost.total_number_of_atoms())
+        self.assertEqual(1, atom.total_number_of_atoms)
+        self.assertEqual(1, ghost.total_number_of_atoms)
 
     def test_number_of_atoms(self):
         atom = ce.Atom(ghost=False)
         ghost = ce.Atom(ghost=True)
 
-        self.assertEqual(0, atom.number_of_atoms())
-        self.assertEqual(1, ghost.number_of_atoms())
+        self.assertEqual(0, atom.number_of_atoms)
+        self.assertEqual(1, ghost.number_of_atoms)
 
     def test_bonds_setter(self):
         atom = ce.Atom()
@@ -187,18 +187,18 @@ class TestAtomGroup(unittest.TestCase):
 
     def test_atom_list(self):
         self.atom2._ghost = True
-        self.assertEqual([self.atom1], self.group.atom_list())
+        self.assertEqual([self.atom1], self.group.atom_list)
 
     def test_copy(self):
         self.assertEqual(None, self.group.copy())
 
     def test_number_of_atoms(self):
         self.atom2._ghost = True
-        self.assertEqual(1, self.group.number_of_atoms())
-        self.assertEqual(2, self.group.total_number_of_atoms())
+        self.assertEqual(1, self.group.number_of_atoms)
+        self.assertEqual(2, self.group.total_number_of_atoms)
 
     def test_root_chemical_system(self):
-        self.assertEqual(repr(self.system), repr(self.group.root_chemical_system()))
+        self.assertEqual(repr(self.system), repr(self.group.root_chemical_system))
 
     def test_serialize(self):
         dictionary = {}
@@ -263,7 +263,7 @@ class TestAtomCluster(unittest.TestCase):
         atom = ce.Atom()
         ghost = ce.Atom(ghost=True)
         cluster = ce.AtomCluster('Cluster1', [atom, ghost], parentless=True)
-        self.assertEqual([atom], cluster.atom_list())
+        self.assertEqual([atom], cluster.atom_list)
 
     def test_copy_parentful(self):
         cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()], parentless=False)
@@ -277,8 +277,8 @@ class TestAtomCluster(unittest.TestCase):
 
     def test_number_of_atoms(self):
         cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom(ghost=True)], parentless=True)
-        self.assertEqual(1, cluster.number_of_atoms())
-        self.assertEqual(2, cluster.total_number_of_atoms())
+        self.assertEqual(1, cluster.number_of_atoms)
+        self.assertEqual(2, cluster.total_number_of_atoms)
 
     def test_reorder_atoms_exception(self):
         cluster = ce.AtomCluster('Cluster1', [ce.Atom(symbol='H'), ce.Atom(symbol='C')], parentless=True)
@@ -406,18 +406,18 @@ class TestMolecule(unittest.TestCase):
         self.assertEqual('Molecule of water (database code "WAT")', str(self.molecule))
 
     def test_atom_list(self):
-        self.assertEqual(3, len(self.molecule.atom_list()))
-        self.compare_atoms(self.molecule.atom_list(), self.molecule)
+        self.assertEqual(3, len(self.molecule.atom_list))
+        self.compare_atoms(self.molecule.atom_list, self.molecule)
 
     def test_copy(self):
         copy = self.molecule.copy()
         self.compare_two_molecules(copy)
 
     def test_number_of_atoms(self):
-        self.assertEqual(3, self.molecule.number_of_atoms())
+        self.assertEqual(3, self.molecule.number_of_atoms)
 
     def test_total_number_of_atoms(self):
-        self.assertEqual(3, self.molecule.total_number_of_atoms())
+        self.assertEqual(3, self.molecule.total_number_of_atoms)
 
     def test_reorder_atoms_invalid_input(self):
         with self.assertRaises(ce.InconsistentAtomNamesError):
@@ -425,9 +425,9 @@ class TestMolecule(unittest.TestCase):
 
     def test_reorder_atoms_valid_input(self):
         self.molecule.reorder_atoms(['HW1', 'HW2', 'OW'])
-        self.assertEqual('HW1', self.molecule.atom_list()[0].name)
-        self.assertEqual('HW2', self.molecule.atom_list()[1].name)
-        self.assertEqual('OW', self.molecule.atom_list()[2].name)
+        self.assertEqual('HW1', self.molecule.atom_list[0].name)
+        self.assertEqual('HW2', self.molecule.atom_list[1].name)
+        self.assertEqual('OW', self.molecule.atom_list[2].name)
 
     def test_serialize_from_empty_dict(self):
         dictionary = {}
@@ -673,13 +673,13 @@ class TestResidue(unittest.TestCase):
     def test_atom_list(self):
         residue = ce.Residue('GLY', 'glycine', None)
         residue.set_atoms(['H', 'HA3', 'O', 'N', 'CA', 'HA2', 'C'])
-        self.compare_atoms(residue.atom_list(), residue)
+        self.compare_atoms(residue.atom_list, residue)
 
     def test_number_of_atoms(self):
         residue = ce.Residue('GLY', 'glycine', None)
         residue.set_atoms(['H', 'HA3', 'O', 'N', 'CA', 'HA2', 'C'])
-        self.assertEqual(7, residue.number_of_atoms())
-        self.assertEqual(7, residue.total_number_of_atoms())
+        self.assertEqual(7, residue.number_of_atoms)
+        self.assertEqual(7, residue.total_number_of_atoms)
 
     def test_copy(self):
         residue = ce.Residue('GLY', 'glycine', None)
@@ -865,13 +865,13 @@ class TestNucleotide(unittest.TestCase):
     def test_atom_list(self):
         nucleotide = ce.Nucleotide('5T1', '5T1', None)
         nucleotide.set_atoms(['HO5\''])
-        self.compare_atoms_in_5t1(nucleotide.atom_list(), nucleotide)
+        self.compare_atoms_in_5t1(nucleotide.atom_list, nucleotide)
 
     def test_number_of_atoms(self):
         nucleotide = ce.Nucleotide('5T1', '5T1', None)
         nucleotide.set_atoms(['HO5\''])
-        self.assertEqual(1, nucleotide.number_of_atoms())
-        self.assertEqual(1, nucleotide.total_number_of_atoms())
+        self.assertEqual(1, nucleotide.number_of_atoms)
+        self.assertEqual(1, nucleotide.total_number_of_atoms)
 
     def test_serialize_empty_dict(self):
         nucleotide = ce.Nucleotide('5T1', '5T1', None)
@@ -1045,8 +1045,8 @@ class TestNucleotideChain(unittest.TestCase):
         n1, n2 = self.prepare_nucleotides()
         self.chain.set_nucleotides([n1, n2])
 
-        self.assertEqual(65, self.chain.number_of_atoms())
-        self.assertEqual(65, self.chain.total_number_of_atoms())
+        self.assertEqual(65, self.chain.number_of_atoms)
+        self.assertEqual(65, self.chain.total_number_of_atoms)
 
     def test_serialize_empty_dict(self):
         n1, n2 = self.prepare_nucleotides()
@@ -1211,14 +1211,14 @@ class TestPeptideChain(unittest.TestCase):
 
         self.assertEqual([r1['HA3'], r1['O'], r1['N'], r1['CA'], r1['HA2'], r1['C'], r1['HT1'], r1['HT2'], r1['HT3'],
                           r2['H'], r2['HA3'], r2['O'], r2['N'], r2['CA'], r2['HA2'], r2['C'], r2['OXT']],
-                         self.chain.atom_list())
+                         self.chain.atom_list)
 
     def test_backbone(self):
         r1, r2 = self.populate_chain()
 
         self.assertEqual([r1['O'], r1['N'], r1['CA'], r1['HA2'], r1['C'], r1['HT1'], r1['HT2'], r1['HT3'],
                           r2['H'], r2['O'], r2['N'], r2['CA'], r2['HA2'], r2['C'], r2['OXT']],
-                         self.chain.backbone())
+                         self.chain.backbone)
 
     def test_copy(self):
         self.populate_chain()
@@ -1229,8 +1229,8 @@ class TestPeptideChain(unittest.TestCase):
 
     def test_number_of_atoms(self):
         self.populate_chain()
-        self.assertEqual(17, self.chain.number_of_atoms())
-        self.assertEqual(17, self.chain.total_number_of_atoms())
+        self.assertEqual(17, self.chain.number_of_atoms)
+        self.assertEqual(17, self.chain.total_number_of_atoms)
 
     def test_peptide_chains(self):
         self.populate_chain()
@@ -1350,13 +1350,13 @@ class TestProtein(unittest.TestCase):
         self.assertEqual([chain[0]['HA3'], chain[0]['O'], chain[0]['N'], chain[0]['CA'], chain[0]['HA2'], chain[0]['C'],
                           chain[0]['HT1'], chain[0]['HT2'], chain[0]['HT3'], chain[1]['H'], chain[1]['HA3'],
                           chain[1]['O'], chain[1]['N'], chain[1]['CA'], chain[1]['HA2'], chain[1]['C'],
-                          chain[1]['OXT']], self.protein.atom_list())
+                          chain[1]['OXT']], self.protein.atom_list)
 
     def test_backbone(self):
         chain = self.populate_protein()
         self.assertEqual([chain[0]['O'], chain[0]['N'], chain[0]['CA'], chain[0]['HA2'], chain[0]['C'], chain[0]['HT1'],
                           chain[0]['HT2'], chain[0]['HT3'], chain[1]['H'], chain[1]['O'], chain[1]['N'], chain[1]['CA'],
-                          chain[1]['HA2'], chain[1]['C'], chain[1]['OXT']], self.protein.backbone())
+                          chain[1]['HA2'], chain[1]['C'], chain[1]['OXT']], self.protein.backbone)
 
     def test_copy(self):
         chain = self.populate_protein()
@@ -1371,8 +1371,8 @@ class TestProtein(unittest.TestCase):
     def test_number_of_atoms(self):
         self.populate_protein()
 
-        self.assertEqual(17, self.protein.number_of_atoms())
-        self.assertEqual(17, self.protein.total_number_of_atoms())
+        self.assertEqual(17, self.protein.number_of_atoms)
+        self.assertEqual(17, self.protein.total_number_of_atoms)
 
     def test_peptide_chains(self):
         chain = self.populate_protein()
@@ -1506,7 +1506,7 @@ class TestChemicalSystem(unittest.TestCase):
         cluster = ce.AtomCluster('name', [atom1, atom2])
         self.system.add_chemical_entity(cluster)
 
-        self.assertEqual([atom1, atom2], self.system.atom_list())
+        self.assertEqual([atom1, atom2], self.system.atom_list)
 
     def test_atoms(self):
         atom1 = ce.Atom(ghost=False)

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -1771,3 +1771,17 @@ class StubConfiguration(dict):
         self.is_periodic = is_periodic
         self.chemical_system = chemical_system
         super().__init__(**kwargs)
+
+
+def suite():
+    loader = unittest.TestLoader()
+    s = unittest.TestSuite()
+    for test_case in [TestChemicalEntity, TestAtom, TestAtomCluster, TestAtomGroup, TestMolecule, TestResidue,
+                      TestNucleotide, TestNucleotideChain, TestPeptideChain, TestProtein, TestTranslateAtomNames,
+                      TestChemicalSystem]:
+        s.addTest(loader.loadTestsFromTestCase(test_case))
+    return s
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -26,89 +26,81 @@ class TestAtom(unittest.TestCase):
     def test_empty_instantiation(self):
         atom = ce.Atom()
 
-        self.assertEqual(atom.symbol, 'H')
-        self.assertEqual(atom.name, 'H')
-        self.assertEqual(atom.bonds, [])
-        self.assertEqual(atom._groups, [])
-        self.assertEqual(atom.ghost, False)
-        self.assertEqual(atom.index, None)
-        self.assertEqual(atom.parent, None)
+        self.assertEqual('H', atom.symbol)
+        self.assertEqual('H', atom.name)
+        self.assertEqual([], atom.bonds)
+        self.assertEqual([], atom._groups)
+        self.assertEqual(False, atom.ghost)
+        self.assertEqual(None, atom.index)
+        self.assertEqual(None, atom.parent)
 
-    def test_correct_instantiation(self):
-        # user getitem
-        atom = ce.Atom(symbol='C', name='carbon12')
+    def test_instantiation_overwriting_default_values(self):
+        bond = ce.Atom()
+        atom = ce.Atom(symbol='C', name='carbon12', bonds=[bond], groups=['backbone'], ghost=True,
+                       index=0, parent=bond, mass=12, random='12345')
 
-    def test_undefined_element(self):
+        self.assertEqual('C', atom.symbol)
+        self.assertEqual('carbon12', atom.name)
+        self.assertEqual([bond], atom.bonds)
+        self.assertEqual(['backbone'], atom._groups)
+        self.assertEqual(True, atom.ghost)
+        self.assertEqual(0, atom.index)
+        self.assertEqual(bond, atom.parent)
+        self.assertEqual(12, atom.mass)
+        self.assertEqual('12345', atom.random)
+
+    def test_instantiation_undefined_element(self):
         with self.assertRaises(ce.UnknownAtomError):
             ce.Atom(symbol='CC')
 
     def test_copy(self):
         atom = ce.Atom()
         copy = atom.copy()
-
-        self.assertEqual(atom.symbol, copy.symbol)
-        self.assertEqual(atom.name, copy.name)
-        self.assertEqual(atom.bonds, copy.bonds)
-        self.assertEqual(atom._groups, copy._groups)
-        self.assertEqual(atom.ghost, copy.ghost)
-        self.assertEqual(atom.index, copy.index)
-        self.assertEqual(atom.parent, copy.parent)
+        self.assertEqual(repr(atom), repr(copy))
 
     def test_pickling(self):
         atom = ce.Atom()
         pickled = pickle.dumps(atom)
         unpickled = pickle.loads(pickled)
-
-        self.assertEqual(atom.symbol, unpickled.symbol)
-        self.assertEqual(atom.name, unpickled.name)
-        self.assertEqual(atom.bonds, unpickled.bonds)
-        self.assertEqual(atom._groups, unpickled._groups)
-        self.assertEqual(atom.ghost, unpickled.ghost)
-        self.assertEqual(atom.index, unpickled.index)
-        self.assertEqual(atom.parent, unpickled.parent)
+        self.assertEqual(repr(atom), repr(unpickled))
 
     def test_dunder_str(self):
         atom = ce.Atom(name='Hydrogen')
-        self.assertEqual(str(atom), 'Hydrogen')
+        self.assertEqual('Hydrogen', str(atom))
 
     def test_dunder_repr(self):
         atom = ce.Atom(name='Hydrogen', bonds=[ce.Atom(name='H5')])
-        self.assertEqual(repr(atom), "MDANSE.Chemistry.ChemicalEntity.Atom(parent=None, name='Hydrogen', "
-                                     "symbol='H', bonds=[Atom(H5)], groups=[], ghost=False, index=None)")
+        self.assertEqual("MDANSE.Chemistry.ChemicalEntity.Atom(parent=None, name='Hydrogen', symbol='H', "
+                         "bonds=[Atom(H5)], groups=[], ghost=False, index=None)", repr(atom))
 
     def test_atom_list_ghost_true(self):
         atom = ce.Atom(ghost=True)
         atom_list = atom.atom_list()
-        self.assertEqual(atom_list, [])
+        self.assertEqual([], atom_list)
 
     def test_atom_list_ghost_false(self):
         atom = ce.Atom(ghost=False)
         atom_list = atom.atom_list()
-        self.assertEqual(atom_list, [atom])
+        self.assertEqual([atom], atom_list)
 
     def test_total_number_of_atoms(self):
-        atom = ce.Atom()
-        n = atom.total_number_of_atoms()
-        self.assertEqual(n, 1)
+        atom = ce.Atom(ghost=False)
+        ghost = ce.Atom(ghost=True)
+        self.assertEqual(1, atom.total_number_of_atoms())
+        self.assertEqual(1, ghost.total_number_of_atoms())
 
     def test_number_of_atoms(self):
         atom = ce.Atom(ghost=False)
         ghost = ce.Atom(ghost=True)
 
-        self.assertEqual(atom.number_of_atoms(), 0)
-        self.assertEqual(ghost.number_of_atoms(), 1)
+        self.assertEqual(0, atom.number_of_atoms())
+        self.assertEqual(1, ghost.number_of_atoms())
 
     def test_bonds_setter(self):
         atom = ce.Atom()
-        atom.bonds = [ce.Atom(symbol='C')]
-        self.assertEqual(len(atom.bonds), 1)
-        self.assertEqual(atom.bonds[0].symbol, 'C')
-        self.assertEqual(atom.bonds[0].name, 'C')
-        self.assertEqual(atom.bonds[0].bonds, [])
-        self.assertEqual(atom.bonds[0]._groups, [])
-        self.assertEqual(atom.bonds[0].ghost, False)
-        self.assertEqual(atom.bonds[0].index, None)
-        self.assertEqual(atom.bonds[0].parent, None)
+        bond = ce.Atom(symbol='C')
+        atom.bonds = [bond]
+        self.assertEqual([bond], atom.bonds)
 
     def test_ghost_setter(self):
         atom = ce.Atom(ghost=False)
@@ -118,23 +110,23 @@ class TestAtom(unittest.TestCase):
     def test_index_setter_index_not_set(self):
         atom = ce.Atom()
         atom.index = 0
-        self.assertEqual(atom.index, 0)
+        self.assertEqual(0, atom.index)
 
     def test_index_setter_index_set(self):
         atom = ce.Atom(index=0)
         atom.index = 1
-        self.assertEqual(atom.index, 0)
+        self.assertEqual(0, atom.index)
 
     def test_name_setter(self):
-        atom = ce.Atom()
+        atom = ce.Atom(name='name')
         atom.name = 'Hydrogen'
-        self.assertEqual(atom.name, 'Hydrogen')
+        self.assertEqual('Hydrogen', atom.name)
 
     def test_symbol_setter(self):
-        atom = ce.Atom()
+        atom = ce.Atom(symbol='H')
         atom.symbol = 'C'
 
-        self.assertEqual(atom.symbol, 'C')
+        self.assertEqual('C', atom.symbol)
         with self.assertRaises(ce.UnknownAtomError):
             atom.symbol = 'CC'
 
@@ -145,6 +137,72 @@ class TestAtom(unittest.TestCase):
 
         self.assertEqual(result, ('atoms', 0))
         self.assertEqual(dictionary, {'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)']})
+
+
+class TestAtomGroup(unittest.TestCase):
+    def setUp(self):
+        self.atom1 = ce.Atom(name='H1')
+        self.atom2 = ce.Atom(name='H2')
+
+        self.system = ce.ChemicalSystem('name')
+        self.system.add_chemical_entity(self.atom1)
+        self.system.add_chemical_entity(self.atom2)
+
+        self.group = ce.AtomGroup([self.atom1, self.atom2])
+
+    def test_instantiation_valid(self):
+        self.assertEqual('', self.group.name)
+        self.assertEqual(None, self.group.parent)
+        self.assertEqual([self.atom1, self.atom2], self.group._atoms)
+        self.assertEqual(self.system, self.group._chemical_system)
+
+    def test_instantiation_invalid(self):
+        system2 = ce.ChemicalSystem('name')
+        system2.add_chemical_entity(self.atom2)
+
+        with self.assertRaises(ce.ChemicalEntityError):
+            ce.AtomGroup([self.atom1, self.atom2])
+
+    def test_pickling(self):
+        pickled = pickle.dumps(self.group)
+        unpickled = pickle.loads(pickled)
+
+        self.assertEqual('', unpickled.name)
+        self.assertEqual(None, unpickled.parent)
+        self.assertEqual(2, len(unpickled._atoms))
+        self.assertEqual(repr(self.atom1), repr(unpickled._atoms[0]))
+        self.assertEqual(repr(self.atom2), repr(unpickled._atoms[1]))
+        self.assertEqual(repr(self.system), repr(unpickled._chemical_system))
+
+    def test_duner_repr(self):
+        self.assertEqual("MDANSE.MolecularDynamics.ChemicalEntity.AtomGroup(parent=None, name='', atoms=[MDANSE."
+                         "Chemistry.ChemicalEntity.Atom(parent=MDANSE.Chemistry.ChemicalEntity.ChemicalSystem(name), "
+                         "name='H1', symbol='H', bonds=[], groups=[], ghost=False, index=0), MDANSE.Chemistry."
+                         "ChemicalEntity.Atom(parent=MDANSE.Chemistry.ChemicalEntity.ChemicalSystem(name), name='H2', "
+                         "symbol='H', bonds=[], groups=[], ghost=False, index=1)], chemical_system=MDANSE.Chemistry."
+                         "ChemicalEntity.ChemicalSystem(name))", repr(self.group))
+
+    def test_atom_list(self):
+        self.atom2._ghost = True
+        self.assertEqual([self.atom1], self.group.atom_list())
+
+    def test_copy(self):
+        self.assertEqual(None, self.group.copy())
+
+    def test_number_of_atoms(self):
+        self.atom2._ghost = True
+        self.assertEqual(1, self.group.number_of_atoms())
+        self.assertEqual(2, self.group.total_number_of_atoms())
+
+    def test_root_chemical_system(self):
+        self.assertEqual(repr(self.system), repr(self.group.root_chemical_system()))
+
+    def test_serialize(self):
+        dictionary = {}
+        result = self.group.serialize(dictionary)
+
+        self.assertEqual(None, result)
+        self.assertDictEqual({}, dictionary)
 
 
 @unittest.skip
@@ -1252,6 +1310,12 @@ class TestProtein(unittest.TestCase):
         chain = self.populate_protein()
         self.assertEqual(chain, self.protein[0])
 
+    def test_dunder_repr(self):
+        self.populate_protein()
+        self.assertEqual("MDANSE.MolecularDynamics.ChemicalEntity.Protein(parent=None, name='name', peptide_chains="
+                         "[MDANSE.MolecularDynamics.ChemicalEntity.PeptideChain(parent=MDANSE.Chemistry.ChemicalEntity."
+                         "Protein(name=name), name='name'", repr(self.protein)[:213])
+
     def test_atom_list(self):
         chain = self.populate_protein()
 
@@ -1382,6 +1446,24 @@ class TestChemicalSystem(unittest.TestCase):
         self.assertEqual(repr(molecule), repr(unpickled.chemical_entities[0]))
         self.assertEqual(None, unpickled._configuration)
         self.assertEqual(None, unpickled._atoms)
+
+    def test_dunder_repr(self):
+        molecule = ce.Molecule('WAT', 'name')
+        self.system.add_chemical_entity(molecule)
+
+        self.maxDiff = None
+        self.assertEqual("MDANSE.MolecularDynamics.ChemicalEntity.ChemicalSystem(parent=None, name='name', "
+                         "chemical_entities=[MDANSE.MolecularDynamics.ChemicalEntity.Molecule(parent=MDANSE.Chemistry."
+                         "ChemicalEntity.ChemicalSystem(name), name='name', atoms=OrderedDict([('OW', MDANSE.Chemistry."
+                         "ChemicalEntity.Atom(parent=MDANSE.Chemistry.ChemicalEntity.Molecule(name), name='OW', "
+                         "symbol='O', bonds=[Atom(HW1), Atom(HW2)], groups=[], ghost=False, index=0, alternatives="
+                         "['O', 'OH2'])), ('HW2', MDANSE.Chemistry.ChemicalEntity.Atom(parent=MDANSE.Chemistry."
+                         "ChemicalEntity.Molecule(name), name='HW2', symbol='H', bonds=[Atom(OW)], groups=[], "
+                         "ghost=False, index=1, alternatives=['H2'])), ('HW1', MDANSE.Chemistry.ChemicalEntity."
+                         "Atom(parent=MDANSE.Chemistry.ChemicalEntity.Molecule(name), name='HW1', symbol='H', bonds="
+                         "[Atom(OW)], groups=[], ghost=False, index=2, alternatives=['H1']))]), code='WAT')], "
+                         "configuration=None, number_of_atoms=3, total_number_of_atoms=3, atoms=None)",
+                         repr(self.system))
 
     def test_atom_list(self):
         atom1 = ce.Atom(ghost=False)

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -33,7 +33,7 @@ class TestAtom(unittest.TestCase):
         self.assertEqual(atom.parent, None)
 
     def test_correct_instantiation(self):
-        #user getitem
+        # user getitem
         atom = ce.Atom(symbol='C', name='carbon12')
 
     def test_undefined_element(self):
@@ -70,9 +70,9 @@ class TestAtom(unittest.TestCase):
         self.assertEqual(str(atom), 'Hydrogen')
 
     def test_dunder_repr(self):
-        atom = ce.Atom(name='Hydrogen')
+        atom = ce.Atom(name='Hydrogen', bonds=[ce.Atom(name='H5')])
         self.assertEqual(repr(atom), "MDANSE.Chemistry.ChemicalEntity.Atom(parent=None, name='Hydrogen', "
-                                     "symbol='H', bonds=[], groups=[], ghost=False, index=None)")
+                                     "symbol='H', bonds=[Atom(H5)], groups=[], ghost=False, index=None)")
 
     def test_atom_list_ghost_true(self):
         atom = ce.Atom(ghost=True)
@@ -145,7 +145,240 @@ class TestAtom(unittest.TestCase):
         self.assertEqual(dictionary, {'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)']})
 
 
-class TestAtomGroup(unittest.TestCase):
-    def test_empty_instantiation(self):
+@unittest.skip
+class TestAtomCluster(unittest.TestCase):
+    def test_valid_instantiation_parentful(self):
+        cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()])
+
+        self.assertEqual(None, cluster.parent)
+        self.assertEqual('Cluster1', cluster.name)
+        self.assertEqual(False, cluster._parentless)
+        self.assertEqual('H', cluster)
+        for atom in cluster._atoms.values():
+            self.assertEqual('H', atom.symbol)
+            self.assertEqual('H', atom.name)
+            self.assertEqual([], atom.bonds)
+            self.assertEqual([], atom._groups)
+            self.assertEqual(False, atom.ghost)
+            self.assertEqual(None, atom.index)
+            self.assertEqual(cluster, atom.parent)
+
+    def test_valid_instantiation_parentless(self):
+        cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()], parentless=True)
+
+        self.assertEqual(cluster.parent, None)
+        self.assertEqual(cluster.name, 'Cluster1')
+        self.assertEqual(cluster._parentless, True)
+        for atom in cluster._atoms:
+            self.assertEqual(atom.symbol, 'H')
+            self.assertEqual(atom.name, 'H')
+            self.assertEqual(atom.bonds, [])
+            self.assertEqual(atom._groups, [])
+            self.assertEqual(atom.ghost, False)
+            self.assertEqual(atom.index, None)
+            self.assertEqual(atom.parent, None)
+
+    def test_pickling(self):
+        cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()], parentless=True)
+
+        pickled = pickle.dumps(cluster)
+        unpickled = pickle.loads(pickled)
+
+        self.assertEqual(cluster.parent, unpickled.parent)
+        self.assertEqual(cluster.name, unpickled.name)
+        self.assertEqual(cluster._parentless, unpickled._parentless)
+        for atom, unpickled_atom in zip(cluster._atoms, unpickled._atoms):
+            self.assertEqual(atom.symbol, unpickled_atom.symbol)
+            self.assertEqual(atom.name, unpickled_atom.name)
+            self.assertEqual(atom.bonds, unpickled_atom.bonds)
+            self.assertEqual(atom._groups, unpickled_atom._groups)
+            self.assertEqual(atom.ghost, unpickled_atom.ghost)
+            self.assertEqual(atom.index, unpickled_atom.index)
+            self.assertEqual(atom.parent, unpickled_atom.parent)
+
+    def test_atom_list(self):
+        cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom(ghost=True)], parentless=True)
+
+        self.assertEqual(1, len(cluster.atom_list()))
+        for atom in cluster.atom_list():
+            self.assertEqual(atom.symbol, 'H')
+            self.assertEqual(atom.name, 'H')
+            self.assertEqual(atom.bonds, [])
+            self.assertEqual(atom._groups, [])
+            self.assertEqual(atom.ghost, False)
+            self.assertEqual(atom.index, None)
+            self.assertEqual(atom.parent, None)
+
+    def test_copy(self):
+        cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()], parentless=True)
+        copy = cluster.copy()
+
+        self.assertEqual(cluster.parent, copy.parent)
+        self.assertEqual(cluster.name, copy.name)
+        self.assertEqual(cluster._parentless, copy._parentless)
+        for atom, copied_atom in zip(cluster._atoms, copy._atoms):
+            self.assertEqual(atom.symbol, copied_atom.symbol)
+            self.assertEqual(atom.name, copied_atom.name)
+            self.assertEqual(atom.bonds, copied_atom.bonds)
+            self.assertEqual(atom._groups, copied_atom._groups)
+            self.assertEqual(atom.ghost, copied_atom.ghost)
+            self.assertEqual(atom.index, copied_atom.index)
+            # self.assertEqual(atom.parent, copied_atom.parent)
+
+    def test_number_of_atoms(self):
+        cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()], parentless=True)
+        ghost_cluster = ce.AtomCluster('Cluster1', [ce.Atom(ghost=True), ce.Atom(ghost=True)], parentless=True)
+
+        self.assertEqual(2, cluster.number_of_atoms())
+        self.assertEqual(0, ghost_cluster.number_of_atoms())
+
+    def test_total_number_of_atoms(self):
+        cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()], parentless=True)
+        ghost_cluster = ce.AtomCluster('Cluster1', [ce.Atom(ghost=True), ce.Atom(ghost=True)], parentless=True)
+
+        self.assertEqual(2, cluster.total_number_of_atoms())
+        self.assertEqual(2, ghost_cluster.total_number_of_atoms())
+
+    def test_reorder_atoms_exception(self):
+        cluster = ce.AtomCluster('Cluster1', [ce.Atom(symbol='H'), ce.Atom(symbol='C')], parentless=True)
+        with self.assertRaises(ce.InconsistentAtomNamesError):
+            cluster.reorder_atoms(['H', 'H'])
+
+    def test_reorder_atoms_valid(self):
+        cluster = ce.AtomCluster('Cluster1', [ce.Atom(symbol='H'), ce.Atom(symbol='C')], parentless=True)
+        cluster.reorder_atoms(['C', 'H'])
 
 
+class TestMolecule(unittest.TestCase):
+    def setUp(self):
+        self.molecule = ce.Molecule('WAT', 'water')
+
+    def compare_two_molecules(self, molecule: ce.Molecule):
+        self.assertEqual(None, molecule.parent)
+        self.assertEqual('water', molecule.name)
+        self.assertEqual('WAT', molecule.code)
+
+        for name, reference_name in zip(molecule._atoms.keys(), ['OW', 'HW2', 'HW1']):
+            self.assertEqual(reference_name, name)
+
+        self.compare_atoms(molecule._atoms, molecule)
+
+    def compare_atoms(self, atom_list, parent: ce.Molecule):
+        try:
+            atom = atom_list['OW']
+        except TypeError:
+            atom = atom_list[0]
+        self.assertEqual('O', atom.symbol)
+        self.assertEqual('OW', atom.name)
+        self.assertEqual(2, len(atom.bonds))
+        self.assertEqual(parent._atoms['HW1'], atom.bonds[0])
+        self.assertEqual(parent._atoms['HW2'], atom.bonds[1])
+        self.assertEqual([], atom._groups)
+        self.assertEqual(False, atom.ghost)
+        self.assertEqual(None, atom.index)
+        self.assertEqual(parent, atom.parent)
+
+        try:
+            atom = atom_list['HW1']
+        except TypeError:
+            atom = atom_list[2]
+        self.assertEqual('H', atom.symbol)
+        self.assertEqual('HW1', atom.name)
+        self.assertEqual(1, len(atom.bonds))
+        self.assertEqual(parent._atoms['OW'], atom.bonds[0])
+        self.assertEqual([], atom._groups)
+        self.assertEqual(False, atom.ghost)
+        self.assertEqual(None, atom.index)
+        self.assertEqual(parent, atom.parent)
+
+        try:
+            atom = atom_list['HW2']
+        except TypeError:
+            atom = atom_list[1]
+        self.assertEqual('H', atom.symbol)
+        self.assertEqual('HW2', atom.name)
+        self.assertEqual(1, len(atom.bonds))
+        self.assertEqual(parent._atoms['OW'], atom.bonds[0])
+        self.assertEqual([], atom._groups)
+        self.assertEqual(False, atom.ghost)
+        self.assertEqual(None, atom.index)
+        self.assertEqual(parent, atom.parent)
+
+    def test_valid_molecule_instantiation(self):
+        self.compare_two_molecules(self.molecule)
+
+    def test_unregistered_molecule_instantiation(self):
+        with self.assertRaises(ce.UnknownMoleculeError):
+            ce.Molecule('000000', '000000')
+
+    def test_dunder_getitem(self):
+        self.assertEqual(self.molecule._atoms['OW'], self.molecule['OW'])
+
+    def test_pickling(self):
+        pickled = pickle.dumps(self.molecule)
+        unpickled = pickle.loads(pickled)
+
+        self.compare_two_molecules(unpickled)
+
+    def test_dunder_repr(self):
+        self.assertEqual("MDANSE.MolecularDynamics.ChemicalEntity.Molecule(parent=None, name='water', "
+                         "atoms=OrderedDict([('OW', MDANSE.Chemistry.ChemicalEntity.Atom(parent=MDANSE.Chemistry."
+                         "ChemicalEntity.Molecule(water), name='OW', symbol='O', bonds=[Atom(HW1), Atom(HW2)], "
+                         "groups=[], ghost=False, index=None, alternatives=['O', 'OH2'])), ('HW2', MDANSE.Chemistry."
+                         "ChemicalEntity.Atom(parent=MDANSE.Chemistry.ChemicalEntity.Molecule(water), name='HW2', "
+                         "symbol='H', bonds=[Atom(OW)], groups=[], ghost=False, index=None, alternatives=['H2'])), "
+                         "('HW1', MDANSE.Chemistry.ChemicalEntity.Atom(parent=MDANSE.Chemistry.ChemicalEntity."
+                         "Molecule(water), name='HW1', symbol='H', bonds=[Atom(OW)], groups=[], ghost=False, index=None"
+                         ", alternatives=['H1']))]), code='WAT')", repr(self.molecule))
+
+    def test_atom_list(self):
+        self.assertEqual(3, len(self.molecule.atom_list()))
+        self.compare_atoms(self.molecule.atom_list(), self.molecule)
+
+    def test_copy(self):
+        copy = self.molecule.copy()
+        self.compare_two_molecules(copy)
+
+    def test_number_of_atoms(self):
+        self.assertEqual(3, self.molecule.number_of_atoms())
+
+    def test_total_number_of_atoms(self):
+        self.assertEqual(3, self.molecule.total_number_of_atoms())
+
+    def test_reorder_atoms_invalid_input(self):
+        with self.assertRaises(ce.InconsistentAtomNamesError):
+            self.molecule.reorder_atoms(['O', 'H', 'H'])
+
+    def test_reorder_atoms_valid_input(self):
+        self.molecule.reorder_atoms(['HW1', 'HW2', 'OW'])
+        self.assertEqual('HW1', self.molecule.atom_list()[0].name)
+        self.assertEqual('HW2', self.molecule.atom_list()[1].name)
+        self.assertEqual('OW', self.molecule.atom_list()[2].name)
+
+    def test_serialize_from_empty_dict(self):
+        dictionary = {}
+        result = self.molecule.serialize(dictionary)
+
+        self.assertEqual(('molecules', 0), result)
+        self.assertDictEqual({'molecules': ['H5Molecule(self._h5_file,h5_contents,[0, 1, 2],code="WAT",name="water")'],
+                              'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="O", name="OW", ghost=False)',
+                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HW2", ghost=False)',
+                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HW1", ghost=False)']},
+                             dictionary)
+
+    def test_serialize_from_nonempty_dict(self):
+        dictionary = {'atoms': ['', '']}
+        result = self.molecule.serialize(dictionary)
+
+        self.assertEqual(('molecules', 0), result)
+        self.assertDictEqual({'atoms': ['', '',
+                                        'H5Atom(self._h5_file,h5_contents,symbol="O", name="OW", ghost=False)',
+                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HW2", ghost=False)',
+                                        'H5Atom(self._h5_file,h5_contents,symbol="H", name="HW1", ghost=False)'],
+                             'molecules': ['H5Molecule(self._h5_file,h5_contents,[2, 3, 4],code="WAT",name="water")']},
+                             dictionary)
+
+
+# class TestAtomGroup(unittest.TestCase):
+#     def test_valid_instantiation(self):
+#         group = ce.AtomGroup()

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -920,9 +920,95 @@ class TestNucleotideChain(unittest.TestCase):
     def test_dunder_repr(self):
         n1, n2 = self.prepare_nucleotides()
         self.chain.set_nucleotides([n1, n2])
-        print(repr(self.chain))
+
         self.maxDiff = None
-        self.assertEqual('', repr(self.chain))
+        self.assertEqual("MDANSE.MolecularDynamics.ChemicalEntity.NucleotideChain(parent=None, name='name', "
+                         "nucleotides=[MDANSE.MolecularDynamics.ChemicalEntity.Nucleotide(parent=MDANSE.Chemistry."
+                         "ChemicalEntity.NucleotideChain(name=name), name='adenine', resname='A', code='A', "
+                         "variant='5T1', selected_variant={'is_3ter_terminus': False, 'atoms':",
+                         repr(self.chain)[:320])
+
+    def test_bases(self):
+        n1, n2 = self.prepare_nucleotides()
+        self.chain.set_nucleotides([n1, n2])
+
+        self.assertEqual([n1['C8'], n1['C2'], n1['C6'], n1['C5'], n1['C4'], n1['N9'], n1['N1'], n1['N3'], n1['N6'],
+                          n1['N7'], n1['H8'], n1['H2'], n1['H61'], n1['H62'], n2['C8'], n2['C2'], n2['C6'], n2['C5'],
+                          n2['C4'], n2['N9'], n2['N1'], n2['N3'], n2['N6'], n2['N7'], n2['H8'], n2['H2'], n2['H61'],
+                          n2['H62']], self.chain.bases)
+
+    def test_copy(self):
+        n1, n2 = self.prepare_nucleotides()
+        self.chain.set_nucleotides([n1, n2])
+        copy = self.chain.copy()
+
+        self.assertEqual(repr(self.chain), repr(copy))
+
+    def test_residues(self):
+        n1, n2 = self.prepare_nucleotides()
+        self.chain.set_nucleotides([n1, n2])
+
+        self.assertEqual([n1, n2], self.chain.residues)
+
+    def test_number_of_atoms(self):
+        n1, n2 = self.prepare_nucleotides()
+        self.chain.set_nucleotides([n1, n2])
+
+        self.assertEqual(65, self.chain.number_of_atoms())
+        self.assertEqual(65, self.chain.total_number_of_atoms())
+
+    def test_serialize_empty_dict(self):
+        n1, n2 = self.prepare_nucleotides()
+        self.chain.set_nucleotides([n1, n2])
+        dictionary = {}
+        result = self.chain.serialize(dictionary)
+
+        self.maxDiff = None
+        self.assertEqual(('nucleotide_chains', 0), result)
+        self.assertDictEqual({'nucleotides': ['H5Nucleotide(self._h5_file,h5_contents,[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, '
+                                              '10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, '
+                                              '28, 29, 30],code="A",name="adenine",variant=\'5T1\')',
+                                              'H5Nucleotide(self._h5_file,h5_contents,[31, 32, 33, 34, 35, 36, 37, 38, '
+                                              '39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, '
+                                              '57, 58, 59, 60, 61, 62, 63, 64],code="A",name="adenine",'
+                                              'variant=\'3T1\')'],
+                              'atoms': [f'H5Atom(self._h5_file,h5_contents,symbol="{i}", name="{j}", ghost=False)'
+                                        for i, j in zip(['C', 'C', 'C', 'H', 'H', 'H', 'O', 'C', 'C', 'H', 'C', 'C',
+                                                         'C', 'H', 'H', 'N', 'C', 'C', 'O', 'N', 'N', 'N', 'N', 'H',
+                                                         'H', 'H', 'O', 'H', 'H', 'O', 'H', 'C', 'C', 'C', 'H', 'H',
+                                                         'H', 'O', 'C', 'C', 'H', 'C', 'C', 'C', 'H', 'H', 'N', 'C',
+                                                         'C', 'O', 'N', 'N', 'N', 'N', 'H', 'H', 'H', 'O', 'H', 'H',
+                                                         'O', 'H', 'O', 'O', 'P'],
+                                                        ['C3\'', 'C1\'', 'C5\'', 'H2\'', 'H5\'', 'H3\'', 'O4\'', 'C8',
+                                                         'C2', 'H1\'', 'C6', 'C5', 'C4', 'H5\'\'', 'HO2\'', 'N9',
+                                                         'C4\'', 'C2\'', 'O2\'', 'N1', 'N3', 'N6', 'N7', 'H4\'', 'H8',
+                                                         'H2', 'O5\'', 'H61', 'H62', 'O3\'', 'HO5\'', 'C3\'', 'C1\'',
+                                                         'C5\'', 'H2\'', 'H5\'', 'H3\'', 'O4\'', 'C8', 'C2', 'H1\'',
+                                                         'C6', 'C5', 'C4', 'H5\'\'', 'HO2\'', 'N9', 'C4\'', 'C2\'',
+                                                         'O2\'', 'N1', 'N3', 'N6', 'N7', 'H4\'', 'H8', 'H2', 'O5\'',
+                                                         'H61', 'H62', 'O3\'', 'HO3\'', 'OP1', 'OP2', 'P'])],
+                              'nucleotide_chains': ['H5NucleotideChain(self._h5_file,h5_contents,"name",[0, 1])']},
+                             dictionary)
+
+    def test_serialize_nonempty_dict(self):
+        n1, n2 = self.prepare_nucleotides()
+        self.chain.set_nucleotides([n1, n2])
+        dictionary = {'nucleotides': ['', '', ''], 'nucleotide_chains': ['']}
+        result = self.chain.serialize(dictionary)
+
+        self.assertEqual(('nucleotide_chains', 1), result)
+        self.assertEqual(['', 'H5NucleotideChain(self._h5_file,h5_contents,"name",[3, 4])'],
+                         dictionary['nucleotide_chains'])
+
+    def test_sugars(self):
+        n1, n2 = self.prepare_nucleotides()
+        self.chain.set_nucleotides([n1, n2])
+
+        self.assertEqual([n1["C3'"], n1["C1'"], n1["C5'"], n1["H2'"], n1["H5'"], n1["H3'"], n1["O4'"], n1["H1'"],
+                          n1["H5''"], n1["HO2'"], n1["C4'"], n1["C2'"], n1["O2'"], n1["H4'"], n2["C3'"], n2["C1'"],
+                          n2["C5'"], n2["H2'"], n2["H5'"], n2["H3'"], n2["O4'"], n2["H1'"], n2["H5''"], n2["HO2'"],
+                          n2["C4'"], n2["C2'"], n2["O2'"], n2["H4'"]],
+                         self.chain.sugars)
 
 
 # class TestAtomGroup(unittest.TestCase):

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -17,7 +17,7 @@ import pickle
 from typing import Union
 import unittest
 
-from MDANSE.Chemistry import RESIDUES_DATABASE, NUCLEOTIDES_DATABASE
+from MDANSE.Chemistry import MOLECULES_DATABASE, RESIDUES_DATABASE, NUCLEOTIDES_DATABASE
 import MDANSE.Chemistry.ChemicalEntity as ce
 
 
@@ -1316,3 +1316,25 @@ class TestProtein(unittest.TestCase):
     def test_sidechains(self):
         chain = self.populate_protein()
         self.assertEqual([chain[0]['HA3'], chain[1]['HA3']], self.protein.sidechains)
+
+
+class TestTranslateAtomNames(unittest.TestCase):
+    def test_valid(self):
+        result = ce.translate_atom_names(MOLECULES_DATABASE, 'WAT', ['O', 'HW2', 'H1'])
+        self.assertEqual(['OW', 'HW2', 'HW1'], result)
+
+    def test_subset_of_all_atoms(self):
+        result = ce.translate_atom_names(MOLECULES_DATABASE, 'WAT', ['O', 'HW2'])
+        self.assertEqual(['OW', 'HW2'], result)
+
+    def test_multiple_of_one_atom(self):
+        result = ce.translate_atom_names(MOLECULES_DATABASE, 'WAT', ['O', 'HW2', 'HW2', 'HW2', 'HW2'])
+        self.assertEqual(['OW', 'HW2', 'HW2', 'HW2', 'HW2'], result)
+
+    def test_invalid_molname(self):
+        with self.assertRaises(ce.UnknownMoleculeError):
+            ce.translate_atom_names(MOLECULES_DATABASE, '00000', ['OW', 'HW1', 'HW2'])
+
+    def test_invalid_atom(self):
+        with self.assertRaises(ce.UnknownAtomError):
+            ce.translate_atom_names(MOLECULES_DATABASE, 'WAT', [''])

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -135,8 +135,8 @@ class TestAtom(unittest.TestCase):
         dictionary = {}
         result = atom.serialize(dictionary)
 
-        self.assertEqual(result, ('atoms', 0))
-        self.assertEqual(dictionary, {'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)']})
+        self.assertEqual(('atoms', 0), result)
+        self.assertEqual({'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)']}, dictionary)
 
 
 class TestAtomGroup(unittest.TestCase):
@@ -210,34 +210,26 @@ class TestAtomGroup(unittest.TestCase):
 
 class TestAtomCluster(unittest.TestCase):
     def test_valid_instantiation_parentful(self):
-        cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()])
+        atom1 = ce.Atom()
+        atom2 = ce.Atom()
+        cluster = ce.AtomCluster('Cluster1', [atom1, atom2])
 
         self.assertEqual(None, cluster.parent)
         self.assertEqual('Cluster1', cluster.name)
         self.assertEqual(False, cluster._parentless)
-        for atom in cluster._atoms:
-            self.assertEqual('H', atom.symbol)
-            self.assertEqual('H', atom.name)
-            self.assertEqual([], atom.bonds)
-            self.assertEqual([], atom._groups)
-            self.assertEqual(False, atom.ghost)
-            self.assertEqual(None, atom.index)
-            self.assertEqual(cluster, atom.parent)
+        self.assertEqual([atom1, atom2], cluster._atoms)
+        self.assertEqual(cluster, cluster._atoms[0].parent)
 
     def test_valid_instantiation_parentless(self):
-        cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()], parentless=True)
+        atom1 = ce.Atom()
+        atom2 = ce.Atom()
+        cluster = ce.AtomCluster('Cluster1', [atom1, atom2], parentless=True)
 
-        self.assertEqual(cluster.parent, None)
-        self.assertEqual(cluster.name, 'Cluster1')
-        self.assertEqual(cluster._parentless, True)
-        for atom in cluster._atoms:
-            self.assertEqual(atom.symbol, 'H')
-            self.assertEqual(atom.name, 'H')
-            self.assertEqual(atom.bonds, [])
-            self.assertEqual(atom._groups, [])
-            self.assertEqual(atom.ghost, False)
-            self.assertEqual(atom.index, None)
-            self.assertEqual(atom.parent, None)
+        self.assertEqual(None, cluster.parent)
+        self.assertEqual('Cluster1', cluster.name)
+        self.assertEqual(True, cluster._parentless)
+        self.assertEqual([atom1, atom2], cluster._atoms)
+        self.assertEqual(None, cluster._atoms[0].parent)
 
     def test_pickling(self):
         cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()], parentless=True)

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -182,6 +182,9 @@ class TestAtomGroup(unittest.TestCase):
                          "symbol='H', bonds=[], groups=[], ghost=False, index=1)], chemical_system=MDANSE.Chemistry."
                          "ChemicalEntity.ChemicalSystem(name))", repr(self.group))
 
+    def test_dunder_str(self):
+        self.assertEqual('AtomGroup consisting of 2 atoms', str(self.group))
+
     def test_atom_list(self):
         self.atom2._ghost = True
         self.assertEqual([self.atom1], self.group.atom_list())
@@ -259,6 +262,10 @@ class TestAtomCluster(unittest.TestCase):
                          "symbol='H', bonds=[], groups=[], ghost=False, index=None), MDANSE.Chemistry.ChemicalEntity."
                          "Atom(parent=None, name='H', symbol='H', bonds=[], groups=[], ghost=False, index=None)])",
                          repr(cluster))
+
+    def test_dunder_str(self):
+        cluster = ce.AtomCluster('Cluster1', [ce.Atom(), ce.Atom()], parentless=True)
+        self.assertEqual('AtomCluster consisting of 2 atoms', str(cluster))
 
     def test_atom_list(self):
         atom = ce.Atom()
@@ -402,6 +409,9 @@ class TestMolecule(unittest.TestCase):
                          "('HW1', MDANSE.Chemistry.ChemicalEntity.Atom(parent=MDANSE.Chemistry.ChemicalEntity."
                          "Molecule(water), name='HW1', symbol='H', bonds=[Atom(OW)], groups=[], ghost=False, index=None"
                          ", alternatives=['H1']))]), code='WAT')", repr(self.molecule))
+
+    def test_dunder_str(self):
+        self.assertEqual('Molecule of water (database code "WAT")', str(self.molecule))
 
     def test_atom_list(self):
         self.assertEqual(3, len(self.molecule.atom_list()))
@@ -663,6 +673,11 @@ class TestResidue(unittest.TestCase):
                          "Atom(+R)], groups=['backbone', 'peptide'], ghost=False, index=None, alternatives=[]))]))",
                          repr(residue))
 
+    def test_dunder_str(self):
+        residue = ce.Residue('GLY', 'glycine', None)
+        residue.set_atoms(['H', 'HA3', 'O', 'N', 'CA', 'HA2', 'C'])
+        self.assertEqual('Amino acid Residue glycine (database code "GLY")', str(residue))
+
     def test_atom_list(self):
         residue = ce.Residue('GLY', 'glycine', None)
         residue.set_atoms(['H', 'HA3', 'O', 'N', 'CA', 'HA2', 'C'])
@@ -841,6 +856,11 @@ class TestNucleotide(unittest.TestCase):
                          '"HO5\'", symbol=\'H\', bonds=[Atom(O5\')], groups=[], ghost=False, index=None, replaces='
                          '[\'OP1\', \'OP2\', \'P\'], o5prime_connected=True, alternatives=[]))]))',
                          repr(nucleotide))
+
+    def test_dunder_str(self):
+        nucleotide = ce.Nucleotide('5T1', '5T1', None)
+        nucleotide.set_atoms(['HO5\''])
+        self.assertEqual('Nucleotide 5T1 (database code "5T1")', str(nucleotide))
 
     def test_copy(self):
         nucleotide = ce.Nucleotide('5T1', '5T1', None)
@@ -1328,6 +1348,10 @@ class TestProtein(unittest.TestCase):
                          "[MDANSE.MolecularDynamics.ChemicalEntity.PeptideChain(parent=MDANSE.Chemistry.ChemicalEntity."
                          "Protein(name=name), name='name'", repr(self.protein)[:213])
 
+    def test_dunder_str(self):
+        self.populate_protein()
+        self.assertEqual('Protein name consisting of 1 peptide chains', str(self.protein))
+
     def test_atom_list(self):
         chain = self.populate_protein()
 
@@ -1476,6 +1500,13 @@ class TestChemicalSystem(unittest.TestCase):
                          "[Atom(OW)], groups=[], ghost=False, index=2, alternatives=['H1']))]), code='WAT')], "
                          "configuration=None, number_of_atoms=3, total_number_of_atoms=3, atoms=None)",
                          repr(self.system))
+
+    def test_dunder_str(self):
+        atom1 = ce.Atom(ghost=False)
+        atom2 = ce.Atom(ghost=False)
+        cluster = ce.AtomCluster('name', [atom1, atom2])
+        self.system.add_chemical_entity(cluster)
+        self.assertEqual('ChemicalSystem name consisting of 1 chemical entities', str(self.system))
 
     def test_atom_list(self):
         atom1 = ce.Atom(ghost=False)

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -529,6 +529,31 @@ class TestResidue(unittest.TestCase):
         with self.assertRaises(ce.InconsistentAtomNamesError):
             residue.set_atoms([])
 
+    def test_set_atoms_variant(self):
+        residue = ce.Residue('GLY', 'glycine', 'CT1')
+        residue.set_atoms(['H', 'HA3', 'O', 'N', 'CA', 'HA2', 'C', 'OXT'])
+        selected_variant = RESIDUES_DATABASE['CT1']
+        selected_variant['atoms']['OXT']['bonds'] = [residue._atoms['C']]
+
+        self.maxDiff = None
+        self.assertEqual('glycine', residue.name)
+        self.assertEqual(None, residue.parent)
+        self.assertEqual('GLY', residue.code)
+        self.assertEqual('CT1', residue._variant)
+        self.assertDictEqual(selected_variant, residue._selected_variant)
+
+        self.compare_atoms(residue._atoms, residue)
+
+        atom = residue._atoms['OXT']
+        self.assertEqual('O', atom.symbol)
+        self.assertEqual('OXT', atom.name)
+        self.assertEqual(1, len(atom.bonds))
+        self.assertEqual(residue._atoms['C'], atom.bonds[0])
+        self.assertEqual(['backbone'], atom._groups)
+        self.assertEqual(False, atom.ghost)
+        self.assertEqual(None, atom.index)
+        self.assertEqual(residue, atom.parent)
+
     def test_pickling(self):
         residue = ce.Residue('GLY', 'glycine', None)
         residue.set_atoms(['H', 'HA3', 'O', 'N', 'CA', 'HA2', 'C'])
@@ -543,6 +568,30 @@ class TestResidue(unittest.TestCase):
         residue = ce.Residue('GLY', 'glycine', None)
         residue.set_atoms(['H', 'HA3', 'O', 'N', 'CA', 'HA2', 'C'])
         self.compare_atoms(residue, residue)
+
+    def test_dunder_repr(self):
+        residue = ce.Residue('GLY', 'glycine', None)
+        residue.set_atoms(['H', 'HA3', 'O', 'N', 'CA', 'HA2', 'C'])
+        self.assertEqual("MDANSE.MolecularDynamics.ChemicalEntity.Residue(parent=None, name='glycine', code='GLY', "
+                         "variant=None, selected_variant=None, atoms=OrderedDict([('H', MDANSE.Chemistry.ChemicalEntity"
+                         ".Atom(parent=MDANSE.Chemistry.ChemicalEntity.Residue(glycine), name='H', symbol='H', bonds="
+                         "[Atom(N)], groups=['backbone', 'peptide'], ghost=False, index=None, alternatives=['HN'])), "
+                         "('HA3', MDANSE.Chemistry.ChemicalEntity.Atom(parent=MDANSE.Chemistry.ChemicalEntity.Residue"
+                         "(glycine), name='HA3', symbol='H', bonds=[Atom(CA)], groups=['sidechain'], ghost=False, "
+                         "index=None, alternatives=['HA1'])), ('O', MDANSE.Chemistry.ChemicalEntity.Atom(parent=MDANSE"
+                         ".Chemistry.ChemicalEntity.Residue(glycine), name='O', symbol='O', bonds=[Atom(C)], groups="
+                         "['backbone', 'peptide'], ghost=False, index=None, alternatives=['OT1'])), ('N', MDANSE."
+                         "Chemistry.ChemicalEntity.Atom(parent=MDANSE.Chemistry.ChemicalEntity.Residue(glycine), name="
+                         "'N', symbol='N', bonds=[Atom(CA), Atom(H), Atom(-R)], groups=['backbone', 'peptide'], ghost="
+                         "False, index=None, alternatives=[])), ('CA', MDANSE.Chemistry.ChemicalEntity.Atom(parent="
+                         "MDANSE.Chemistry.ChemicalEntity.Residue(glycine), name='CA', symbol='C', bonds=[Atom(C), "
+                         "Atom(HA2), Atom(HA3), Atom(N)], groups=['backbone'], ghost=False, index=None, alternatives="
+                         "[])), ('HA2', MDANSE.Chemistry.ChemicalEntity.Atom(parent=MDANSE.Chemistry.ChemicalEntity."
+                         "Residue(glycine), name='HA2', symbol='H', bonds=[Atom(CA)], groups=['backbone'], ghost=False,"
+                         " index=None, alternatives=['HA'])), ('C', MDANSE.Chemistry.ChemicalEntity.Atom(parent=MDANSE"
+                         ".Chemistry.ChemicalEntity.Residue(glycine), name='C', symbol='C', bonds=[Atom(CA), Atom(O), "
+                         "Atom(+R)], groups=['backbone', 'peptide'], ghost=False, index=None, alternatives=[]))]))",
+                         repr(residue))
 
     def test_atom_list(self):
         residue = ce.Residue('GLY', 'glycine', None)
@@ -711,6 +760,17 @@ class TestNucleotide(unittest.TestCase):
 
         self.compare_base_residues(unpickled, False)
         self.compare_atoms_in_5t1(unpickled._atoms, unpickled)
+
+    def test_dunder_repr(self):
+        nucleotide = ce.Nucleotide('5T1', '5T1', None)
+        nucleotide.set_atoms(['HO5\''])
+
+        self.assertEqual('MDANSE.MolecularDynamics.ChemicalEntity.Nucleotide(parent=None, name=\'5T1\', resname=\'5T1\''
+                         ', code=\'5T1\', variant=None, selected_variant=None, atoms=OrderedDict([("HO5\'", MDANSE.'
+                         'Chemistry.ChemicalEntity.Atom(parent=MDANSE.Chemistry.ChemicalEntity.Nucleotide(5T1), name='
+                         '"HO5\'", symbol=\'H\', bonds=[Atom(O5\')], groups=[], ghost=False, index=None, replaces='
+                         '[\'OP1\', \'OP2\', \'P\'], o5prime_connected=True, alternatives=[]))]))',
+                         repr(nucleotide))
 
     def test_copy(self):
         nucleotide = ce.Nucleotide('5T1', '5T1', None)

--- a/Tests/UnitTests/TestChemicalEntity.py
+++ b/Tests/UnitTests/TestChemicalEntity.py
@@ -1,0 +1,151 @@
+# **************************************************************************
+#
+# MDANSE: Molecular Dynamics Analysis for Neutron Scattering Experiments
+#
+# @file      Tests/UnitTests/TestElementsDatabase.py
+# @brief     Implements module/class/test TestElementsDatabase
+#
+# @homepage  https://mdanse.org
+# @license   GNU General Public License v3 or higher (see LICENSE)
+# @copyright Institut Laue Langevin 2013-now
+# @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now
+# @authors   Scientific Computing Group at ILL (see AUTHORS)
+#
+# **************************************************************************
+
+import pickle
+import unittest
+
+import MDANSE.Chemistry.ChemicalEntity as ce
+
+
+class TestAtom(unittest.TestCase):
+
+    def test_empty_instantiation(self):
+        atom = ce.Atom()
+
+        self.assertEqual(atom.symbol, 'H')
+        self.assertEqual(atom.name, 'H')
+        self.assertEqual(atom.bonds, [])
+        self.assertEqual(atom._groups, [])
+        self.assertEqual(atom.ghost, False)
+        self.assertEqual(atom.index, None)
+        self.assertEqual(atom.parent, None)
+
+    def test_correct_instantiation(self):
+        #user getitem
+        atom = ce.Atom(symbol='C', name='carbon12')
+
+    def test_undefined_element(self):
+        with self.assertRaises(ce.UnknownAtomError):
+            ce.Atom(symbol='CC')
+
+    def test_copy(self):
+        atom = ce.Atom()
+        copy = atom.copy()
+
+        self.assertEqual(atom.symbol, copy.symbol)
+        self.assertEqual(atom.name, copy.name)
+        self.assertEqual(atom.bonds, copy.bonds)
+        self.assertEqual(atom._groups, copy._groups)
+        self.assertEqual(atom.ghost, copy.ghost)
+        self.assertEqual(atom.index, copy.index)
+        self.assertEqual(atom.parent, copy.parent)
+
+    def test_pickling(self):
+        atom = ce.Atom()
+        pickled = pickle.dumps(atom)
+        unpickled = pickle.loads(pickled)
+
+        self.assertEqual(atom.symbol, unpickled.symbol)
+        self.assertEqual(atom.name, unpickled.name)
+        self.assertEqual(atom.bonds, unpickled.bonds)
+        self.assertEqual(atom._groups, unpickled._groups)
+        self.assertEqual(atom.ghost, unpickled.ghost)
+        self.assertEqual(atom.index, unpickled.index)
+        self.assertEqual(atom.parent, unpickled.parent)
+
+    def test_dunder_str(self):
+        atom = ce.Atom(name='Hydrogen')
+        self.assertEqual(str(atom), 'Hydrogen')
+
+    def test_dunder_repr(self):
+        atom = ce.Atom(name='Hydrogen')
+        self.assertEqual(repr(atom), "MDANSE.Chemistry.ChemicalEntity.Atom(parent=None, name='Hydrogen', "
+                                     "symbol='H', bonds=[], groups=[], ghost=False, index=None)")
+
+    def test_atom_list_ghost_true(self):
+        atom = ce.Atom(ghost=True)
+        atom_list = atom.atom_list()
+        self.assertEqual(atom_list, [])
+
+    def test_atom_list_ghost_false(self):
+        atom = ce.Atom(ghost=False)
+        atom_list = atom.atom_list()
+        self.assertEqual(atom_list, [atom])
+
+    def test_total_number_of_atoms(self):
+        atom = ce.Atom()
+        n = atom.total_number_of_atoms()
+        self.assertEqual(n, 1)
+
+    def test_number_of_atoms(self):
+        atom = ce.Atom(ghost=False)
+        ghost = ce.Atom(ghost=True)
+
+        self.assertEqual(atom.number_of_atoms(), 0)
+        self.assertEqual(ghost.number_of_atoms(), 1)
+
+    def test_bonds_setter(self):
+        atom = ce.Atom()
+        atom.bonds = [ce.Atom(symbol='C')]
+        self.assertEqual(len(atom.bonds), 1)
+        self.assertEqual(atom.bonds[0].symbol, 'C')
+        self.assertEqual(atom.bonds[0].name, 'C')
+        self.assertEqual(atom.bonds[0].bonds, [])
+        self.assertEqual(atom.bonds[0]._groups, [])
+        self.assertEqual(atom.bonds[0].ghost, False)
+        self.assertEqual(atom.bonds[0].index, None)
+        self.assertEqual(atom.bonds[0].parent, None)
+
+    def test_ghost_setter(self):
+        atom = ce.Atom(ghost=False)
+        atom.ghost = True
+        self.assertTrue(atom.ghost)
+
+    def test_index_setter_index_not_set(self):
+        atom = ce.Atom()
+        atom.index = 0
+        self.assertEqual(atom.index, 0)
+
+    def test_index_setter_index_set(self):
+        atom = ce.Atom(index=0)
+        atom.index = 1
+        self.assertEqual(atom.index, 0)
+
+    def test_name_setter(self):
+        atom = ce.Atom()
+        atom.name = 'Hydrogen'
+        self.assertEqual(atom.name, 'Hydrogen')
+
+    def test_symbol_setter(self):
+        atom = ce.Atom()
+        atom.symbol = 'C'
+
+        self.assertEqual(atom.symbol, 'C')
+        with self.assertRaises(ce.UnknownAtomError):
+            atom.symbol = 'CC'
+
+    def test_serialize(self):
+        atom = ce.Atom()
+        dictionary = {}
+        result = atom.serialize(dictionary)
+
+        self.assertEqual(result, ('atoms', 0))
+        self.assertEqual(dictionary, {'atoms': ['H5Atom(self._h5_file,h5_contents,symbol="H", name="H", ghost=False)']})
+
+
+class TestAtomGroup(unittest.TestCase):
+    def test_empty_instantiation(self):
+
+

--- a/Tests/UnitTests/TestPDBReader.py
+++ b/Tests/UnitTests/TestPDBReader.py
@@ -65,11 +65,11 @@ class TestPDBReader(unittest.TestCase):
 
         chemicalSystem = reader.build_chemical_system()
 
-        atomList = chemicalSystem.atom_list()
+        atomList = chemicalSystem.atom_list
 
         self.assertEqual(atomList[4].symbol,'C')
         self.assertEqual(atomList[7].name,'HB2')
-        self.assertEqual(atomList[10].full_name(),'.LYS1.HG2')
+        self.assertEqual(atomList[10].full_name,'...LYS1.HG2')
         self.assertEqual(atomList[28].parent.name,'VAL2')
 
         conf = chemicalSystem.configuration


### PR DESCRIPTION
Hi @eurydice76, I have been looking over the new code and thought that the best way to understand it would be to write tests for it, so I did that. It's not finished yet, but I wanted to get this to you before my leave so you can look over it. I will be gone from today until 5.7., but please leave any comments here or push any changes yourself. We can discuss it when I return.

I have only gone over ChemicalEntity.py in detail so far. Overall, I think it works pretty well. The cyclic references are a bit concerning, but ultimately it should probably OK. There were some bugs and so on, but I should have fixed all of them. There are only two things that I was not able to resolve and I want your input on:

1. I mentioned this #64, but I am not sure how to deal with managing the atoms in the `AtomCluster` class. For now, I kept the atoms in a list (the way it was) and just fixed the bug in the `reorder_atoms()` method, taking into account the possibility of multiple atoms with the same name. However, this might not be the best solution. What is, though, depends on what purpose the `AtomCluster` class is supposed to play in MDANSE, and I am not sure what that is. Therefore, I wanted to ask you what you intend the purpose of  `AtomCluster` to be and how you intend it to be used. If you settle on an implementation that you think works best, please feel free to push that here.
2. The use of `eval()` in `ChemicalSystem.load()` is a security vulnerability in this case since it is used on data stored on disk. It would be trivial to create a malicious HDF5 file and send it to someone who would then use MDANSE to load that file, executing the malicious code within. I reduced this vulnerability, by restricting the eval's access to `__builtins__`, but [that is still not secure](https://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html). I propose changing how the chemical entities are stored on disk; instead of storing strings containing data on instantiating H5ChemicalEntity objects, I think we should only store the arguments, and then instantiating the objects manually (in the code) using the stored data. We can sort out the details later, but I think that the security of users is the most important thing. Please let me know your opinions on this.


Besides that, I have done many more changes; here's the list:

1. Additions
    1. Unit tests: I have added unit tests for almost all classes. They should have a very good coverage, so if there is any change, we should be able to notice if anything breaks. Writing them has also allowed me to find a number of bugs.
    2. Documentation: I have added docstrings to all methods, and they should be fine, but I think they can still be improved, so please make any improvements you can see.
    3. Type hints: since type hinting has become a permanent feature of Python3, I tried adding type hints to all methods, and I have to say that it makes writing code much, much easier. I propose taking this opportunity to use type hints everywhere in MDANSE.
    4. `__str__` and `__repr__`: I implemented these methods in every class to make bugfixing, unit testing, and exceptions better.
    5. Exception handling in `NucleotideChain._connect_nucleotides()` and `PeptideChain._connect_residues()`: this should provide helpful errors is the `set_nucleotides()`/`set_residues()` method is called with invalid input.
2. Bugfixes
    1.  Correct bonds setter in `Atom`
    2. Fix `AtomGroup.__setstate__()`
    3. In `AtomCluster.copy()`, set the parent of copied atoms to the copied `AtomCluster` only if `parentless is True`
    4. Correct the exception handling in `Residue.__init__()` and `Nucleotide.__init__()`
    5. Correct method name in `NucleotideChain.copy()` from `self._connect_residues()` to `self._connect_nucleotides()`
    6. Fix total number of atoms count in `ChemicalSystem`
3. Improvements
    1. Improve the usefulness of error messages by providing more information
    2. Add the possibility to use `ChemicalSystem.load()` with an h5py.File object instead of just a string.
    3. Improve PEP8 etc. compliance
4. Changes
    1. Change all `serialize()` methods to conform to the ABC and accept only one argument. This is an h5py.File in `ChemicalSystem` and a dict in every other class. There was no point passing the file down to the other classes anyway since they were not using it.


Lastly, I have some questions and proposals:

1. Why does the `Atom.__init__()` only define kwargs instead of directly defining specific keyword arguments? I.e., why not do this: `def __init__(symbol='H', name=None, bonds=None, groups=None, ghost=False, **kwargs)` and then using if else  statements inside to save desired values?
2. I think that methods `atom_list()`, `number_of_atoms()`, `total_number_of_atoms()`, etc. would make more sense as `@property`, since they don't really do anything and are instead, well, properties of the chemical entities. What do you think?


Hopefully I got everything. Please let me know all the comments you have about this, and thank you for your help!