### PR TITLE
Improve Configuration tests

### DIFF
--- a/Extensions/atoms_in_shell.pyx
+++ b/Extensions/atoms_in_shell.pyx
@@ -130,8 +130,6 @@ def atoms_in_shell_box(ndarray[np.float64_t, ndim=2]  config not None,
 
     cdef int i
 
-    cdef ndarray[np.float64_t, ndim=2] scaleconfig = np.empty((config.shape[0],3),dtype=np.float)
-
     cdef double mini2 = mini**2
     cdef double maxi2 = maxi**2
 
@@ -150,9 +148,9 @@ def atoms_in_shell_box(ndarray[np.float64_t, ndim=2]  config not None,
         sdy = config[i,1] - refy
         sdz = config[i,2] - refz
 
-        sdx -= round(sdx)
-        sdy -= round(sdy)
-        sdz -= round(sdz)
+        sdx = round(sdx)
+        sdy = round(sdy)
+        sdz = round(sdz)
             
         r2 = sdx*sdx + sdy*sdy + sdz*sdz
 

--- a/Extensions/atoms_in_shell.pyx
+++ b/Extensions/atoms_in_shell.pyx
@@ -38,28 +38,28 @@ def atoms_in_shell_real(ndarray[np.float64_t, ndim=2]  config not None,
 
     cdef int i
 
-    cdef ndarray[np.float64_t, ndim=2] scaleconfig = np.empty((config.shape[0],3),dtype=np.float)
+    cdef ndarray[np.float64_t, ndim=2] scaleconfig = np.empty((config.shape[0], 3), dtype=np.float64)
 
     cdef double mini2 = mini**2
     cdef double maxi2 = maxi**2
 
-    refx = config[refIndex,0]
-    refy = config[refIndex,1]
-    refz = config[refIndex,2]
+    refx = config[refIndex, 0]
+    refy = config[refIndex, 1]
+    refz = config[refIndex, 2]
 
     for 0 <= i < config.shape[0]:
 
-        x = config[i,0]
-        y = config[i,1]
-        z = config[i,2]
+        x = config[i, 0]
+        y = config[i, 1]
+        z = config[i, 2]
 
-        scaleconfig[i,0] = x*rcell[0,0] + y*rcell[0,1] + z*rcell[0,2]
-        scaleconfig[i,1] = x*rcell[1,0] + y*rcell[1,1] + z*rcell[1,2]
-        scaleconfig[i,2] = x*rcell[2,0] + y*rcell[2,1] + z*rcell[2,2]
+        scaleconfig[i, 0] = x*rcell[0, 0] + y*rcell[0, 1] + z*rcell[0, 2]
+        scaleconfig[i, 1] = x*rcell[1, 0] + y*rcell[1, 1] + z*rcell[1, 2]
+        scaleconfig[i, 2] = x*rcell[2, 0] + y*rcell[2, 1] + z*rcell[2, 2]
 
-    refsx = scaleconfig[refIndex,0]
-    refsy = scaleconfig[refIndex,1]
-    refsz = scaleconfig[refIndex,2]
+    refsx = scaleconfig[refIndex, 0]
+    refsy = scaleconfig[refIndex, 1]
+    refsz = scaleconfig[refIndex, 2]
 
     indexes = []
 
@@ -68,17 +68,17 @@ def atoms_in_shell_real(ndarray[np.float64_t, ndim=2]  config not None,
         if i == refIndex:
             continue
 
-        sdx = scaleconfig[i,0] - refsx
-        sdy = scaleconfig[i,1] - refsy
-        sdz = scaleconfig[i,2] - refsz
+        sdx = scaleconfig[i, 0] - refsx
+        sdy = scaleconfig[i, 1] - refsy
+        sdz = scaleconfig[i, 2] - refsz
 
         sdx -= round(sdx)
         sdy -= round(sdy)
         sdz -= round(sdz)
             
-        rx = sdx*cell[0,0] + sdy*cell[0,1] + sdz*cell[0,2]
-        ry = sdx*cell[1,0] + sdy*cell[1,1] + sdz*cell[1,2]
-        rz = sdx*cell[2,0] + sdy*cell[2,1] + sdz*cell[2,2]
+        rx = sdx*cell[0, 0] + sdy*cell[0, 1] + sdz*cell[0, 2]
+        ry = sdx*cell[1, 0] + sdy*cell[1, 1] + sdz*cell[1, 2]
+        rz = sdx*cell[2, 0] + sdy*cell[2, 1] + sdz*cell[2, 2]
 
         r2 = rx*rx + ry*ry + rz*rz
 
@@ -148,9 +148,9 @@ def atoms_in_shell_box(ndarray[np.float64_t, ndim=2]  config not None,
         sdy = config[i,1] - refy
         sdz = config[i,2] - refz
 
-        sdx = round(sdx)
-        sdy = round(sdy)
-        sdz = round(sdz)
+        sdx -= round(sdx)
+        sdy -= round(sdy)
+        sdz -= round(sdz)
             
         r2 = sdx*sdx + sdy*sdy + sdz*sdz
 

--- a/Extensions/contiguous_coordinates.pyx
+++ b/Extensions/contiguous_coordinates.pyx
@@ -92,33 +92,33 @@ def contiguous_coordinates_box(ndarray[np.float64_t, ndim=2]  coords not None,
 
     cdef double sdx, sdy, sdz, newx, newy, newz
 
-    cdef ndarray[np.float64_t, ndim=2] contiguous_coords = np.empty((coords.shape[0],3),dtype=np.float)
+    cdef ndarray[np.float64_t, ndim=2] contiguous_coords = np.empty((coords.shape[0],3), dtype=np.float64)
 
     for idxs in indexes:
-        contiguous_coords[idxs[0],0] = coords[idxs[0],0]
-        contiguous_coords[idxs[0],1] = coords[idxs[0],1]
-        contiguous_coords[idxs[0],2] = coords[idxs[0],2]
+        contiguous_coords[idxs[0], 0] = coords[idxs[0], 0]
+        contiguous_coords[idxs[0], 1] = coords[idxs[0], 1]
+        contiguous_coords[idxs[0], 2] = coords[idxs[0], 2]
 
         if len(idxs) == 1:
             continue
 
         for idx in idxs[1:]:
 
-            sdx = coords[idx,0] - coords[idxs[0],0]
-            sdy = coords[idx,1] - coords[idxs[0],1]
-            sdz = coords[idx,2] - coords[idxs[0],2]
+            sdx = coords[idx, 0] - coords[idxs[0], 0]
+            sdy = coords[idx, 1] - coords[idxs[0], 1]
+            sdz = coords[idx, 2] - coords[idxs[0], 2]
 
             sdx -= round(sdx)
             sdy -= round(sdy)
             sdz -= round(sdz)
 
-            newx = coords[idxs[0],0] + sdx
-            newy = coords[idxs[0],1] + sdy
-            newz = coords[idxs[0],2] + sdz
+            newx = coords[idxs[0], 0] + sdx
+            newy = coords[idxs[0], 1] + sdy
+            newz = coords[idxs[0], 2] + sdz
 
-            contiguous_coords[idx,0] = newx*cell[0,0] + newy*cell[0,1] + newz*cell[0,2]
-            contiguous_coords[idx,1] = newx*cell[1,0] + newy*cell[1,1] + newz*cell[1,2]
-            contiguous_coords[idx,2] = newx*cell[2,0] + newy*cell[2,1] + newz*cell[2,2]
+            contiguous_coords[idx, 0] = newx*cell[0, 0] + newy*cell[0, 1] + newz*cell[0, 2]
+            contiguous_coords[idx, 1] = newx*cell[1, 0] + newy*cell[1, 1] + newz*cell[1, 2]
+            contiguous_coords[idx, 2] = newx*cell[2, 0] + newy*cell[2, 1] + newz*cell[2, 2]
 
     return contiguous_coords
 
@@ -167,7 +167,7 @@ def contiguous_offsets_box(ndarray[np.float64_t, ndim=2]  coords not None,
 
     cdef double sdx, sdy, sdz
 
-    cdef ndarray[np.float64_t, ndim=2] offsets = np.zeros((coords.shape[0],3),dtype=np.float)
+    cdef ndarray[np.float64_t, ndim=2] offsets = np.zeros((coords.shape[0], 3), dtype=np.float64)
 
     for idxs in indexes:
         if len(idxs) == 1:
@@ -175,13 +175,13 @@ def contiguous_offsets_box(ndarray[np.float64_t, ndim=2]  coords not None,
         
         for idx in idxs[1:]:
 
-            sdx = coords[idx,0] - coords[idxs[0],0]
-            sdy = coords[idx,1] - coords[idxs[0],1]
-            sdz = coords[idx,2] - coords[idxs[0],2]
+            sdx = coords[idx, 0] - coords[idxs[0], 0]
+            sdy = coords[idx, 1] - coords[idxs[0], 1]
+            sdz = coords[idx, 2] - coords[idxs[0], 2]
 
-            offsets[idx,0] = -round(sdx)
-            offsets[idx,1] = -round(sdy)
-            offsets[idx,2] = -round(sdz)
+            offsets[idx, 0] = -round(sdx)
+            offsets[idx, 1] = -round(sdy)
+            offsets[idx, 2] = -round(sdz)
 
     return offsets
 

--- a/Extensions/fold_coordinates.pyx
+++ b/Extensions/fold_coordinates.pyx
@@ -38,7 +38,7 @@ def fold_coordinates(
 
     cdef int i
 
-    cdef ndarray[np.float64_t, ndim=3] folded_coords = np.empty((coords.shape[0],coords.shape[1],3),dtype=np.float)
+    cdef ndarray[np.float64_t, ndim=3] folded_coords = np.empty((coords.shape[0],coords.shape[1],3),dtype=np.float64)
 
     cdef ndarray[np.float64_t, ndim=3] box_coords
 
@@ -48,7 +48,7 @@ def fold_coordinates(
 
     if not box_coordinates:
 
-        box_coords = np.empty((coords.shape[0],coords.shape[1],3),dtype=np.float)
+        box_coords = np.empty((coords.shape[0],coords.shape[1],3),dtype=np.float64)
 
         for 0 <= i < box_coords.shape[0]:
 

--- a/Src/Framework/Selectors/WithinShell.py
+++ b/Src/Framework/Selectors/WithinShell.py
@@ -27,7 +27,7 @@ class WithinShell(ISelector):
         sel = set()
 
         if self._chemicalSystem.configuration is not None:
-            sel.update(self._chemicalSystem.configuration.atomsInShell(ref,mini,maxi))
+            sel.update(self._chemicalSystem.configuration.atoms_in_shell(ref, mini, maxi))
         
         return sel
     

--- a/Src/Mathematics/Transformation.py
+++ b/Src/Mathematics/Transformation.py
@@ -175,7 +175,7 @@ class Rotation(RigidBodyTransformation):
         elif len(args) == 2:
             axis, angle = args
             axis = axis.normal()
-            projector = axis.dyadicProduct(axis)
+            projector = axis.dyadic_product(axis)
             self.tensor = projector - \
                           float(np.sin(angle))*(epsilon*axis) + \
                           float(np.cos(angle))*(delta-projector)

--- a/Src/MolecularDynamics/Configuration.py
+++ b/Src/MolecularDynamics/Configuration.py
@@ -36,11 +36,7 @@ class _Configuration(metaclass=abc.ABCMeta):
 
         self._variables = {}
 
-        coords = np.array(coords)
-        if coords.shape != (self._chemical_system.number_of_atoms(), 3):
-            raise ValueError('Invalid coordinates dimensions')
-
-        self['coordinates'] = coords
+        self['coordinates'] = np.array(coords)
 
         for k, v in variables.items():
             self[k] = v
@@ -96,7 +92,10 @@ class _Configuration(metaclass=abc.ABCMeta):
         conf = self['coordinates']
         rot = transfo.rotation().tensor.array
         conf[:] = np.dot(conf, np.transpose(rot))
-        np.add(conf, transfo.translation().vector.array[np.newaxis, :], conf)
+
+        # The casting here must be set to 'unsafe' to allow for conversion from int to float; the vector array may be
+        # of float dtype while conf, after the dot product, can be int.
+        np.add(conf, transfo.translation().vector.array[np.newaxis, :], conf, casting='unsafe')
 
         if 'velocities' in self._variables:
             velocities = self._variables['velocities']

--- a/Src/MolecularDynamics/UnitCell.py
+++ b/Src/MolecularDynamics/UnitCell.py
@@ -12,9 +12,15 @@ class UnitCell:
         :type unit_cell: 3x3 numpy array
         """
 
-        self._unit_cell = unit_cell.astype(np.float64)
+        self._unit_cell = np.array(unit_cell).astype(np.float64)
 
         self._inverse_unit_cell = np.linalg.inv(self._unit_cell)
+
+    def __eq__(self, other):
+        if isinstance(other, UnitCell):
+            return np.allclose(self._unit_cell, other._unit_cell)
+        else:
+            return False
 
     @property
     def a_vector(self):

--- a/Tests/UnitTests/TestConfiguration.py
+++ b/Tests/UnitTests/TestConfiguration.py
@@ -42,14 +42,14 @@ class TestPeriodicConfiguration(unittest.TestCase):
 
         self.chem_system.add_chemical_entity(ac)
 
-    def test_instantiation_valid(self):
-        coords = np.random.uniform(0,1,(self._nAtoms,3))
-        unit_cell = UnitCell(np.random.uniform(0,1,(3,3)))
-        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
+        self.coords = np.random.uniform(0, 1, (self._nAtoms, 3))
+        self.unit_cell = UnitCell(np.random.uniform(0, 1, (3, 3)))
+        self.conf = PeriodicBoxConfiguration(self.chem_system, self.coords, self.unit_cell)
 
-        self.assertEqual(self.chem_system, conf.chemical_system)
-        self.assertTrue(np.allclose(coords, conf['coordinates']))
-        self.assertEqual(unit_cell, conf.unit_cell)
+    def test_instantiation_valid(self):
+        self.assertEqual(self.chem_system, self.conf.chemical_system)
+        self.assertTrue(np.allclose(self.coords, self.conf['coordinates']))
+        self.assertEqual(self.unit_cell, self.conf.unit_cell)
 
     def test_instantiation_invalid_unit_cell(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
@@ -58,45 +58,31 @@ class TestPeriodicConfiguration(unittest.TestCase):
             PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
 
     def test_clone_valid_chemical_system(self):
-        coords = np.random.uniform(0, 1, (self._nAtoms, 3))
-        unit_cell = UnitCell(np.random.uniform(0, 1, (3, 3)))
-        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
-        clone = conf.clone(self.chem_system)
+        clone = self.conf.clone(self.chem_system)
 
         self.assertEqual(self.chem_system, clone.chemical_system)
-        self.assertTrue(np.allclose(coords, clone['coordinates']))
-        self.assertEqual(unit_cell, clone.unit_cell)
+        self.assertTrue(np.allclose(self.coords, clone['coordinates']))
+        self.assertEqual(self.unit_cell, clone.unit_cell)
 
     def test_clone_valid_none(self):
-        coords = np.random.uniform(0, 1, (self._nAtoms, 3))
-        unit_cell = UnitCell(np.random.uniform(0, 1, (3, 3)))
-        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
-        clone = conf.clone()
+        clone = self.conf.clone()
 
         self.assertEqual(self.chem_system, clone.chemical_system)
-        self.assertTrue(np.allclose(coords, clone['coordinates']))
-        self.assertEqual(unit_cell, clone.unit_cell)
+        self.assertTrue(np.allclose(self.coords, clone['coordinates']))
+        self.assertEqual(self.unit_cell, clone.unit_cell)
 
     def test_unit_cell_setter_valid(self):
-        coords = np.random.uniform(0, 1, (self._nAtoms, 3))
-        unit_cell = UnitCell(np.random.uniform(0, 1, (3, 3)))
-        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
-
         unit_cell_new = UnitCell(np.random.uniform(0, 2, (3, 3)))
-        conf.unit_cell = unit_cell_new
-        self.assertEqual(unit_cell_new, conf.unit_cell)
+        self.conf.unit_cell = unit_cell_new
+        self.assertEqual(unit_cell_new, self.conf.unit_cell)
 
     def test_unit_cell_setter_invalid_shape(self):
-        coords = np.random.uniform(0, 1, (self._nAtoms, 3))
-        unit_cell = UnitCell(np.random.uniform(0, 1, (3, 3)))
-        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
-
         unit_cell_new = UnitCell(np.random.uniform(0, 2, (4, 4)))
         with self.assertRaises(ValueError):
-            conf.unit_cell = unit_cell_new
+            self.conf.unit_cell = unit_cell_new
 
 
-class TestPeriodicBoxConfiguaration(unittest.TestCase):
+class TestPeriodicBoxConfiguration(unittest.TestCase):
     def setUp(self):
         self.chem_system = ChemicalSystem()
         self._nAtoms = 4

--- a/Tests/UnitTests/TestConfiguration.py
+++ b/Tests/UnitTests/TestConfiguration.py
@@ -50,8 +50,68 @@ import unittest
 import numpy as np
 
 from MDANSE.Chemistry.ChemicalEntity import Atom, AtomCluster, ChemicalSystem
-from MDANSE.MolecularDynamics.Configuration import BoxConfiguration, RealConfiguration
+from MDANSE.MolecularDynamics.Configuration import PeriodicBoxConfiguration, RealConfiguration
+from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
+
+class TestPeriodicConfiguration(unittest.TestCase):
+    """Uses PeriodicBoxConfiguration to test the methods of its abstract base class, _PeriodicConfiguration."""
+    def setUp(self):
+        self.chem_system = ChemicalSystem()
+        self._nAtoms = 4
+
+        atoms = []
+        for i in range(self._nAtoms):
+            atoms.append(Atom(symbol='H'))
+        ac = AtomCluster('', atoms)
+
+        self.chem_system.add_chemical_entity(ac)
+
+    def test_instantiation_valid(self):
+        coords = np.random.uniform(0,1,(self._nAtoms,3))
+        unit_cell = UnitCell(np.random.uniform(0,1,(3,3)))
+        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
+
+        self.assertEqual(self.chem_system, conf.chemical_system)
+        self.assertTrue(np.allclose(coords, conf['coordinates']))
+        self.assertEqual(unit_cell, conf.unit_cell)
+
+    def test_instantiation_invalid_unit_cell(self):
+        coords = np.random.uniform(0, 1, (self._nAtoms, 3))
+        unit_cell = UnitCell(np.random.uniform(0, 1, (4, 4)))
+        with self.assertRaises(ValueError):
+            PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
+
+    def test_clone_valid(self):
+        coords = np.random.uniform(0, 1, (self._nAtoms, 3))
+        unit_cell = UnitCell(np.random.uniform(0, 1, (3, 3)))
+        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
+        clone = conf.clone(self.chem_system)
+
+        self.assertEqual(self.chem_system, clone.chemical_system)
+        self.assertTrue(np.allclose(coords, clone['coordinates']))
+        self.assertEqual(unit_cell, clone.unit_cell)
+
+    def test_unit_cell_setter_valid(self):
+        coords = np.random.uniform(0, 1, (self._nAtoms, 3))
+        unit_cell = UnitCell(np.random.uniform(0, 1, (3, 3)))
+        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
+
+        unit_cell_new = UnitCell(np.random.uniform(0, 2, (3, 3)))
+        conf.unit_cell = unit_cell_new
+        self.assertEqual(unit_cell_new, conf.unit_cell)
+
+    def test_unit_cell_setter_invalid_shape(self):
+        coords = np.random.uniform(0, 1, (self._nAtoms, 3))
+        unit_cell = UnitCell(np.random.uniform(0, 1, (3, 3)))
+        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
+
+        unit_cell_new = UnitCell(np.random.uniform(0, 2, (4, 4)))
+        with self.assertRaises(ValueError):
+            conf.unit_cell = unit_cell_new
+
+
+@unittest.skip
 class TestConfiguration(unittest.TestCase):
     '''
     Unittest for the geometry-related functions

--- a/Tests/UnitTests/TestConfiguration.py
+++ b/Tests/UnitTests/TestConfiguration.py
@@ -13,11 +13,11 @@
 #
 # **************************************************************************
 
-''' 
+"""
 Created on May 29, 2015
 
 @author: Eric C. Pellegrini
-'''
+"""
 
 import unittest
 
@@ -36,6 +36,7 @@ class TestConfiguration(unittest.TestCase):
     Uses :class: `MDNASE.MolecularDynamics.Configuration.RealConfiguration` to test methods of the abstract base
     class :class: `MDANSE.MolecularDynamics.Configuration._Configuration`.
     """
+
     def setUp(self):
         self.chem_system = ChemicalSystem()
         self._nAtoms = 4
@@ -91,7 +92,7 @@ class TestConfiguration(unittest.TestCase):
         conf = RealConfiguration(self.chem_system, coords)
 
         with self.assertRaises(ValueError):
-            conf['velocities'] = np.random.uniform(0, 1, (self._nAtoms+1, 3))
+            conf['velocities'] = np.random.uniform(0, 1, (self._nAtoms + 1, 3))
         with self.assertRaises(ValueError):
             conf['velocities'] = np.random.uniform(0, 1, (self._nAtoms, 4))
 
@@ -111,7 +112,6 @@ class TestConfiguration(unittest.TestCase):
         self.assertTrue(np.allclose(vels, conf['velocities']), f'\nactual = {conf["velocities"]}')
         self.assertTrue(np.allclose(forces, conf['forces']), f'\nactual = {conf["forces"]}')
 
-    @unittest.skip
     def test_apply_transformation_rotation(self):
         coords = np.array([[1, 1, 1], [2, 1, 1], [5, 1, 1], [9, 1, 1]])
         vels = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 1]])
@@ -251,7 +251,6 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
                                     real['coordinates']), f'\nactual = {real["coordinates"]}')
         self.assertEqual(unit_cell, real._unit_cell)
 
-    @unittest.skip
     def test_atoms_in_shell(self):
         unit_cell = UnitCell(np.array([[10, 0, 0], [0, 10, 0], [0, 0, 10]]))
         coords = np.array(([1, 1, 1], [2, 1, 1], [5, 1, 1], [9, 1, 1]))
@@ -272,7 +271,6 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
         self.assertTrue(np.allclose([[0.1, 0.1, 0.1], [0.8, 1.1, -1.6], [-0.9, -0.8, 1.2], [-1.9, 0.8, 0.4]],
                                     contiguous_conf['coordinates']), f'\nactual = {contiguous_conf["coordinates"]}')
 
-    @unittest.skip
     def test_contiguous_offsets_valid_no_input(self):
         self.chem_system.add_chemical_entity(AtomCluster('2', [Atom(), Atom()]))
 
@@ -284,7 +282,6 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
         self.assertTrue(np.allclose([[0, 0, 0], [0.8, 1.1, -1.6], [-0.9, -0.8, 1.2], [-1.9, 0.8, 0.4], [0, 0, 0],
                                      [1.9, 1.5, 1.9]], offsets), f'\nactual = {offsets}')
 
-    @unittest.skip
     def test_contiguous_offsets_valid_specified_list(self):
         self.chem_system.add_chemical_entity(AtomCluster('2', [Atom(), Atom()]))
 
@@ -362,7 +359,6 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         real = conf.to_real_coordinates()
         self.assertTrue(np.allclose(coords, real), f'\nactual = {real}')
 
-    @unittest.skip
     def test_atoms_in_shell(self):
         coords = np.array([[1, 1, 1], [2, 1, 1], [5, 1, 1], [9, 1, 1]])
         unit_cell = UnitCell(np.array([[10, 0, 0], [0, 10, 0], [0, 0, 10]]))
@@ -371,7 +367,6 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
 
         self.assertEqual([1, 2], [at.index for at in atoms])
 
-    @unittest.skip
     def test_contiguous_configuration(self):
         coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])
         unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
@@ -385,7 +380,6 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
                                     result['coordinates']), f'\nactual = {result["coordinates"]}')
         self.assertEqual(unit_cell, result._unit_cell)
 
-    @unittest.skip
     def test_continuous_configuration(self):
         coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])
         unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
@@ -399,27 +393,25 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
                                     result['coordinates']), f'\nactual = {result["coordinates"]}')
         self.assertEqual(unit_cell, result._unit_cell)
 
-    @unittest.skip
     def test_contiguous_offsets_valid_no_input(self):
         coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])
         unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
         conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
 
         offsets = conf.contiguous_offsets()
-        self.assertTrue(np.allclose([[ 0.,  0.,  0.], [-3., -3., -3.], [-6., -6., -6.], [-9., -9., -9.]], offsets),
+        self.assertTrue(np.allclose([[0., 0., 0.], [-3., -3., -3.], [-6., -6., -6.], [-9., -9., -9.]], offsets),
                         f'\nactual = {offsets}')
 
-    @unittest.skip
     def test_contiguous_offsets_valid_specified_list(self):
         self.chem_system.add_chemical_entity(AtomCluster('2', [Atom(), Atom()]))
 
         coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0],
-                          [15.0, 15.0, 15.0], [10.0, 10.0, 10.0]])
+                           [15.0, 15.0, 15.0], [10.0, 10.0, 10.0]])
         unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
         conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
 
         offsets = conf.contiguous_offsets(self.chem_system.chemical_entities[0])
-        self.assertTrue(np.allclose([[ 0.,  0.,  0.], [-3., -3., -3.], [-6., -6., -6.], [-9., -9., -9.]],
+        self.assertTrue(np.allclose([[0., 0., 0.], [-3., -3., -3.], [-6., -6., -6.], [-9., -9., -9.]],
                                     offsets), f'\nactual = {offsets}')
 
     def test_contiguous_offsets_invalid(self):
@@ -504,7 +496,7 @@ class TestRealConfiguration(unittest.TestCase):
 
     def test_contiguous_offsets_valid_none(self):
         self.chem_system.add_chemical_entity(AtomCluster('', [Atom(), Atom()]))
-        coords = np.random.uniform(0, 1, (self._nAtoms+2, 3))
+        coords = np.random.uniform(0, 1, (self._nAtoms + 2, 3))
         conf = RealConfiguration(self.chem_system, coords)
 
         offsets = conf.contiguous_offsets()
@@ -529,6 +521,7 @@ class TestRealConfiguration(unittest.TestCase):
 def suite():
     loader = unittest.TestLoader()
     s = unittest.TestSuite()
+    s.addTest(loader.loadTestsFromTestCase(TestConfiguration))
     s.addTest(loader.loadTestsFromTestCase(TestPeriodicConfiguration))
     s.addTest(loader.loadTestsFromTestCase(TestPeriodicBoxConfiguration))
     s.addTest(loader.loadTestsFromTestCase(TestPeriodicRealConfiguration))

--- a/Tests/UnitTests/TestConfiguration.py
+++ b/Tests/UnitTests/TestConfiguration.py
@@ -253,11 +253,11 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
 
     def test_atoms_in_shell(self):
         unit_cell = UnitCell(np.array([[10, 0, 0], [0, 10, 0], [0, 0, 10]]))
-        coords = np.array(([1, 1, 1], [2, 1, 1], [5, 1, 1], [9, 1, 1]))
+        coords = np.array(([0.1, 0.1, 0.1], [0.2, 0.1, 0.1], [0.5, 0.1, 0.1], [0.9, 0.1, 0.1]))
         conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
-        atoms = conf.atoms_in_shell(0, 0.0, 5)
+        atoms = conf.atoms_in_shell(0, 0.0, 0.3)
 
-        self.assertEqual([1, 2], [at.index for at in atoms])
+        self.assertEqual([1, 3], [at.index for at in atoms])
 
     def test_contiguous_configuration(self):
         unit_cell = UnitCell(np.array([[2, 1, 0], [-3, 2, 0], [2, 1, -4]]))
@@ -363,9 +363,9 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         coords = np.array([[1, 1, 1], [2, 1, 1], [5, 1, 1], [9, 1, 1]])
         unit_cell = UnitCell(np.array([[10, 0, 0], [0, 10, 0], [0, 0, 10]]))
         conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
-        atoms = conf.atoms_in_shell(0, 0, 5)
+        atoms = conf.atoms_in_shell(0, 0, 3)
 
-        self.assertEqual([1, 2], [at.index for at in atoms])
+        self.assertEqual([1, 3], [at.index for at in atoms])
 
     def test_contiguous_configuration(self):
         coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])

--- a/Tests/UnitTests/TestConfiguration.py
+++ b/Tests/UnitTests/TestConfiguration.py
@@ -31,6 +31,7 @@ from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 class TestPeriodicConfiguration(unittest.TestCase):
     """Uses PeriodicBoxConfiguration to test the methods of its abstract base class, _PeriodicConfiguration."""
+
     def setUp(self):
         self.chem_system = ChemicalSystem()
         self._nAtoms = 4
@@ -96,17 +97,17 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
 
     def test_fold_coordinates(self):
         coords = np.array([
-            [-1.65955991,  4.40648987, -9.9977125 ],
-            [-3.95334855, -7.06488218, -8.1532281 ],
+            [-1.65955991, 4.40648987, -9.9977125],
+            [-3.95334855, -7.06488218, -8.1532281],
             [-6.27479577, -3.08878546, -2.06465052],
-            [ 0.77633468, -1.61610971,  3.70439001]])
-        unit_cell = UnitCell(np.array([[1.0,2.0,1.0],[2.0,-1.0,1.0],[3.0,1.0,1.0]]))
+            [0.77633468, -1.61610971, 3.70439001]])
+        unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
         conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
 
-        self.assertTrue(np.allclose(conf['coordinates'], [[-1.65955991,  4.40648987, -9.9977125 ],
-            [-3.95334855, -7.06488218, -8.1532281 ],
-            [-6.27479577, -3.08878546, -2.06465052],
-            [ 0.77633468, -1.61610971,  3.70439001]], rtol=1.0e-6),
+        self.assertTrue(np.allclose(conf['coordinates'], [[-1.65955991, 4.40648987, -9.9977125],
+                                                          [-3.95334855, -7.06488218, -8.1532281],
+                                                          [-6.27479577, -3.08878546, -2.06465052],
+                                                          [0.77633468, -1.61610971, 3.70439001]], rtol=1.0e-6),
                         f'actual = {conf["coordinates"]}')
 
     def test_to_box_coordinates(self):
@@ -121,7 +122,7 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
         coords = np.array(([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]))
         conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
 
-        self.assertTrue(np.allclose([[14.0,3.0,6.0], [32.0,9.0,15.0], [50.0,15.0,24.0], [68.0,21.0,33.0]],
+        self.assertTrue(np.allclose([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]],
                                     conf.to_real_coordinates()), f'\nactual = {conf.to_real_coordinates()}')
 
     def test_to_real_configuration(self):
@@ -133,10 +134,11 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
         self.assertTrue(isinstance(real, PeriodicRealConfiguration))
         self.assertEqual(repr(self.chem_system), repr(real._chemical_system))
         self.assertEqual(['coordinates'], list(real._variables.keys()))
-        self.assertTrue(np.allclose([[14.0,3.0,6.0], [32.0,9.0,15.0], [50.0,15.0,24.0], [68.0,21.0,33.0]],
+        self.assertTrue(np.allclose([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]],
                                     real['coordinates']), f'\nactual = {real["coordinates"]}')
         self.assertEqual(unit_cell, real._unit_cell)
 
+    @unittest.skip
     def test_atoms_in_shell(self):
         unit_cell = UnitCell(np.array([[10, 0, 0], [0, 10, 0], [0, 0, 10]]))
         coords = np.array(([1, 1, 1], [2, 1, 1], [5, 1, 1], [9, 1, 1]))
@@ -157,6 +159,7 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
         self.assertTrue(np.allclose([[0.1, 0.1, 0.1], [0.8, 1.1, -1.6], [-0.9, -0.8, 1.2], [-1.9, 0.8, 0.4]],
                                     contiguous_conf['coordinates']), f'\nactual = {contiguous_conf["coordinates"]}')
 
+    @unittest.skip
     def test_contiguous_offsets_valid_no_input(self):
         self.chem_system.add_chemical_entity(AtomCluster('2', [Atom(), Atom()]))
 
@@ -168,6 +171,7 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
         self.assertTrue(np.allclose([[0, 0, 0], [0.8, 1.1, -1.6], [-0.9, -0.8, 1.2], [-1.9, 0.8, 0.4], [0, 0, 0],
                                      [1.9, 1.5, 1.9]], offsets), f'\nactual = {offsets}')
 
+    @unittest.skip
     def test_contiguous_offsets_valid_specified_list(self):
         self.chem_system.add_chemical_entity(AtomCluster('2', [Atom(), Atom()]))
 
@@ -188,6 +192,132 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
             conf.contiguous_offsets([Atom(parent=ChemicalSystem())])
 
 
+class TestPeriodicRealConfiguration(unittest.TestCase):
+    def setUp(self):
+        self.chem_system = ChemicalSystem()
+        self._nAtoms = 4
+
+        atoms = []
+        for i in range(self._nAtoms):
+            atoms.append(Atom(symbol='H'))
+        ac = AtomCluster('', atoms)
+
+        self.chem_system.add_chemical_entity(ac)
+
+    def test_fold_coordinates(self):
+        coords = np.array([
+            [-1.65955991, 4.40648987, -9.9977125],
+            [-3.95334855, -7.06488218, -8.1532281],
+            [-6.27479577, -3.08878546, -2.06465052],
+            [0.77633468, -1.61610971, 3.70439001]])
+        unit_cell = UnitCell(np.array([[2, 1, 0], [-3, 2, 0], [2, 1, -4]]))
+        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+        conf.fold_coordinates()
+
+        self.assertTrue(np.allclose(conf['coordinates'], [[-0.65955991, 1.40648987, -1.9977125],
+                                                          [1.04665145, -1.06488218, -0.1532281],
+                                                          [-0.27479577, -0.08878546, 1.93534948],
+                                                          [-0.22366532, 1.38389029, -0.29560999]], rtol=1.0e-6),
+                        f'actual = {conf["coordinates"]}')
+
+    def test_to_box_coordinates(self):
+        coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])
+        unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
+        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+
+        box = conf.to_box_coordinates()
+        self.assertTrue(np.allclose([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], box), f'\nactual = {box}')
+
+    def test_to_box_configuration(self):
+        coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])
+        unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
+        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+
+        box_conf = conf.to_box_configuration()
+        self.assertTrue(isinstance(box_conf, PeriodicBoxConfiguration))
+        self.assertEqual(repr(self.chem_system), repr(box_conf._chemical_system))
+        self.assertEqual(['coordinates'], list(box_conf._variables.keys()))
+        self.assertTrue(np.allclose([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], box_conf['coordinates']),
+                        f'\nactual = {box_conf["coordinates"]}')
+        self.assertEqual(unit_cell, box_conf._unit_cell)
+
+    def test_to_real_coordinates(self):
+        coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])
+        unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
+        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+
+        real = conf.to_real_coordinates()
+        self.assertTrue(np.allclose(coords, real), f'\nactual = {real}')
+
+    @unittest.skip
+    def test_atoms_in_shell(self):
+        coords = np.array([[1, 1, 1], [2, 1, 1], [5, 1, 1], [9, 1, 1]])
+        unit_cell = UnitCell(np.array([[10, 0, 0], [0, 10, 0], [0, 0, 10]]))
+        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+        atoms = conf.atoms_in_shell(0, 0, 5)
+
+        self.assertEqual([1, 2], [at.index for at in atoms])
+
+    @unittest.skip
+    def test_contiguous_configuration(self):
+        coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])
+        unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
+        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+
+        result = conf.contiguous_configuration()
+        self.assertTrue(isinstance(result, PeriodicRealConfiguration))
+        self.assertEqual(repr(self.chem_system), repr(result._chemical_system))
+        self.assertEqual(['coordinates'], list(result._variables.keys()))
+        self.assertTrue(np.allclose([[14., 3., 6.], [14., 3., 6.], [14., 3., 6.], [14., 3., 6.]],
+                                    result['coordinates']), f'\nactual = {result["coordinates"]}')
+        self.assertEqual(unit_cell, result._unit_cell)
+
+    @unittest.skip
+    def test_continuous_configuration(self):
+        coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])
+        unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
+        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+
+        result = conf.continuous_configuration()
+        self.assertTrue(isinstance(result, PeriodicRealConfiguration))
+        self.assertEqual(repr(self.chem_system), repr(result._chemical_system))
+        self.assertEqual(['coordinates'], list(result._variables.keys()))
+        self.assertTrue(np.allclose([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]],
+                                    result['coordinates']), f'\nactual = {result["coordinates"]}')
+        self.assertEqual(unit_cell, result._unit_cell)
+
+    @unittest.skip
+    def test_contiguous_offsets_valid_no_input(self):
+        coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])
+        unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
+        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+
+        offsets = conf.contiguous_offsets()
+        self.assertTrue(np.allclose([[ 0.,  0.,  0.], [-3., -3., -3.], [-6., -6., -6.], [-9., -9., -9.]], offsets),
+                        f'\nactual = {offsets}')
+
+    @unittest.skip
+    def test_contiguous_offsets_valid_specified_list(self):
+        self.chem_system.add_chemical_entity(AtomCluster('2', [Atom(), Atom()]))
+
+        coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0],
+                          [15.0, 15.0, 15.0], [10.0, 10.0, 10.0]])
+        unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
+        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+
+        offsets = conf.contiguous_offsets(self.chem_system.chemical_entities[0])
+        self.assertTrue(np.allclose([[ 0.,  0.,  0.], [-3., -3., -3.], [-6., -6., -6.], [-9., -9., -9.]],
+                                    offsets), f'\nactual = {offsets}')
+
+    def test_contiguous_offsets_invalid(self):
+        coords = np.array([[14.0, 3.0, 6.0], [32.0, 9.0, 15.0], [50.0, 15.0, 24.0], [68.0, 21.0, 33.0]])
+        unit_cell = UnitCell(np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]]))
+        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+
+        with self.assertRaises(ConfigurationError):
+            conf.contiguous_offsets([Atom(parent=ChemicalSystem())])
+
+
 @unittest.skip
 class TestConfiguration(unittest.TestCase):
     '''
@@ -195,163 +325,152 @@ class TestConfiguration(unittest.TestCase):
     '''
 
     def setUp(self):
-                
         self._chemicalSystem = ChemicalSystem()
         self._nAtoms = 4
 
         atoms = []
         for i in range(self._nAtoms):
             atoms.append(Atom(symbol='H'))
-        ac = AtomCluster('',atoms)
+        ac = AtomCluster('', atoms)
 
         self._chemicalSystem.add_chemical_entity(ac)
 
     def test_assertion(self):
-
-        coordinates = np.random.uniform(0,1,(2,3))
+        coordinates = np.random.uniform(0, 1, (2, 3))
         with self.assertRaises(ValueError):
-            _ = RealConfiguration(self._chemicalSystem,coordinates)
+            _ = RealConfiguration(self._chemicalSystem, coordinates)
 
-        coordinates = np.random.uniform(0,1,(2,3))
+        coordinates = np.random.uniform(0, 1, (2, 3))
         with self.assertRaises(ValueError):
-            _ = BoxConfiguration(self._chemicalSystem,coordinates)
+            _ = BoxConfiguration(self._chemicalSystem, coordinates)
 
     def test_real_configuration(self):
-
-        coordinates = np.random.uniform(0,1,(self._nAtoms,3))
-        conf = RealConfiguration(self._chemicalSystem,coordinates)
-        self.assertTrue(np.allclose(conf.to_real_coordinates(),coordinates,rtol=1.0e-6))
+        coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
+        conf = RealConfiguration(self._chemicalSystem, coordinates)
+        self.assertTrue(np.allclose(conf.to_real_coordinates(), coordinates, rtol=1.0e-6))
 
     def test_to_box_coordinates(self):
+        coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
+        conf = RealConfiguration(self._chemicalSystem, coordinates)
+        self.assertTrue(np.allclose(conf.to_box_coordinates(), coordinates, rtol=1.0e-6))
 
-        coordinates = np.random.uniform(0,1,(self._nAtoms,3))
-        conf = RealConfiguration(self._chemicalSystem,coordinates)
-        self.assertTrue(np.allclose(conf.to_box_coordinates(),coordinates,rtol=1.0e-6))
-
-        unitCell = np.array([[1.0,2.0,1.0],[2.0,-1.0,1.0],[3.0,1.0,1.0]],dtype=np.float)
-        coordinates = np.array(([1,2,3],[4,5,6],[7,8,9],[10,11,12]),dtype=np.float)
-        conf = RealConfiguration(self._chemicalSystem,coordinates,unitCell)
+        unitCell = np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]], dtype=np.float)
+        coordinates = np.array(([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]), dtype=np.float)
+        conf = RealConfiguration(self._chemicalSystem, coordinates, unitCell)
 
         boxCoordinates = conf.to_box_coordinates()
-        self.assertTrue(np.allclose(boxCoordinates,[[3.0,2.0,-2.0],
-                                                    [5.4,3.2,-2.6],
-                                                    [7.8,4.4,-3.2],
-                                                    [10.2,5.6,-3.8]],rtol=1.0e-6))
+        self.assertTrue(np.allclose(boxCoordinates, [[3.0, 2.0, -2.0],
+                                                     [5.4, 3.2, -2.6],
+                                                     [7.8, 4.4, -3.2],
+                                                     [10.2, 5.6, -3.8]], rtol=1.0e-6))
 
     def test_fold_coordinates(self):
-
-        unitCell = np.array([[1.0,2.0,1.0],[2.0,-1.0,1.0],[3.0,1.0,1.0]],dtype=np.float)
-        coordinates = np.array(([1,2,3],[4,5,6],[7,8,9],[10,11,12]),dtype=np.float)
-        conf = RealConfiguration(self._chemicalSystem,coordinates,unitCell)
+        unitCell = np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]], dtype=np.float)
+        coordinates = np.array(([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]), dtype=np.float)
+        conf = RealConfiguration(self._chemicalSystem, coordinates, unitCell)
         conf.fold_coordinates()
 
-        self.assertTrue(np.allclose(conf.variables['coordinates'],[[0.0,0.0,0.0],
-                                                                   [2.0,1.0,1.0],
-                                                                   [0.0,-1.0,0.0],
-                                                                   [0.0,1.0,0.0]],rtol=1.0e-6))
+        self.assertTrue(np.allclose(conf.variables['coordinates'], [[0.0, 0.0, 0.0],
+                                                                    [2.0, 1.0, 1.0],
+                                                                    [0.0, -1.0, 0.0],
+                                                                    [0.0, 1.0, 0.0]], rtol=1.0e-6))
 
     def test_box_configuration(self):
-
-        coordinates = np.random.uniform(0,1,(self._nAtoms,3))
-        conf = BoxConfiguration(self._chemicalSystem,coordinates)
-        self.assertTrue(np.allclose(conf.to_box_coordinates(),coordinates,rtol=1.0e-6))
+        coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
+        conf = BoxConfiguration(self._chemicalSystem, coordinates)
+        self.assertTrue(np.allclose(conf.to_box_coordinates(), coordinates, rtol=1.0e-6))
 
     def test_to_real_coordinates(self):
-
-        unitCell = np.array([[1.0,2.0,1.0],[2.0,-1.0,1.0],[3.0,1.0,1.0]],dtype=np.float)
-        coordinates = np.array(([1,2,3],[4,5,6],[7,8,9],[10,11,12]),dtype=np.float)
-        conf = BoxConfiguration(self._chemicalSystem,coordinates,unitCell)
+        unitCell = np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]], dtype=np.float)
+        coordinates = np.array(([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]), dtype=np.float)
+        conf = BoxConfiguration(self._chemicalSystem, coordinates, unitCell)
 
         realCoordinates = conf.to_real_coordinates()
-        self.assertTrue(np.allclose(realCoordinates,[[14.0,3.0,6.0],
-                                                     [32.0,9.0,15.0],
-                                                     [50.0,15.0,24.0],
-                                                     [68.0,21.0,33.0]],rtol=1.0e-6))
-            
+        self.assertTrue(np.allclose(realCoordinates, [[14.0, 3.0, 6.0],
+                                                      [32.0, 9.0, 15.0],
+                                                      [50.0, 15.0, 24.0],
+                                                      [68.0, 21.0, 33.0]], rtol=1.0e-6))
+
     def test_fold_coordinates_real_pbc(self):
-
-        unit_cell = np.array([[2,1,0],[-3,2,0],[2,1,-4]],dtype=np.float)
+        unit_cell = np.array([[2, 1, 0], [-3, 2, 0], [2, 1, -4]], dtype=np.float)
         coords = np.array([
-            [-1.65955991,  4.40648987, -9.9977125 ],
-            [-3.95334855, -7.06488218, -8.1532281 ],
+            [-1.65955991, 4.40648987, -9.9977125],
+            [-3.95334855, -7.06488218, -8.1532281],
             [-6.27479577, -3.08878546, -2.06465052],
-            [ 0.77633468, -1.61610971,  3.70439001]])
+            [0.77633468, -1.61610971, 3.70439001]])
 
-        conf = RealConfiguration(self._chemicalSystem,coords,unit_cell)
+        conf = RealConfiguration(self._chemicalSystem, coords, unit_cell)
         conf.fold_coordinates()
 
         real_coordinates = conf['coordinates']
 
-        self.assertTrue(np.allclose(real_coordinates,[[-0.65955991,  1.40648987, -1.9977125 ],
-                                                      [ 1.04665145, -1.06488218, -0.1532281 ],
-                                                      [-0.27479577, -0.08878546,  1.93534948],
-                                                      [-0.22366532,  1.38389029, -0.29560999]],rtol=1.0e-6))
+        self.assertTrue(np.allclose(real_coordinates, [[-0.65955991, 1.40648987, -1.9977125],
+                                                       [1.04665145, -1.06488218, -0.1532281],
+                                                       [-0.27479577, -0.08878546, 1.93534948],
+                                                       [-0.22366532, 1.38389029, -0.29560999]], rtol=1.0e-6))
 
     def test_fold_coordinates_real_nopbc(self):
-
         coords = np.array([
-            [-1.65955991,  4.40648987, -9.9977125 ],
-            [-3.95334855, -7.06488218, -8.1532281 ],
+            [-1.65955991, 4.40648987, -9.9977125],
+            [-3.95334855, -7.06488218, -8.1532281],
             [-6.27479577, -3.08878546, -2.06465052],
-            [ 0.77633468, -1.61610971,  3.70439001]])
+            [0.77633468, -1.61610971, 3.70439001]])
 
-        conf = RealConfiguration(self._chemicalSystem,coords)
+        conf = RealConfiguration(self._chemicalSystem, coords)
         conf.fold_coordinates()
 
         real_coordinates = conf['coordinates']
 
-        self.assertTrue(np.allclose(real_coordinates,coords,rtol=1.0e-6))
+        self.assertTrue(np.allclose(real_coordinates, coords, rtol=1.0e-6))
 
     def test_fold_coordinates_box_pbc(self):
-
-        unit_cell = np.array([[2,1,0],[-3,2,0],[2,1,-4]],dtype=np.float)
+        unit_cell = np.array([[2, 1, 0], [-3, 2, 0], [2, 1, -4]], dtype=np.float)
         coords = np.array([
-            [ 0.6, 0.8, -0.7],
-            [ 0.3, -0.1, 1.2],
-            [ 0.4, 0.2, -0.9],
+            [0.6, 0.8, -0.7],
+            [0.3, -0.1, 1.2],
+            [0.4, 0.2, -0.9],
             [-0.2, 0.4, 0.6]])
 
-        conf = BoxConfiguration(self._chemicalSystem,coords,unit_cell)
+        conf = BoxConfiguration(self._chemicalSystem, coords, unit_cell)
         conf.fold_coordinates()
 
         real_coordinates = conf['coordinates']
 
-        self.assertTrue(np.allclose(real_coordinates,[[-0.4,-0.2, 0.3],
-                                                      [ 0.3,-0.1, 0.2],
-                                                      [ 0.4, 0.2, 0.1],
-                                                      [-0.2, 0.4,-0.4]],rtol=1.0e-6))
+        self.assertTrue(np.allclose(real_coordinates, [[-0.4, -0.2, 0.3],
+                                                       [0.3, -0.1, 0.2],
+                                                       [0.4, 0.2, 0.1],
+                                                       [-0.2, 0.4, -0.4]], rtol=1.0e-6))
 
     def test_fold_coordinates_box_nopbc(self):
-
         coords = np.array([
-            [ 0.6, 0.8, -0.7],
-            [ 0.3, -0.1, 1.2],
-            [ 0.4, 0.2, -0.9],
+            [0.6, 0.8, -0.7],
+            [0.3, -0.1, 1.2],
+            [0.4, 0.2, -0.9],
             [-0.2, 0.4, 0.6]])
 
-        conf = BoxConfiguration(self._chemicalSystem,coords)
+        conf = BoxConfiguration(self._chemicalSystem, coords)
         conf.fold_coordinates()
 
         real_coordinates = conf['coordinates']
 
-        self.assertTrue(np.allclose(real_coordinates,coords,rtol=1.0e-6))
+        self.assertTrue(np.allclose(real_coordinates, coords, rtol=1.0e-6))
 
     def test_contiguous_configuration_real_pbc(self):
+        unit_cell = np.array([[2, 1, 0], [-3, 2, 0], [2, 1, -4]], dtype=np.float)
 
-        unit_cell = np.array([[2,1,0],[-3,2,0],[2,1,-4]],dtype=np.float)
-
-        box_coords = [[0.1,0.1,0.1],[0.3,0.2,0.4],[-1.3,-1.1,-1.3],[1.9,1.5,1.9]]
-        box_conf = BoxConfiguration(self._chemicalSystem,box_coords,unit_cell)
+        box_coords = [[0.1, 0.1, 0.1], [0.3, 0.2, 0.4], [-1.3, -1.1, -1.3], [1.9, 1.5, 1.9]]
+        box_conf = BoxConfiguration(self._chemicalSystem, box_coords, unit_cell)
         real_coords = box_conf.to_real_coordinates()
-        real_conf = RealConfiguration(self._chemicalSystem,real_coords,unit_cell)
+        real_conf = RealConfiguration(self._chemicalSystem, real_coords, unit_cell)
 
         contiguous_conf = real_conf.contiguous_configuration()
         real_coordinates = contiguous_conf['coordinates']
 
-        self.assertTrue(np.allclose(real_coordinates,[[ 0.1,  0.4,-0.4],
-                                                      [ 0.8,  1.1,-1.6],
-                                                      [-0.9, -0.8, 1.2],
-                                                      [-1.9,  0.8, 0.4]],rtol=1.0e-6))
+        self.assertTrue(np.allclose(real_coordinates, [[0.1, 0.4, -0.4],
+                                                       [0.8, 1.1, -1.6],
+                                                       [-0.9, -0.8, 1.2],
+                                                       [-1.9, 0.8, 0.4]], rtol=1.0e-6))
+
 
 def suite():
     loader = unittest.TestLoader()
@@ -362,5 +481,3 @@ def suite():
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)
-            
-        


### PR DESCRIPTION
As with the other PRs, here I have also mostly just added type hints, expanded documentation. The tests now cover all classes and all methods;; I tried keeping the values from the previous tests where I was able to see which ones did what. In terms of documentation, I reformatted it to match the style from other parts of MDANSE, particularly the ones I have reviewed already. There were no major changes, only a couple minor ones:

1. I renamed the `atomsInShell()` method to `atoms_in_shell` so as to match both the names of the other methods and PEP8.
2. In the `contiguous_configuration` and `continuous_configuration` methods of `_PeriodicConfiguration` subclasses, I have changed the line `conf = self` to `conf = self.clone()` since I reckoned that the purpose of those methods was to return a new object rather than modify itself and then return the modified self. Please correct me if I am wrong.
3. I had to add `.astype(np.float64)` when passing the coordinates to some of the Cython functions to get them to work
4. I modified the `contiguous_offsets` methods to pass in to the Cython function only the coordinates corresponding to the atoms that were passed in via the chemical_entities argument.
5. I had to add the `casting='unsafe'` argument to np.add in `_Configuration.apply_transformation` method to get it to work with rotations.

Please have a look and let me know all your comments.

That said though, the tests are not passing, and with that, I would like to ask for your help. The tests that are failing I have kept that way because I do not understand what/why exactly the method is doing, so I didn't want to just copy the results over. In fact I'm a bit sceptical about some of the results, so I would like to discuss with you.

1. `_Configuration.apply_transformation()` - in this one, it's, I think, simply an issue me not understanding how the transformations work. I attempted to test this by rotating 180° around the x-axis, but the results I'm getting are different from that, so I think the Rotation object I created simply does something else. Can you please check this? If the result of the method is correct for the transformation, I'll just copy the results as the expected results.
2. `PeriodicBoxConfiguration.atoms_in_shell()` and `PeriodicRealConfiguration.atoms_in_shell()` - here, I genuinely believe that with the given parameters, the output should be [1, 2] instead of [1, 2, 3]. Further, I don't understand what's going on in the Cython code; why are these lines `sdx -= round(sdx)` present? Rounding by itself I could understand, but why is it subtracted?
3. `PeriodicBoxConfiguration.contiguous_offsets()` and `PeriodicRealConfiguration.contiguous_offsets()` - in this case, I have no idea what's going on, but I would assume that, since it's an offset, these methods would return the difference between the coordinates calculated by the `contiguous_configuration()` methods and the normal coordinates, but that's not the case. If the current results are correct, I''ll just copy them as the expected results, but please have a look.

Lastly, I have no idea what the methods `PeriodicBoxConfiguration.contiguous_configuration()`, `PeriodicRealConfiguration.contiguous_configuration()`, and `PeriodicRealConfiguration.continuous_configuration()` are calculating, so I just copied the current output as the expected output, but because of that, I would appreciate if you could check these as well that they are doing what they are supposed to be doing.

Thank you for your help in advance!