### PR TITLE
Fix inheritance diagrams in installer-enclosed documentation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -715,7 +715,7 @@ jobs:
 
       - name: Alter conf_api.py for correct sphinx build
         run: |
-          cd %GITHUB_WORKSPACE%\Doc\
+          Set-Location $Env:GITHUB_WORKSPACE\Doc\
           (gc conf_api.py) -replace '#graphviz_dot', 'graphviz_dot' | Out-File -encoding UTF8 conf_api.py
 
       - name: Deploy

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -713,6 +713,11 @@ jobs:
           %CONDA%\envs\mdanse\python.exe -m pip install PyQt4‑4.11.4‑cp27‑cp27m‑win_amd64.whl VTK‑6.3.0‑cp27‑cp27m‑win_amd64.whl wxPython_common‑3.0.2.0‑py2‑none‑any.whl wxPython‑3.0.2.0‑cp27‑none‑win_amd64.whl
         shell: cmd /C CALL {0}
 
+      - name: Alter conf_api.py for correct sphinx build
+        run: |
+          cd %GITHUB_WORKSPACE%\Doc\
+          (gc conf_api.py) -replace '#graphviz_dot', 'graphviz_dot' | Out-File -encoding UTF8 conf_api.py
+
       - name: Deploy
         run: |
           mkdir %GITHUB_WORKSPACE%\BuildServer\Windows\Build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -199,6 +199,7 @@ jobs:
 
   ci_ubuntu22:
     runs-on: 'ubuntu-22.04'
+    if: false
     strategy:
       fail-fast: false
     steps:
@@ -355,6 +356,7 @@ jobs:
   # OSX
   ci_osx:
     runs-on: ${{ matrix.os }}
+    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,6 @@ on: [push, workflow_dispatch]
 jobs:
   ci_ubuntu:
     runs-on: ${{ matrix.os }}
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python2 -m pip install numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro sphinx==1.6.7 stdeb docutils==0.17.1 pyyaml h5py psutil
+          python2 -m pip install numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro stdeb pyyaml h5py psutil
           sudo cp /usr/include/netcdf.h $RUNNER_TOOL_CACHE/Python/2.7.18/x64/include/python2.7
 
       - name: Install netCDF4 python package
@@ -83,7 +82,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '152' )
         run: |
           cd $RUNNER_TOOL_CACHE/Python/2.7.18
           mv x64 python
@@ -97,7 +97,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '152' )
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}_artifacts
@@ -119,7 +120,8 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' )
+      contains( github.ref, 'web' ) ||
+      contains( github.ref, '152' )
     steps:
       - uses: actions/checkout@v2
 
@@ -152,10 +154,11 @@ jobs:
           sudo cp -r ~/tempenv/lib/python2.7/site-packages/vtk ~/python/lib/python2.7/site-packages
           sudo cp ~/tempenv/lib/libvtk* ~/python/lib
 
-      - run: sudo apt-get install dos2unix
+      - run: sudo apt-get install dos2unix graphviz
 
       - name: Deploy
         run: |
+          sudo ~/python/bin/python -m pip install sphinx==1.6.7 stdeb docutils==0.17.1 graphviz
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh
@@ -212,7 +215,7 @@ jobs:
 
       - name: Install python packages
         run: |
-          $CONDA/envs/mdanse/bin/python -m pip install numpy matplotlib Cython Pyro sphinx==1.6.7 stdeb docutils==0.17.1 pyyaml h5py psutil
+          $CONDA/envs/mdanse/bin/python -m pip install numpy matplotlib Cython Pyro stdeb pyyaml h5py psutil
 
       - name: Install ScientificPython
         run: |
@@ -258,7 +261,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '152' )
         run: |
           cd $CONDA/envs
           tar -czf python.tar.gz mdanse
@@ -271,7 +275,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '152' )
         uses: actions/upload-artifact@v2
         with:
           name: ubuntu-22.04_artifacts
@@ -290,7 +295,8 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' )
+      contains( github.ref, 'web' ) ||
+      contains( github.ref, '152' )
     steps:
       - uses: actions/checkout@v2
 
@@ -321,10 +327,11 @@ jobs:
           sudo conda install -n mdanse -c daf wxpython
           sudo conda install -n mdanse -c ccordoba12 vtk
 
-      - run: sudo apt-get install dos2unix
+      - run: sudo apt-get install dos2unix graphviz
 
       - name: Deploy
         run: |
+          sudo $CONDA/envs/mdanse/bin/python -m pip install sphinx==1.6.7 docutils==0.17.1 graphviz
           sed -i 's|PYTHONEXE=$HOME/python|PYTHONEXE=$CONDA/envs/mdanse|' $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
@@ -358,7 +365,7 @@ jobs:
 
       - name: Install dependencies with pip
         run: |
-          python2 -m pip install numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro sphinx==1.6.7 stdeb docutils==0.17.1 pyyaml h5py psutil
+          python2 -m pip install numpy==1.16.6 matplotlib==2.2.5 Cython==0.29.24 Pyro stdeb pyyaml h5py psutil
 
       - name: Install netCDF4 python package
         run: |
@@ -418,14 +425,14 @@ jobs:
           python2 AllTests.py
 
       - name: Tar python
-        if: ${{ (matrix.os == 'macos-12') && ( contains( github.ref, 'main' ) || contains( github.ref, 'develop' ) || contains( github.ref, 'release-' ) || contains( github.ref, 'hotfix-' ) || contains( github.ref, 'build-' ) || contains( github.ref, 'tags' ) || contains( github.ref, 'web' ) || contains( github.ref, '136' ) ) }}
+        if: ${{ (matrix.os == 'macos-12') && ( contains( github.ref, 'main' ) || contains( github.ref, 'develop' ) || contains( github.ref, 'release-' ) || contains( github.ref, 'hotfix-' ) || contains( github.ref, 'build-' ) || contains( github.ref, 'tags' ) || contains( github.ref, 'web' ) || contains( github.ref, '136' ) || contains( github.ref, '152' ) ) }}
         run: |
           cd $RUNNER_TOOL_CACHE/Python/2.7.18
           mv x64 Resources
           tar -czf python.tar.gz Resources
 
       - name: Upload artifacts
-        if: ${{ (matrix.os == 'macos-12') && ( contains( github.ref, 'main' ) || contains( github.ref, 'develop' ) || contains( github.ref, 'release-' ) || contains( github.ref, 'hotfix-' ) || contains( github.ref, 'build-' ) || contains( github.ref, 'tags' ) || contains( github.ref, 'web' ) || contains( github.ref, '136' ) ) }}
+        if: ${{ (matrix.os == 'macos-12') && ( contains( github.ref, 'main' ) || contains( github.ref, 'develop' ) || contains( github.ref, 'release-' ) || contains( github.ref, 'hotfix-' ) || contains( github.ref, 'build-' ) || contains( github.ref, 'tags' ) || contains( github.ref, 'web' ) || contains( github.ref, '136' ) || contains( github.ref, '152' ) ) }}
         uses: actions/upload-artifact@v2
         with:
           name: MacOS_artifacts
@@ -444,7 +451,7 @@ jobs:
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
       contains( github.ref, 'web' ) || 
-      contains( github.ref, '136' )
+      contains( github.ref, '152' )
     steps:
       - uses: actions/checkout@v2
 
@@ -454,7 +461,7 @@ jobs:
           name: MacOS_artifacts
           path: ~/
 
-      - run: brew install netcdf
+      - run: brew install netcdf graphviz
 
       - name: Untar python
         run: |
@@ -476,6 +483,7 @@ jobs:
 
       - name: Deploy MDANSE
         run: |
+          sudo  ~/Contents/Resources/bin/python -m pip install sphinx==1.6.7 docutils==0.17.1 graphviz
           source $GITHUB_WORKSPACE/BuildServer/Unix/MacOS/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/MacOS/deploy.sh
@@ -605,7 +613,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '152' )
         run: |
           cd /D %CONDA%\envs
           tar -czf mdanse.tar.gz mdanse
@@ -619,7 +628,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '152' )
         uses: actions/upload-artifact@v2
         with:
           name: windows_artifacts
@@ -636,7 +646,8 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' )
+      contains( github.ref, 'web' ) ||
+      contains( github.ref, '152' )
     steps:
       - uses: actions/checkout@v2
 
@@ -693,6 +704,7 @@ jobs:
       - name: Install packages required for documentation and psutil
         run: |
           %CONDA%\envs\mdanse\python.exe -m pip install docutils==0.17.1 sphinx==1.6.7 stdeb psutil
+          conda install graphviz
         shell: cmd /C CALL {0}
 
       - name: Install GUI dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,6 +154,12 @@ jobs:
           sudo cp -r ~/tempenv/lib/python2.7/site-packages/vtk ~/python/lib/python2.7/site-packages
           sudo cp ~/tempenv/lib/libvtk* ~/python/lib
 
+      - name: Install libgtk on ubuntu 20 so that sphinx can document GUI modules
+        if: ${{ (matrix.os == 'ubuntu-20.04') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgtk2.0-0 libgtk2.0-dev
+
       - run: sudo apt-get install dos2unix graphviz
 
       - name: Deploy
@@ -326,7 +332,7 @@ jobs:
           sudo conda install -n mdanse -c daf wxpython
           sudo conda install -n mdanse -c ccordoba12 vtk
 
-      - run: sudo apt-get install dos2unix graphviz
+      - run: sudo apt-get install dos2unix graphviz libgtk2.0-0 libgtk2.0-dev
 
       - name: Deploy
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -502,7 +502,6 @@ jobs:
   # WINDOWS
   ci_windows:
     runs-on: windows-2019
-    if: false
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,6 @@ on: [push, workflow_dispatch]
 jobs:
   ci_ubuntu:
     runs-on: ${{ matrix.os }}
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -108,7 +107,6 @@ jobs:
 
 
   deploy_ubuntu:
-    needs: ci_ubuntu
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -194,7 +192,6 @@ jobs:
 
   ci_ubuntu22:
     runs-on: 'ubuntu-22.04'
-    if: false
     strategy:
       fail-fast: false
     steps:
@@ -351,7 +348,6 @@ jobs:
   # OSX
   ci_osx:
     runs-on: ${{ matrix.os }}
-    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on: [push, workflow_dispatch]
 jobs:
   ci_ubuntu:
     runs-on: ${{ matrix.os }}
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -153,12 +154,6 @@ jobs:
           sudo conda install -p ~/tempenv -c ccordoba12 vtk
           sudo cp -r ~/tempenv/lib/python2.7/site-packages/vtk ~/python/lib/python2.7/site-packages
           sudo cp ~/tempenv/lib/libvtk* ~/python/lib
-
-      - name: Install libgtk on ubuntu 20 so that sphinx can document GUI modules
-        if: ${{ (matrix.os == 'ubuntu-20.04') }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install libgtk2.0-0 libgtk2.0-dev
 
       - run: sudo apt-get install dos2unix graphviz
 
@@ -333,7 +328,7 @@ jobs:
           sudo conda install -n mdanse -c daf wxpython
           sudo conda install -n mdanse -c ccordoba12 vtk
 
-      - run: sudo apt-get install dos2unix graphviz libgtk2.0-0 libgtk2.0-dev
+      - run: sudo apt-get install dos2unix graphviz
 
       - name: Deploy
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,6 +107,7 @@ jobs:
 
 
   deploy_ubuntu:
+    needs: ci_ubuntu
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,7 +158,6 @@ jobs:
 
       - name: Deploy
         run: |
-          sudo ~/python/bin/python -m pip install sphinx==1.6.7 stdeb docutils==0.17.1 graphviz
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,6 +158,7 @@ jobs:
 
       - name: Deploy
         run: |
+          sudo ~/python/bin/python -m pip install sphinx==1.6.7 stdeb docutils==0.17.1 graphviz
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh
@@ -192,7 +193,6 @@ jobs:
 
   ci_ubuntu22:
     runs-on: 'ubuntu-22.04'
-    if: false
     strategy:
       fail-fast: false
     steps:
@@ -482,7 +482,6 @@ jobs:
 
       - name: Deploy MDANSE
         run: |
-          sudo  ~/Contents/Resources/bin/python -m pip install sphinx==1.6.7 docutils==0.17.1 graphviz
           source $GITHUB_WORKSPACE/BuildServer/Unix/MacOS/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/MacOS/deploy.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -399,19 +399,16 @@ jobs:
           python2 setup.py install
 
       - name: Run dependency tests
-        if: false
         run: |
           cd $GITHUB_WORKSPACE/Tests/DependenciesTests
           python2 AllTests.py
 
       - name: Run unit tests
-        if: false
         run: |
           cd $GITHUB_WORKSPACE/Tests/UnitTests
           python2 AllTests.py
 
       - name: Run functional tests
-        if: false
         run: |
           cd $GITHUB_WORKSPACE/Tests/FunctionalTests/Jobs
           python2 BuildJobTests.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,8 +82,7 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' ) ||
-          contains( github.ref, '152' )
+          contains( github.ref, 'web' )
         run: |
           cd $RUNNER_TOOL_CACHE/Python/2.7.18
           mv x64 python
@@ -97,8 +96,7 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' ) ||
-          contains( github.ref, '152' )
+          contains( github.ref, 'web' )
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}_artifacts
@@ -120,8 +118,7 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' ) ||
-      contains( github.ref, '152' )
+      contains( github.ref, 'web' )
     steps:
       - uses: actions/checkout@v2
 
@@ -260,8 +257,7 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' ) ||
-          contains( github.ref, '152' )
+          contains( github.ref, 'web' )
         run: |
           cd $CONDA/envs
           tar -czf python.tar.gz mdanse
@@ -274,8 +270,7 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' ) ||
-          contains( github.ref, '152' )
+          contains( github.ref, 'web' )
         uses: actions/upload-artifact@v2
         with:
           name: ubuntu-22.04_artifacts
@@ -294,8 +289,7 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' ) ||
-      contains( github.ref, '152' )
+      contains( github.ref, 'web' )
     steps:
       - uses: actions/checkout@v2
 
@@ -424,14 +418,14 @@ jobs:
           python2 AllTests.py
 
       - name: Tar python
-        if: ${{ (matrix.os == 'macos-12') && ( contains( github.ref, 'main' ) || contains( github.ref, 'develop' ) || contains( github.ref, 'release-' ) || contains( github.ref, 'hotfix-' ) || contains( github.ref, 'build-' ) || contains( github.ref, 'tags' ) || contains( github.ref, 'web' ) || contains( github.ref, '136' ) || contains( github.ref, '152' ) ) }}
+        if: ${{ (matrix.os == 'macos-12') && ( contains( github.ref, 'main' ) || contains( github.ref, 'develop' ) || contains( github.ref, 'release-' ) || contains( github.ref, 'hotfix-' ) || contains( github.ref, 'build-' ) || contains( github.ref, 'tags' ) || contains( github.ref, 'web' ) ) }}
         run: |
           cd $RUNNER_TOOL_CACHE/Python/2.7.18
           mv x64 Resources
           tar -czf python.tar.gz Resources
 
       - name: Upload artifacts
-        if: ${{ (matrix.os == 'macos-12') && ( contains( github.ref, 'main' ) || contains( github.ref, 'develop' ) || contains( github.ref, 'release-' ) || contains( github.ref, 'hotfix-' ) || contains( github.ref, 'build-' ) || contains( github.ref, 'tags' ) || contains( github.ref, 'web' ) || contains( github.ref, '136' ) || contains( github.ref, '152' ) ) }}
+        if: ${{ (matrix.os == 'macos-12') && ( contains( github.ref, 'main' ) || contains( github.ref, 'develop' ) || contains( github.ref, 'release-' ) || contains( github.ref, 'hotfix-' ) || contains( github.ref, 'build-' ) || contains( github.ref, 'tags' ) || contains( github.ref, 'web' ) ) }}
         uses: actions/upload-artifact@v2
         with:
           name: MacOS_artifacts
@@ -449,8 +443,7 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' ) || 
-      contains( github.ref, '152' )
+      contains( github.ref, 'web' )
     steps:
       - uses: actions/checkout@v2
 
@@ -610,8 +603,7 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' ) ||
-          contains( github.ref, '152' )
+          contains( github.ref, 'web' )
         run: |
           cd /D %CONDA%\envs
           tar -czf mdanse.tar.gz mdanse
@@ -625,8 +617,7 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' ) ||
-          contains( github.ref, '152' )
+          contains( github.ref, 'web' )
         uses: actions/upload-artifact@v2
         with:
           name: windows_artifacts
@@ -643,8 +634,7 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' ) ||
-      contains( github.ref, '152' )
+      contains( github.ref, 'web' )
     steps:
       - uses: actions/checkout@v2
 

--- a/BuildServer/Unix/MacOS/deploy.sh
+++ b/BuildServer/Unix/MacOS/deploy.sh
@@ -20,6 +20,7 @@ export PYTHONPATH=${CI_TEMP_INSTALL_DIR}/lib/python2.7/site-packages:${PYTHONPAT
 sudo install_name_tool -change /Users/runner/hostedtoolcache/Python/2.7.18/x64/lib/libpython2.7.dylib /Users/runner/Contents/Resources/lib/libpython2.7.dylib /Users/runner/Contents/Resources/bin/python2.7
 sudo install_name_tool -change /Users/runner/hostedtoolcache/Python/2.7.18/x64/lib/libpython2.7.dylib /Users/runner/Contents/Resources/lib/libpython2.7.dylib /Users/runner/Contents/Resources/bin/python
 export MACOSX_DEPLOYMENT_TARGET=10.9
+sudo ${PYTHONEXE} -m pip install sphinx==1.6.7 stdeb docutils==0.17.1 graphviz
 sudo ${PYTHONEXE} setup.py build build_api build_help install
 
 status=$?
@@ -47,7 +48,7 @@ sudo cp -fv "$GITHUB_WORKSPACE/BuildServer/Unix/MacOS/py2app/qt5.py" "$PYTHON_FO
 sudo cp -fv "$GITHUB_WORKSPACE/BuildServer/Unix/MacOS/py2app/qt6.py" "$PYTHON_FOLDER/lib/python2.7/site-packages/py2app/recipes"
 
 echo "Uninstall sphinx and its dependencies"
-sudo ${PYTHONEXE} -m pip uninstall -y sphinx Jinja2 MarkupSafe Pygments alabaster babel chardet colorama docutils idna imagesize requests snowballstemmer sphinxcontrib-websupport typing urllib3
+sudo ${PYTHONEXE} -m pip uninstall -y sphinx Jinja2 MarkupSafe Pygments alabaster babel chardet colorama docutils idna imagesize requests snowballstemmer sphinxcontrib-websupport typing urllib3 graphviz
 
 echo "Building mdanse app"
 cd "${GITHUB_WORKSPACE}/BuildServer/Unix/MacOS" || exit

--- a/BuildServer/Windows/deploy.bat
+++ b/BuildServer/Windows/deploy.bat
@@ -31,12 +31,14 @@ rmdir /s /q PyQT4
 rmdir /s /q PyQT4-4.11.4.dist-info
 rmdir /s /q matplotlib\mpl-data\sample_data
 "%PYTHON_EXE%" -m pip uninstall sphinx Jinja2 MarkupSafe Pygments alabaster babel chardet colorama docutils idna imagesize requests snowballstemmer sphinxcontrib-websupport typing urllib3 -y
-conda remove graphviz
 cd %MDANSE_TEMPORARY_INSTALLATION_DIR%\Library
 rmdir /s /q cmake
 del /f /q USING*
 cd bin
 del /f /q *.exe
+rmdir /s /q graphviz
+cd ..\share
+rmdir /s /q graphviz
 
 cd /D "%GITHUB_WORKSPACE%\BuildServer\Windows"
 

--- a/BuildServer/Windows/deploy.bat
+++ b/BuildServer/Windows/deploy.bat
@@ -13,7 +13,7 @@ rem see http://p-nand-q.com/python/building-python-27-with-vs2010.html for more 
 set VS90COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\Tools"
 
 rem Prepare the environment for building MDANSE
-set PATH="C:\Program Files (x86)\Microsoft Visual Studio 9.0\";"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\Bin\x86_amd64";%PATH%
+set PATH="C:\Program Files (x86)\Microsoft Visual Studio 9.0\";"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\Bin\x86_amd64";"%CONDA%\envs\mdanse\Library\bin\graphviz";%PATH%
 copy /y "%GITHUB_WORKSPACE%\BuildServer\setup.py" %GITHUB_WORKSPACE%
 
 "%PYTHON_EXE%" setup.py build build_api build_help install

--- a/BuildServer/Windows/deploy.bat
+++ b/BuildServer/Windows/deploy.bat
@@ -13,10 +13,8 @@ rem see http://p-nand-q.com/python/building-python-27-with-vs2010.html for more 
 set VS90COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\Tools"
 
 rem Prepare the environment for building MDANSE
-set PATH="C:\Program Files (x86)\Microsoft Visual Studio 9.0\";"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\Bin\x86_amd64";"%CONDA%\envs\mdanse\Library\bin\graphviz";"%CONDA%\envs\mdanse\Library\bin";%PATH%
-cd /d %CONDA%\envs\mdanse\Library\bin\graphviz
-dir /s
-cd %MDANSE_SOURCE_DIR%
+set PATH="C:\Program Files (x86)\Microsoft Visual Studio 9.0\";"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\Bin\x86_amd64";%PATH%
+powershell -Command "(gc %GITHUB_WORKSPACE%\Doc\conf_api.py) -replace '#graphviz_dot', 'graphviz_dot' | Out-File -encoding UTF8 %GITHUB_WORKSPACE%\Doc\conf_api.py"
 copy /y "%GITHUB_WORKSPACE%\BuildServer\setup.py" %GITHUB_WORKSPACE%
 
 "%PYTHON_EXE%" setup.py build build_api build_help install

--- a/BuildServer/Windows/deploy.bat
+++ b/BuildServer/Windows/deploy.bat
@@ -14,7 +14,9 @@ set VS90COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\To
 
 rem Prepare the environment for building MDANSE
 set PATH="C:\Program Files (x86)\Microsoft Visual Studio 9.0\";"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\Bin\x86_amd64";"%CONDA%\envs\mdanse\Library\bin\graphviz";"%CONDA%\envs\mdanse\Library\bin";%PATH%
-echo %PATH%
+cd /d %CONDA%\envs\mdanse\Library\bin\graphviz
+dir /s
+cd %MDANSE_SOURCE_DIR%
 copy /y "%GITHUB_WORKSPACE%\BuildServer\setup.py" %GITHUB_WORKSPACE%
 
 "%PYTHON_EXE%" setup.py build build_api build_help install

--- a/BuildServer/Windows/deploy.bat
+++ b/BuildServer/Windows/deploy.bat
@@ -14,7 +14,6 @@ set VS90COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\To
 
 rem Prepare the environment for building MDANSE
 set PATH="C:\Program Files (x86)\Microsoft Visual Studio 9.0\";"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\Bin\x86_amd64";%PATH%
-powershell -Command "(gc %GITHUB_WORKSPACE%\Doc\conf_api.py) -replace '#graphviz_dot', 'graphviz_dot' | Out-File -encoding UTF8 %GITHUB_WORKSPACE%\Doc\conf_api.py"
 copy /y "%GITHUB_WORKSPACE%\BuildServer\setup.py" %GITHUB_WORKSPACE%
 
 "%PYTHON_EXE%" setup.py build build_api build_help install

--- a/BuildServer/Windows/deploy.bat
+++ b/BuildServer/Windows/deploy.bat
@@ -13,7 +13,8 @@ rem see http://p-nand-q.com/python/building-python-27-with-vs2010.html for more 
 set VS90COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\Tools"
 
 rem Prepare the environment for building MDANSE
-set PATH="C:\Program Files (x86)\Microsoft Visual Studio 9.0\";"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\Bin\x86_amd64";"%CONDA%\envs\mdanse\Library\bin\graphviz";%PATH%
+set PATH="C:\Program Files (x86)\Microsoft Visual Studio 9.0\";"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\Bin\x86_amd64";"%CONDA%\envs\mdanse\Library\bin\graphviz";"%CONDA%\envs\mdanse\Library\bin";%PATH%
+echo %PATH%
 copy /y "%GITHUB_WORKSPACE%\BuildServer\setup.py" %GITHUB_WORKSPACE%
 
 "%PYTHON_EXE%" setup.py build build_api build_help install
@@ -31,6 +32,7 @@ rmdir /s /q PyQT4
 rmdir /s /q PyQT4-4.11.4.dist-info
 rmdir /s /q matplotlib\mpl-data\sample_data
 "%PYTHON_EXE%" -m pip uninstall sphinx Jinja2 MarkupSafe Pygments alabaster babel chardet colorama docutils idna imagesize requests snowballstemmer sphinxcontrib-websupport typing urllib3 -y
+conda remove graphviz
 cd %MDANSE_TEMPORARY_INSTALLATION_DIR%\Library
 rmdir /s /q cmake
 del /f /q USING*

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+version 1.5.2
+-------------
+* FIXED issue #152 MDANSE API documentation that comes with released installers now has class inheritance diagrams displayed properly
+
 version 1.5.1
 --------------
 * ADDED issue #129 Installers for Ubuntu 22.x are now automatically generated and available for download

--- a/Doc/conf_api.py
+++ b/Doc/conf_api.py
@@ -72,6 +72,9 @@ inheritance_graph_attrs = dict(rankdir="TB", size='""')
 
 inheritance_node_attrs = dict(color='lightblue', style='filled')
 
+# The following is uncommented only in Windows CI/CD
+#graphviz_dot = r'C:\Miniconda\envs\mdanse\Library\bin\graphviz\dot.exe'
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 


### PR DESCRIPTION
**Description of work**

Fixes #152 

MDANSE API documentation has inbuilt inheritance diagrams but they were not being displayed properly because graphviz was not being installed on CI/CD. This has been fixed by installing graphviz.

**To test**

1. Download one of the installers from [this run](https://github.com/ISISNeutronMuon/MDANSE/actions/runs/3015397798) and install MDANSE.
2. Open MDANSE and click on the API documentation button in toolbar.
3. Navigate to e.g. `MDANSE.Framework.Jobs.AngularCorrelation`
4. Observe that below the 'Inheritance' heading is displayed and inheritance diagram.


I have tested this on Windows computer and Ubuntu VM, but everyone feel free to go over it yourselves. @MBartkowiakSTFC can you please test on MacOS?