### PR TITLE
Add tests for UnitCell

### DIFF
--- a/Src/MolecularDynamics/UnitCell.py
+++ b/Src/MolecularDynamics/UnitCell.py
@@ -1,95 +1,114 @@
 import numpy as np
+from numpy.typing import ArrayLike
+
 
 class UnitCell:
-    """This class stores a unit cell. is stored row-wise i.e. the a, b and c vectors are 
-    respectively the first, second and thrid row of the unit cell matrix.
+    """
+    This class stores a unit cell, which is stored row-wise i.e. the a, b and c vectors are
+    respectively the first, second and third row of the unit cell matrix.
     """
 
-    def __init__(self,unit_cell):
-        """The constructor.
+    def __init__(self, unit_cell: ArrayLike) -> None:
+        """
+        The constructor.
 
         :param unit_cell: the unit cell matrix
         :type unit_cell: 3x3 numpy array
         """
 
-        self._unit_cell = unit_cell.astype(np.float64)
+        self._unit_cell = np.array(unit_cell).astype(np.float64)
+
+        if self._unit_cell.shape != (3, 3):
+            raise ValueError(f'the unit cell must have a shape of 3×3 but {self._unit_cell.shape} was provided.')
 
         self._inverse_unit_cell = np.linalg.inv(self._unit_cell)
 
+    def __eq__(self, other: 'UnitCell') -> bool:
+        if isinstance(other, UnitCell):
+            return np.allclose(self._unit_cell, other._unit_cell)
+        else:
+            return False
+
+    def __repr__(self) -> str:
+        return f'MDANSE.MolecularDynamics.UnitCell.UnitCell({repr(self._unit_cell)})'
+
     @property
-    def a_vector(self):
-        """Return the a vector.
+    def a_vector(self) -> np.ndarray:
+        """
+        Return the a vector.
 
         :return: the a vector
-        :rtype: numpy array
+        :rtype: numpy.ndarray
         """
-        return self._unit_cell[0,:]
+        return self._unit_cell[0, :]
 
     @property
-    def b_vector(self):
-        """Return the b vector.
+    def b_vector(self) -> np.ndarray:
+        """
+        Return the b vector.
 
         :return: the b vector
-        :rtype: numpy array
+        :rtype: numpy.ndarray
         """
-        return self._unit_cell[1,:]
+        return self._unit_cell[1, :]
 
     @property
-    def c_vector(self):
+    def c_vector(self) -> np.ndarray:
         """Return the c vector.
 
         :return: the c vector
-        :rtype: numpy array
+        :rtype: numpy.ndarray
         """
-        return self._unit_cell[2,:]
+        return self._unit_cell[2, :]
 
     @property
-    def direct(self):
-        """Return the unit cell matrix.
+    def direct(self) -> np.ndarray:
+        """
+        Return the unit cell matrix.
 
         :return: the unit cell matrix
-        :rtype: numpy array
+        :rtype: numpy.ndarray
         """
         return self._unit_cell
 
     @property
-    def inverse(self):
-        """Return the inverse of the unit cell matrix.
+    def inverse(self) -> np.ndarray:
+        """
+        Return the inverse of the unit cell matrix.
 
         :return: the inverse of the unit cell matrix
-        :rtype: numpy array
+        :rtype: numpy.ndarray
         """
         return self._inverse_unit_cell
 
     @property
-    def transposed_direct(self):
-        """Return the transposed of the unit cell matrix.
+    def transposed_direct(self) -> np.ndarray:
+        """
+        Return the transposed of the unit cell matrix.
 
         :return: the transposed of the unit cell matrix
-        :rtype: numpy array
+        :rtype: numpy.ndarray
         """
         return self._unit_cell.T
 
     @property
-    def transposed_inverse(self):
-        """Return the transposed of the inverse of unit cell matrix.
+    def transposed_inverse(self) -> np.ndarray:
+        """
+        Return the transposed of the inverse of unit cell matrix.
 
         :return: the transposed of the inverse of the unit cell matrix
-        :rtype: numpy array
+        :rtype: numpy.ndarray
         """
 
         return self._inverse_unit_cell.T
 
     @property
-    def volume(self):
-        """Return the volume unit cell matrix.
+    def volume(self) -> float:
+        """
+        Return the volume unit cell matrix.
 
-        :return: the volume
+        :return: the volume of the unit cell
         :rtype: float
         """
 
-        return np.abs(
-            np.dot(
-                np.cross(self._unit_cell[0,:],self._unit_cell[1,:]),
-                self._unit_cell[2,:])
-            )
+        return np.abs(np.dot(np.cross(self._unit_cell[0, :], self._unit_cell[1, :]), self._unit_cell[2, :]))

--- a/Tests/UnitTests/TestUnitCell.py
+++ b/Tests/UnitTests/TestUnitCell.py
@@ -1,0 +1,51 @@
+import unittest
+
+import numpy as np
+
+from MDANSE.MolecularDynamics.UnitCell import UnitCell
+
+
+class TestUnitCell(unittest.TestCase):
+    def setUp(self):
+        self.cell = UnitCell(np.array([[1, 0, 1], [0, 2, 0], [0, 0, 1 / 2]]))
+
+    def test_instantiation(self):
+        self.assertTrue(np.allclose(np.array([[1, 0, 1], [0, 2, 0], [0, 0, 1/2]]), self.cell._unit_cell),
+                        f'actual = {self.cell._unit_cell}')
+        self.assertTrue(np.allclose(np.array([[1. , 0. , -2. ], [0. , 0.5, 0. ], [0. , 0. , 2. ]]),
+                                    self.cell._inverse_unit_cell), f'actual = {self.cell._inverse_unit_cell}')
+
+    def test_instantiation_invalid_cell_shape(self):
+        with self.assertRaises(ValueError):
+            UnitCell(np.ones((3, 5)))
+
+    def test_dunder_eq(self):
+        same_cell = UnitCell(np.array([[1, 0, 1], [0, 2, 0], [0, 0, 1 / 2]]))
+        different_cell = UnitCell(np.array([[1, 0, 0], [0, 2, 0], [0, 0, 1 / 2]]))
+
+        self.assertEqual(same_cell, self.cell)
+        self.assertFalse(different_cell == self.cell)
+
+    def test_dunder_repr(self):
+        self.assertEqual('MDANSE.MolecularDynamics.UnitCell.UnitCell(array([[1. , 0. , 1. ],\n       [0. , 2. , 0. ],\n'
+                         '       [0. , 0. , 0.5]]))', repr(self.cell))
+
+    def test_properties(self):
+        self.assertTrue(np.allclose(np.array([1, 0, 1]), self.cell.a_vector), f'actual = {self.cell.a_vector}')
+        self.assertTrue(np.allclose(np.array([0, 2, 0]), self.cell.b_vector), f'actual = {self.cell.b_vector}')
+        self.assertTrue(np.allclose(np.array([0, 0, 1 / 2]), self.cell.c_vector), f'actual = {self.cell.c_vector}')
+
+    def test_matrices(self):
+        self.assertTrue(np.allclose(np.array([[1, 0, 1], [0, 2, 0], [0, 0, 1 / 2]]), self.cell.direct),
+                        f'actual = {self.cell.direct}')
+        self.assertTrue(np.allclose(np.array([[1. , 0. , -2. ], [0. , 0.5, 0. ], [0. , 0. , 2. ]]), self.cell.inverse),
+                        f'actual = {self.cell.inverse}')
+
+    def test_transposed_matrices(self):
+        self.assertTrue(np.allclose(np.array([[1, 0, 0], [0, 2, 0], [1, 0, 1 / 2]]), self.cell.transposed_direct),
+                        f'actual = {self.cell.transposed_direct}')
+        self.assertTrue(np.allclose(np.array([[1, 0, 0], [0, 0.5, 0], [-2, 0, 2]]), self.cell.transposed_inverse),
+                        f'actual = {self.cell.transposed_inverse}')
+
+    def test_volume(self):
+        self.assertAlmostEqual(1, self.cell.volume)

--- a/Tests/UnitTests/TestUnitCell.py
+++ b/Tests/UnitTests/TestUnitCell.py
@@ -49,3 +49,14 @@ class TestUnitCell(unittest.TestCase):
 
     def test_volume(self):
         self.assertAlmostEqual(1, self.cell.volume)
+
+
+def suite():
+    loader = unittest.TestLoader()
+    s = unittest.TestSuite()
+    s.addTest(loader.loadTestsFromTestCase(TestUnitCell))
+    return s
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Not much different in this one, I have just written tests and added type hints. The main thing is that I added a check for the passed in unit cell; if it is not 3×3, a `ValueError` is raised. I think this should make sense since this should be the only shape that a unit cell can ever be, but please correct me if I am wrong. Having the check here means that we do not have to constantly check for it in `Configuration` methods..