### PR TITLE
Disable MolecularViewer on MacOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -540,7 +540,7 @@ jobs:
 
       - name: Install backend dependencies
         run: |
-          %CONDA%\envs\mdanse\python.exe -m pip install numpy matplotlib Cython pyyaml Pyro
+          %CONDA%\envs\mdanse\python.exe -m pip install numpy==1.16.6 matplotlib Cython pyyaml Pyro
         shell: cmd /C CALL {0}
 
       - name: Install ScientificPython

--- a/Src/GUI/Plugins/MolecularViewerPlugin.py
+++ b/Src/GUI/Plugins/MolecularViewerPlugin.py
@@ -14,6 +14,7 @@
 # **************************************************************************
 
 import os
+import platform
 
 import numpy
 
@@ -137,8 +138,11 @@ class MolecularViewerPlugin(ComponentPlugin):
     '''
             
     label = "Molecular Viewer"
-    
-    ancestor = ["mmtk_trajectory"]
+
+    if platform.system() == "Darwin":
+        ancestor = ["this_must_be_disabled"]
+    else:
+        ancestor = ["mmtk_trajectory"]
     
     category = ("Viewer",)
                 


### PR DESCRIPTION
The MolecularViewerPlugin now checks what platform it is on. If it is on MacOS ("Darwin"), it sets the ancestor of the plugin to a different value.
