### PR TITLE
Add a check for REGISTRY keys in PluginsTreePanel

### DIFF
--- a/Src/GUI/PluginsTreePanel.py
+++ b/Src/GUI/PluginsTreePanel.py
@@ -87,7 +87,8 @@ class PluginsTreePanel(wx.Panel):
             ancestors = []
             for anc in ancestor:
                 ancestors.append(anc)
-                ancestors.extend([c._type for c in REGISTRY['plugin'][anc].__subclasses__()])
+                if anc in REGISTRY['plugin'].keys():
+                    ancestors.extend([c._type for c in REGISTRY['plugin'][anc].__subclasses__()])
             
             for a in ancestors:
 


### PR DESCRIPTION
My last change to the MolecularViewer plugin was not sufficient to make MDANSE work with MolecularViewer disabled on MacOS. This change should fix the problem.

MDANSE on other platforms was not affected to start with.