### PR TITLE
Fix system issues caused by Ubuntu 22 installer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -324,7 +324,7 @@ jobs:
 
       - run: sudo apt-get install dos2unix
 
-      - run: conda remove ncurses
+      - run: conda remove ncurses --force
 
       - name: Deploy
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -256,8 +256,7 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' ) ||
-          contains( github.ref, '151' )
+          contains( github.ref, 'web' )
         run: |
           cd $CONDA/envs
           tar -czf python.tar.gz mdanse
@@ -270,8 +269,7 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' ) ||
-          contains( github.ref, '151' )
+          contains( github.ref, 'web' )
         uses: actions/upload-artifact@v2
         with:
           name: ubuntu-22.04_artifacts
@@ -290,8 +288,7 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' ) ||
-      contains( github.ref, '151' )
+      contains( github.ref, 'web' )
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -256,7 +256,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '151' )
         run: |
           cd $CONDA/envs
           tar -czf python.tar.gz mdanse
@@ -269,7 +270,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '151' )
         uses: actions/upload-artifact@v2
         with:
           name: ubuntu-22.04_artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,6 @@ on: [push, workflow_dispatch]
 jobs:
   ci_ubuntu:
     runs-on: ${{ matrix.os }}
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -190,7 +189,6 @@ jobs:
 
   ci_ubuntu22:
     runs-on: 'ubuntu-22.04'
-    if: false
     strategy:
       fail-fast: false
     steps:
@@ -290,7 +288,8 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' )
+      contains( github.ref, 'web' ) ||
+      contains( github.ref, '151' )
     steps:
       - uses: actions/checkout@v2
 
@@ -326,6 +325,7 @@ jobs:
       - name: Deploy
         run: |
           sed -i 's|PYTHONEXE=$HOME/python|PYTHONEXE=$CONDA/envs/mdanse|' $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh
+          sudo rm $CONDA/envs/mdanse/lib/libtinfo*
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh
@@ -496,7 +496,6 @@ jobs:
   # WINDOWS
   ci_windows:
     runs-on: windows-2019
-    if: false
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -327,7 +327,7 @@ jobs:
       - name: Deploy
         run: |
           sed -i 's|PYTHONEXE=$HOME/python|PYTHONEXE=$CONDA/envs/mdanse|' $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh
-          sudo rm $CONDA/envs/mdanse/lib/libtinfo*
+          sudo rm -v $CONDA/envs/mdanse/lib/libtinfo.*
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -329,6 +329,8 @@ jobs:
       - name: Deploy
         run: |
           sed -i 's|PYTHONEXE=$HOME/python|PYTHONEXE=$CONDA/envs/mdanse|' $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh
+          sudo rm $CONDA/envs/mdanse/lib/libtinfo*
+          sudo rm $CONDA/envs/mdanse/lib/libncurses*
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -256,7 +256,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '151' )
         run: |
           cd $CONDA/envs
           tar -czf python.tar.gz mdanse
@@ -269,7 +270,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '151' )
         uses: actions/upload-artifact@v2
         with:
           name: ubuntu-22.04_artifacts
@@ -288,7 +290,8 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' )
+      contains( github.ref, 'web' ) ||
+      contains( github.ref, '151' )
     steps:
       - uses: actions/checkout@v2
 
@@ -321,10 +324,11 @@ jobs:
 
       - run: sudo apt-get install dos2unix
 
+      - run: conda remove ncurses
+
       - name: Deploy
         run: |
           sed -i 's|PYTHONEXE=$HOME/python|PYTHONEXE=$CONDA/envs/mdanse|' $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh
-          sudo rm -v $CONDA/envs/mdanse/lib/libtinfo.*
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+version 1.5.2
+-------------
+* FIXED issue #151 MDANSE should no longer interfere with system functionalities such as nano on Ubuntu 22
+
 version 1.5.1
 --------------
 * ADDED issue #129 Installers for Ubuntu 22.x are now automatically generated and available for download


### PR DESCRIPTION
**Description of work**

Fixes #151 

Installing MDANSE on Ubuntu 22 using the installer caused some system issues like warnings showing up in bash or the inability to use some utilities like nano. This was caused by the inclusion of `libtinfo.so.6` library with the installer (generated by conda on the CI/CD). Removing this library prior to packaging MDANSE has removed the issue.

**To test**

1. Download Ubuntu 22 installer from [here](https://github.com/ISISNeutronMuon/MDANSE/actions/runs/3009421555) and install it.
2. Open a new shell and use various command line tools.
3. Observe no issues.