### PR TITLE
Improved the contents of the output file in case of ASCII selection

### DIFF
--- a/Src/Framework/Formats/ASCIIFormat.py
+++ b/Src/Framework/Formats/ASCIIFormat.py
@@ -53,11 +53,10 @@ class ASCIIFormat(IFormat):
         tf = tarfile.open(filename,'w')
         
         for var in data.values():
-
             tempStr = StringIO.StringIO()
             tempStr.write(var.info())
             tempStr.write('\n\n')            
-            cls.write_array(tempStr,var)
+            cls.write_data(tempStr,var,data)
             tempStr.seek(0)
 
             info = tarfile.TarInfo(name='%s%s' % (var.varname,cls.extensions[0]))
@@ -76,33 +75,61 @@ class ASCIIFormat(IFormat):
         tf.close()
 
     @classmethod
-    def write_array(cls, fileobject, array, slices=None):
+    def write_data(cls, fileobject, data, allData):
         '''
         Write an Framework.OutputVariables.IOutputVariable into a file-like object
         
         :param fileobject: the file object where the output variable should be written.
         :type fileobject: python file-like object
-        :param array: the output variable to write (subclass of NumPy array).
-        :type array: Framework.OutputVariables.IOutputVariable
-        :param slices: the slices of the output variable to write. If None, the whole output variable will be written.
-        :type: python slice
+        :param data: the output variable to write (subclass of NumPy array).
+        :type data: Framework.OutputVariables.IOutputVariable
+        :param allData: the complete set of output variables
+        :type allData: dict of Framework.OutputVariables.IOutputVariable
         
         :attention: this is a recursive method.
         '''
         
-        if slices is None:
-            slices = [0]*array.ndim
-            slices[-2:] = array.shape[-2:]
+        if data.ndim > 2:
+            fileobject.write("Can not write ASCII output for data of dimensionality > 2")
 
-        if array.ndim > 2:
-        
-            for a in array:
-                cls.write_array(fileobject,a, slices)
-                slices[len(slices)-array.ndim] = slices[len(slices)-array.ndim] + 1
+        elif data.ndim == 2:
+            xData,yData = data.axis.split("|")
+
+            if xData == "index":
+                xValues = numpy.arange(data.shape[0])
+                fileobject.write("# 1st column: %s (%s)\n"% (xData,"au"))
+            else:
+                xValues = allData[xData]
+                fileobject.write("# 1st column: %s (%s)\n"% (allData[xData].varname,allData[xData].units))
+
+            if yData == "index":
+                yValues = numpy.arange(data.shape[1])
+                fileobject.write("# 1st row: %s (%s)\n\n"% (yData,"au"))
+            else:
+                yValues = allData[yData]
+                fileobject.write("# 1st row: %s (%s)\n\n"% (allData[yData].varname,allData[yData].units))
+
+            zData = numpy.zeros((data.shape[0]+1,data.shape[1]+1),dtype=numpy.float)
+            zData[1:,0] = xValues
+            zData[0,1:] = yValues
+            zData[1:,1:] = data
+
+            numpy.savetxt(fileobject,zData)
+            fileobject.write('\n')
 
         else:
-            fileobject.write('#slice:%s\n' % slices)
-            numpy.savetxt(fileobject, array)
+            xData = data.axis.split("|")[0]
+
+            if xData == "index":
+                xValues = numpy.arange(data.size)
+                fileobject.write("# 1st column: %s (%s)\n"% (xData,"au"))
+            else:
+                xValues = allData[xData]
+                fileobject.write("# 1st column: %s (%s)\n"% (allData[xData].varname,allData[xData].units))
+
+            fileobject.write("# 2nd column: %s (%s)\n\n"% (data.varname,data.units))
+
+            numpy.savetxt(fileobject,numpy.column_stack([xValues,data]))
             fileobject.write('\n')
 
 REGISTRY['ascii'] = ASCIIFormat

--- a/Src/Framework/Jobs/DensityOfStates.py
+++ b/Src/Framework/Jobs/DensityOfStates.py
@@ -57,7 +57,7 @@ class DensityOfStates(IJob):
         instrResolution = self.configuration["instrument_resolution"]        
                 
         self._outputData.add("time","line", self.configuration['frames']['duration'], units='ps')
-        self._outputData.add("time_window","line", instrResolution["time_window"], axis="time", units="au") 
+        self._outputData.add("time_window","line", instrResolution["time_window"], units="au") 
 
         self._outputData.add("omega","line", instrResolution["omega"], units='rad/ps')
         self._outputData.add("omega_window","line", instrResolution["omega_window"], axis="omega", units="au") 

--- a/Src/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/Src/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -66,7 +66,7 @@ class DynamicIncoherentStructureFactor(IJob):
         self._outputData.add("q","line", self.configuration["q_vectors"]["shells"], units="1/nm") 
 
         self._outputData.add("time","line", self.configuration['frames']['duration'], units='ps')
-        self._outputData.add("time_window","line", self._instrResolution["time_window"], axis="time", units="au") 
+        self._outputData.add("time_window","line", self._instrResolution["time_window"], units="au") 
 
         self._outputData.add("omega","line", self._instrResolution["omega"], units='rad/ps')
         self._outputData.add("omega_window","line", self._instrResolution["omega_window"], axis="omega", units="au") 

--- a/Src/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/Src/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -70,7 +70,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         self._outputData.add("q2","line",self._kSquare,units="1/nm2") 
 
         self._outputData.add("time","line",self.configuration['frames']['duration'], units='ps')
-        self._outputData.add("time_window","line",self._instrResolution["time_window"], axis="time", units="au") 
+        self._outputData.add("time_window","line",self._instrResolution["time_window"], units="au") 
 
         self._outputData.add("omega","line",self.configuration["instrument_resolution"]["omega"], units='rad/ps')
         self._outputData.add("omega_window","line",self._instrResolution["omega_window"], axis="omega", units="au") 

--- a/Src/Framework/Jobs/StructureFactorFromScatteringFunction.py
+++ b/Src/Framework/Jobs/StructureFactorFromScatteringFunction.py
@@ -51,7 +51,7 @@ class StructureFactorFromScatteringFunction(IJob):
         
         self._outputData.add("time","line", inputFile.variables['time'][:], units='ps')
 
-        self._outputData.add("time_window","line", inputFile.variables['time_window'][:], axis="time", units="au") 
+        self._outputData.add("time_window","line", inputFile.variables['time_window'][:], units="au") 
 
         self._outputData.add("q","line", inputFile.variables['q'][:], units="1/nm") 
 


### PR DESCRIPTION
@MBartkowiakSTFC @sanghamitra-mukhopadhyay @gonzalezma After our discussion, I could finally find a way to implement a better output when ASCII is selected as the output file format for the analysis. Now, for 1D variables, the output file contains two columns one for the Y axis and one for the X axis and for 2D variables the output contains the matrix with the X axis as the 1st column and the Y axis as the 1st row. While doing this, the support for data whose dimensionality is > 2 has been stopped because 1) so far there has never been such data produced by MDANSE 2) it makes nearly impossible the handling of the dependant axis when producing the output.  I also fixed some bugs in "time_window" output variable which was set as depending upon "time" variable which is not true.