### PR TITLE
Fix VTK parts of MDANSE on Ubuntu 22

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,6 @@ on: [push, workflow_dispatch]
 jobs:
   ci_ubuntu:
     runs-on: ${{ matrix.os }}
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -257,8 +256,7 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' ) ||
-          contains( github.ref, '158' )
+          contains( github.ref, 'web' )
         run: |
           cd $CONDA/envs
           tar -czf python.tar.gz mdanse
@@ -271,8 +269,7 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' ) ||
-          contains( github.ref, '158' )
+          contains( github.ref, 'web' )
         uses: actions/upload-artifact@v2
         with:
           name: ubuntu-22.04_artifacts
@@ -291,8 +288,7 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' ) ||
-      contains( github.ref, '158' )
+      contains( github.ref, 'web' )
     steps:
       - uses: actions/checkout@v2
 
@@ -346,7 +342,6 @@ jobs:
   # OSX
   ci_osx:
     runs-on: ${{ matrix.os }}
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -497,7 +492,6 @@ jobs:
   # WINDOWS
   ci_windows:
     runs-on: windows-2019
-    if: false
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -190,7 +190,6 @@ jobs:
 
   ci_ubuntu22:
     runs-on: 'ubuntu-22.04'
-    if: false
     strategy:
       fail-fast: false
     steps:
@@ -258,7 +257,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '158' )
         run: |
           cd $CONDA/envs
           tar -czf python.tar.gz mdanse
@@ -271,7 +271,8 @@ jobs:
           contains( github.ref, 'hotfix-' ) ||
           contains( github.ref, 'build-' ) ||
           contains( github.ref, 'tags' ) ||
-          contains( github.ref, 'web' )
+          contains( github.ref, 'web' ) ||
+          contains( github.ref, '158' )
         uses: actions/upload-artifact@v2
         with:
           name: ubuntu-22.04_artifacts
@@ -290,7 +291,8 @@ jobs:
       contains( github.ref, 'hotfix-' ) ||
       contains( github.ref, 'build-' ) ||
       contains( github.ref, 'tags' ) ||
-      contains( github.ref, 'web' )
+      contains( github.ref, 'web' ) ||
+      contains( github.ref, '158' )
     steps:
       - uses: actions/checkout@v2
 
@@ -326,6 +328,7 @@ jobs:
       - name: Deploy
         run: |
           sed -i 's|PYTHONEXE=$HOME/python|PYTHONEXE=$CONDA/envs/mdanse|' $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh
+          sudo rm -v $CONDA/envs/mdanse/lib/libstdc*
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/definitions.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/setup_ci.sh
           source $GITHUB_WORKSPACE/BuildServer/Unix/Debian/deploy.sh
@@ -343,6 +346,7 @@ jobs:
   # OSX
   ci_osx:
     runs-on: ${{ matrix.os }}
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -399,19 +403,16 @@ jobs:
           python2 setup.py install
 
       - name: Run dependency tests
-        if: false
         run: |
           cd $GITHUB_WORKSPACE/Tests/DependenciesTests
           python2 AllTests.py
 
       - name: Run unit tests
-        if: false
         run: |
           cd $GITHUB_WORKSPACE/Tests/UnitTests
           python2 AllTests.py
 
       - name: Run functional tests
-        if: false
         run: |
           cd $GITHUB_WORKSPACE/Tests/FunctionalTests/Jobs
           python2 BuildJobTests.py

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+version 1.5.2
+-------------
+* FIXED issue #158 Molecular Viewer and Elevation, Iso-Surface, and Scalar-Field plotters no longer crash MDANSE on Ubuntu 22
+
 version 1.5.1
 --------------
 * ADDED issue #129 Installers for Ubuntu 22.x are now automatically generated and available for download


### PR DESCRIPTION
**Description of work**

Fixes #158 

The parts of MDANSE that use VTK were crashing on the installer-gotten MDANSE on Ubuntu 22. This was caused by libstdc++ shared objects that were included in the installer bundle. Removing them before packaging mdanse on the build server has fixed the issue.

**To test**

1. Install MDANSE on Ubuntu 22 using [this installer.](https://github.com/ISISNeutronMuon/MDANSE/actions/runs/3051401626)
2. Load a trajectory and open Molecule Viewer (observe no crashes)
3. Open and start Animation (observe no crashes)
4. Open 2D/3D Plotter and plot a plot using the Elevation, Iso-Surface, and Scalar-Field plotters. (observe no crashes)