### PR TITLE
Add EndModal before closing the dialog

### DIFF
--- a/Src/GUI/UnitsEditor.py
+++ b/Src/GUI/UnitsEditor.py
@@ -323,8 +323,10 @@ class UnitsEditor(wx.Dialog):
                 wx.MessageBox("Units database saved successfully", "Success", wx.OK | wx.ICON_INFORMATION)
             else:
                 LOGGER("Units database saved successfully","info")
+                self.EndModal(wx.ID_OK)
                 self.Destroy()
         else:
+            self.EndModal(wx.ID_OK)
             self.Destroy()
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a simple fix to make sure that the GUI remains responsive after the Units Editor has been closed.

This should fix the problem described here:
https://github.com/ISISNeutronMuon/MDANSE/issues/182
