### PR TITLE
Fix links

### DIFF
--- a/BuildServer/Unix/Debian/Resources/DEBIAN/control
+++ b/BuildServer/Unix/Debian/Resources/DEBIAN/control
@@ -1,11 +1,11 @@
 Package: mdanse
-Version: 1.5.0
+Version: 1.5.2
 Architecture: amd64
 Depends: netcdf-bin, libnetcdf-dev, libgtk2.0-0
 Section: Science
 Priority: optional
 Installed-Size: 1000
-Homepage: https://mdanse.org
+Homepage: https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 Maintainer: S. Mukhopadhyay <sanghamitra.mukhopadhyay@stfc.ac.uk>
 Description: MDANSE - Molecular Dynamics Analysis for Neutron Scattering Experiments.
  MDANSE (Molecular Dynamics Analysis for Neutron Scattering Experiments) is a python application designed for computing properties that can be directly compared with neutron scattering experiments such as the coherent and incoherent intermediate scattering functions and their Fourier transforms, the elastic incoherent structure factor, the static coherent structure factor or the radial distribution function. Moreover, it can also compute quantities such as the mean-square displacement, the velocity autocorrelation function as well as its Fourier Transform (the so-called vibrational density of states) enlarging the scope of the program to a broader range of physico-chemical properties.

--- a/BuildServer/Unix/Debian/Resources/DEBIAN/copyright
+++ b/BuildServer/Unix/Debian/Resources/DEBIAN/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0
 Upstream-Name: mdanse
 Upstream-Contact: Sanghamitra Mukhopadhyay <sanghamitra.mukhopadhyay@stfc.ac.uk>
-Source: https://mdanse.org/
+Source: https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 
 Files: *
 Copyright: Copyright 2016, Eric Pellegrini <pellegrini@ill.fr>; Copyright 2021, Sanghamitra Mukhopadhyay <sanghamitra.mukhopadhyay@stfc.ac.uk>

--- a/BuildServer/Windows/Resources/nsis/MDANSE_installer.nsi
+++ b/BuildServer/Windows/Resources/nsis/MDANSE_installer.nsi
@@ -32,7 +32,7 @@ ShowInstDetails show
 ShowUnInstDetails show
 
 !define PUBLISHER "ISIS Neutron and Muon Source"
-!define WEB_SITE "http://www.mdanse.org"
+!define WEB_SITE "https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx"
 !define UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\MDANSE"
 !define UNINST_ROOT_KEY "HKLM"
 

--- a/Doc/index.rst
+++ b/Doc/index.rst
@@ -18,9 +18,12 @@ Welcome to MDANSE's documentation!
 Introduction
 ============
 
-Molecular Dynamics Analysis for Neutron Scattering Experiments
+`MDANSE Project Website <https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx>`_
 
-MDANSE is a python application designed for computing neutron observables
+`MDANSE GitHub Page <https://github.com/ISISNeutronMuon/MDANSE>`_
+
+**MDANSE** (**Molecular Dynamics Analysis for Neutron Scattering Experiments**)
+is a python application designed for computing neutron observables
 from molecular dynamics (MD) trajectories that can be directly compared with
 neutron scattering experiments, particularly inelastic and quasi-elastic
 neutron scattering spectroscopies.

--- a/Doc/pages/references.rst
+++ b/Doc/pages/references.rst
@@ -45,7 +45,7 @@ References
 
 .. [Ref7] “The HDF Group.” https://www.hdfgroup.org/.
 
-.. [Ref8] “MDANSE.” https://mdanse.org/.
+.. [Ref8] “MDANSE.” https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 
 .. [Ref9] “MDANSE GitHub Issues.”
    https://github.com/ISISNeutronMuon/MDANSE/issues.

--- a/Extensions/setup.py
+++ b/Extensions/setup.py
@@ -5,7 +5,7 @@
 # @file      Extensions/setup.py
 # @brief     Implements module/class/test setup
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ any other software on that OS. After that, we recommend starting by using the GU
 4. Check the results with the plotter
 
 The most complete user documentation of MDANSE can be found on [our Read the Docs page](https://mdanse.readthedocs.io). At the same time, it is still possible to access the original **[MDANSE User Guide](https://epubs.stfc.ac.uk/work/51935555)** \
-Other information including example scripts can be found on the MDANSE website [mdanse.org](https://mdanse.org/) 
+Other information including example scripts can be found on the [MDANSE website](https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx) 
 
 ## Installing from source
 

--- a/Scripts/mdanse
+++ b/Scripts/mdanse
@@ -7,7 +7,7 @@
 # @file      Src/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Scripts/mdanse_elements_database
+++ b/Scripts/mdanse_elements_database
@@ -7,7 +7,7 @@
 # @file      Src/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Scripts/mdanse_gui
+++ b/Scripts/mdanse_gui
@@ -7,7 +7,7 @@
 # @file      Src/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Scripts/mdanse_job
+++ b/Scripts/mdanse_job
@@ -7,7 +7,7 @@
 # @file      Src/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Scripts/mdanse_periodic_table
+++ b/Scripts/mdanse_periodic_table
@@ -7,7 +7,7 @@
 # @file      Src/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Scripts/mdanse_plotter
+++ b/Scripts/mdanse_plotter
@@ -7,7 +7,7 @@
 # @file      Src/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Scripts/mdanse_ud_editor
+++ b/Scripts/mdanse_ud_editor
@@ -7,7 +7,7 @@
 # @file      Src/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Scripts/mdanse_units_editor
+++ b/Scripts/mdanse_units_editor
@@ -7,7 +7,7 @@
 # @file      Src/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Core/ClassRegistry.py
+++ b/Src/Core/ClassRegistry.py
@@ -5,7 +5,7 @@
 # @file      Src/Core/ClassRegistry.py
 # @brief     Implements module/class/test ClassRegistry
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Core/Error.py
+++ b/Src/Core/Error.py
@@ -5,7 +5,7 @@
 # @file      Src/Core/Error.py
 # @brief     Implements module/class/test Error
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Core/Platform.py
+++ b/Src/Core/Platform.py
@@ -5,7 +5,7 @@
 # @file      Src/Core/Platform.py
 # @brief     Implements module/class/test Platform
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Core/Singleton.py
+++ b/Src/Core/Singleton.py
@@ -5,7 +5,7 @@
 # @file      Src/Core/Singleton.py
 # @brief     Implements module/class/test Singleton
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Core/__init__.py
+++ b/Src/Core/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Core/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Data/ElementsDatabase.py
+++ b/Src/Data/ElementsDatabase.py
@@ -5,7 +5,7 @@
 # @file      Src/Data/ElementsDatabase.py
 # @brief     Implements module/class/test ElementsDatabase
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Data/__init__.py
+++ b/Src/Data/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Data/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/DistributedComputing/MasterSlave.py
+++ b/Src/DistributedComputing/MasterSlave.py
@@ -5,7 +5,7 @@
 # @file      Src/DistributedComputing/MasterSlave.py
 # @brief     Implements module/class/test MasterSlave
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/DistributedComputing/Slave.py
+++ b/Src/DistributedComputing/Slave.py
@@ -5,7 +5,7 @@
 # @file      Src/DistributedComputing/Slave.py
 # @brief     Implements module/class/test Slave
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/DistributedComputing/__init__.py
+++ b/Src/DistributedComputing/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/DistributedComputing/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Extensions/__init__.py
+++ b/Src/Extensions/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Extensions/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/__init__.py
+++ b/Src/Externals/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/__init__.py
+++ b/Src/Externals/pubsub/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/autosetuppubsubv1.py
+++ b/Src/Externals/pubsub/autosetuppubsubv1.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/autosetuppubsubv1.py
 # @brief     Implements module/class/test autosetuppubsubv1
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/__init__.py
+++ b/Src/Externals/pubsub/core/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/arg1/__init__.py
+++ b/Src/Externals/pubsub/core/arg1/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/arg1/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/arg1/listenerimpl.py
+++ b/Src/Externals/pubsub/core/arg1/listenerimpl.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/arg1/listenerimpl.py
 # @brief     Implements module/class/test listenerimpl
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/arg1/publisher.py
+++ b/Src/Externals/pubsub/core/arg1/publisher.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/arg1/publisher.py
 # @brief     Implements module/class/test publisher
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/arg1/publishermixin.py
+++ b/Src/Externals/pubsub/core/arg1/publishermixin.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/arg1/publishermixin.py
 # @brief     Implements module/class/test publishermixin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/arg1/topicargspecimpl.py
+++ b/Src/Externals/pubsub/core/arg1/topicargspecimpl.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/arg1/topicargspecimpl.py
 # @brief     Implements module/class/test topicargspecimpl
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/arg1/topicmgrimpl.py
+++ b/Src/Externals/pubsub/core/arg1/topicmgrimpl.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/arg1/topicmgrimpl.py
 # @brief     Implements module/class/test topicmgrimpl
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/callables.py
+++ b/Src/Externals/pubsub/core/callables.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/callables.py
 # @brief     Implements module/class/test callables
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/datamsg.py
+++ b/Src/Externals/pubsub/core/datamsg.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/datamsg.py
 # @brief     Implements module/class/test datamsg
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/imp2.py
+++ b/Src/Externals/pubsub/core/imp2.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/imp2.py
 # @brief     Implements module/class/test imp2
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/itopicdefnprovider.py
+++ b/Src/Externals/pubsub/core/itopicdefnprovider.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/itopicdefnprovider.py
 # @brief     Implements module/class/test itopicdefnprovider
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/kwargs/__init__.py
+++ b/Src/Externals/pubsub/core/kwargs/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/kwargs/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/kwargs/datamsg.py
+++ b/Src/Externals/pubsub/core/kwargs/datamsg.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/kwargs/datamsg.py
 # @brief     Implements module/class/test datamsg
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/kwargs/listenerimpl.py
+++ b/Src/Externals/pubsub/core/kwargs/listenerimpl.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/kwargs/listenerimpl.py
 # @brief     Implements module/class/test listenerimpl
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/kwargs/publisher.py
+++ b/Src/Externals/pubsub/core/kwargs/publisher.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/kwargs/publisher.py
 # @brief     Implements module/class/test publisher
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/kwargs/publishermixin.py
+++ b/Src/Externals/pubsub/core/kwargs/publishermixin.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/kwargs/publishermixin.py
 # @brief     Implements module/class/test publishermixin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/kwargs/topicargspecimpl.py
+++ b/Src/Externals/pubsub/core/kwargs/topicargspecimpl.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/kwargs/topicargspecimpl.py
 # @brief     Implements module/class/test topicargspecimpl
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/kwargs/topicmgrimpl.py
+++ b/Src/Externals/pubsub/core/kwargs/topicmgrimpl.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/kwargs/topicmgrimpl.py
 # @brief     Implements module/class/test topicmgrimpl
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/listener.py
+++ b/Src/Externals/pubsub/core/listener.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/listener.py
 # @brief     Implements module/class/test listener
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/listenerbase.py
+++ b/Src/Externals/pubsub/core/listenerbase.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/listenerbase.py
 # @brief     Implements module/class/test listenerbase
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/notificationmgr.py
+++ b/Src/Externals/pubsub/core/notificationmgr.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/notificationmgr.py
 # @brief     Implements module/class/test notificationmgr
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/notificationmgr_old.py
+++ b/Src/Externals/pubsub/core/notificationmgr_old.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/notificationmgr_old.py
 # @brief     Implements module/class/test notificationmgr_old
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/policies.py
+++ b/Src/Externals/pubsub/core/policies.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/policies.py
 # @brief     Implements module/class/test policies
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/publisherbase.py
+++ b/Src/Externals/pubsub/core/publisherbase.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/publisherbase.py
 # @brief     Implements module/class/test publisherbase
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/topicargspec.py
+++ b/Src/Externals/pubsub/core/topicargspec.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/topicargspec.py
 # @brief     Implements module/class/test topicargspec
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/topicdefnprovider.py
+++ b/Src/Externals/pubsub/core/topicdefnprovider.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/topicdefnprovider.py
 # @brief     Implements module/class/test topicdefnprovider
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/topicexc.py
+++ b/Src/Externals/pubsub/core/topicexc.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/topicexc.py
 # @brief     Implements module/class/test topicexc
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/topicmgr.py
+++ b/Src/Externals/pubsub/core/topicmgr.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/topicmgr.py
 # @brief     Implements module/class/test topicmgr
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/topicobj.py
+++ b/Src/Externals/pubsub/core/topicobj.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/topicobj.py
 # @brief     Implements module/class/test topicobj
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/topictreetraverser.py
+++ b/Src/Externals/pubsub/core/topictreetraverser.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/topictreetraverser.py
 # @brief     Implements module/class/test topictreetraverser
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/topicutils.py
+++ b/Src/Externals/pubsub/core/topicutils.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/topicutils.py
 # @brief     Implements module/class/test topicutils
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/treeconfig.py
+++ b/Src/Externals/pubsub/core/treeconfig.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/treeconfig.py
 # @brief     Implements module/class/test treeconfig
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/validatedefnargs.py
+++ b/Src/Externals/pubsub/core/validatedefnargs.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/validatedefnargs.py
 # @brief     Implements module/class/test validatedefnargs
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/core/weakmethod.py
+++ b/Src/Externals/pubsub/core/weakmethod.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/core/weakmethod.py
 # @brief     Implements module/class/test weakmethod
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/policies.py
+++ b/Src/Externals/pubsub/policies.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/policies.py
 # @brief     Implements module/class/test policies
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/pub.py
+++ b/Src/Externals/pubsub/pub.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/pub.py
 # @brief     Implements module/class/test pub
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/pubsub1/pub.py
+++ b/Src/Externals/pubsub/pubsub1/pub.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/pubsub1/pub.py
 # @brief     Implements module/class/test pub
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/pubsub1/utils.py
+++ b/Src/Externals/pubsub/pubsub1/utils.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/pubsub1/utils.py
 # @brief     Implements module/class/test utils
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/pubsub2/pub.py
+++ b/Src/Externals/pubsub/pubsub2/pub.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/pubsub2/pub.py
 # @brief     Implements module/class/test pub
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/pubsub2/utils.py
+++ b/Src/Externals/pubsub/pubsub2/utils.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/pubsub2/utils.py
 # @brief     Implements module/class/test utils
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/pubsubconf.py
+++ b/Src/Externals/pubsub/pubsubconf.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/pubsubconf.py
 # @brief     Implements module/class/test pubsubconf
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/py2and3.py
+++ b/Src/Externals/pubsub/py2and3.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/py2and3.py
 # @brief     Implements module/class/test py2and3
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/setuparg1.py
+++ b/Src/Externals/pubsub/setuparg1.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/setuparg1.py
 # @brief     Implements module/class/test setuparg1
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/setupkwargs.py
+++ b/Src/Externals/pubsub/setupkwargs.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/setupkwargs.py
 # @brief     Implements module/class/test setupkwargs
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/setupv1.py
+++ b/Src/Externals/pubsub/setupv1.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/setupv1.py
 # @brief     Implements module/class/test setupv1
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/setupv2.py
+++ b/Src/Externals/pubsub/setupv2.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/setupv2.py
 # @brief     Implements module/class/test setupv2
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/utils/__init__.py
+++ b/Src/Externals/pubsub/utils/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/utils/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/utils/exchandling.py
+++ b/Src/Externals/pubsub/utils/exchandling.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/utils/exchandling.py
 # @brief     Implements module/class/test exchandling
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/utils/globalsettings.py
+++ b/Src/Externals/pubsub/utils/globalsettings.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/utils/globalsettings.py
 # @brief     Implements module/class/test globalsettings
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/utils/misc.py
+++ b/Src/Externals/pubsub/utils/misc.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/utils/misc.py
 # @brief     Implements module/class/test misc
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/utils/notification.py
+++ b/Src/Externals/pubsub/utils/notification.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/utils/notification.py
 # @brief     Implements module/class/test notification
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/utils/topictreeprinter.py
+++ b/Src/Externals/pubsub/utils/topictreeprinter.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/utils/topictreeprinter.py
 # @brief     Implements module/class/test topictreeprinter
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/utils/topictreevisitor.py
+++ b/Src/Externals/pubsub/utils/topictreevisitor.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/utils/topictreevisitor.py
 # @brief     Implements module/class/test topictreevisitor
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pubsub/utils/xmltopicdefnprovider.py
+++ b/Src/Externals/pubsub/utils/xmltopicdefnprovider.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pubsub/utils/xmltopicdefnprovider.py
 # @brief     Implements module/class/test xmltopicdefnprovider
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pyparsing/__init__.py
+++ b/Src/Externals/pyparsing/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pyparsing/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/pyparsing/pyparsing.py
+++ b/Src/Externals/pyparsing/pyparsing.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/pyparsing/pyparsing.py
 # @brief     Implements module/class/test pyparsing
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/svgfig/__init__.py
+++ b/Src/Externals/svgfig/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/svgfig/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Externals/svgfig/svgfig.py
+++ b/Src/Externals/svgfig/svgfig.py
@@ -5,7 +5,7 @@
 # @file      Src/Externals/svgfig/svgfig.py
 # @brief     Implements module/class/test svgfig
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/AtomSelectionParser.py
+++ b/Src/Framework/AtomSelectionParser.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/AtomSelectionParser.py
 # @brief     Implements module/class/test AtomSelectionParser
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurable.py
+++ b/Src/Framework/Configurable.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurable.py
 # @brief     Implements module/class/test Configurable
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/AtomSelectionConfigurator.py
+++ b/Src/Framework/Configurators/AtomSelectionConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/AtomSelectionConfigurator.py
 # @brief     Implements module/class/test AtomSelectionConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/AtomTransmutationConfigurator.py
+++ b/Src/Framework/Configurators/AtomTransmutationConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/AtomTransmutationConfigurator.py
 # @brief     Implements module/class/test AtomTransmutationConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/AtomsListConfigurator.py
+++ b/Src/Framework/Configurators/AtomsListConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/AtomsListConfigurator.py
 # @brief     Implements module/class/test AtomsListConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/AxisSelectionConfigurator.py
+++ b/Src/Framework/Configurators/AxisSelectionConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/AxisSelectionConfigurator.py
 # @brief     Implements module/class/test AxisSelectionConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/BasisSelectionConfigurator.py
+++ b/Src/Framework/Configurators/BasisSelectionConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/BasisSelectionConfigurator.py
 # @brief     Implements module/class/test BasisSelectionConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/BooleanConfigurator.py
+++ b/Src/Framework/Configurators/BooleanConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/BooleanConfigurator.py
 # @brief     Implements module/class/test BooleanConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/ComplexNumberConfigurator.py
+++ b/Src/Framework/Configurators/ComplexNumberConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/ComplexNumberConfigurator.py
 # @brief     Implements module/class/test ComplexNumberConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/FloatConfigurator.py
+++ b/Src/Framework/Configurators/FloatConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/FloatConfigurator.py
 # @brief     Implements module/class/test FloatConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/FramesConfigurator.py
+++ b/Src/Framework/Configurators/FramesConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/FramesConfigurator.py
 # @brief     Implements module/class/test FramesConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/GroupingLevelConfigurator.py
+++ b/Src/Framework/Configurators/GroupingLevelConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/GroupingLevelConfigurator.py
 # @brief     Implements module/class/test GroupingLevelConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/IConfigurator.py
+++ b/Src/Framework/Configurators/IConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/IConfigurator.py
 # @brief     Implements module/class/test IConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/InputDirectoryConfigurator.py
+++ b/Src/Framework/Configurators/InputDirectoryConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/InputDirectoryConfigurator.py
 # @brief     Implements module/class/test InputDirectoryConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/InputFileConfigurator.py
+++ b/Src/Framework/Configurators/InputFileConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/InputFileConfigurator.py
 # @brief     Implements module/class/test InputFileConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/InstrumentResolutionConfigurator.py
+++ b/Src/Framework/Configurators/InstrumentResolutionConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/InstrumentResolutionConfigurator.py
 # @brief     Implements module/class/test InstrumentResolutionConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/IntegerConfigurator.py
+++ b/Src/Framework/Configurators/IntegerConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/IntegerConfigurator.py
 # @brief     Implements module/class/test IntegerConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/InterpolationOrderConfigurator.py
+++ b/Src/Framework/Configurators/InterpolationOrderConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/InterpolationOrderConfigurator.py
 # @brief     Implements module/class/test InterpolationOrderConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/MMTKTrajectoryConfigurator.py
+++ b/Src/Framework/Configurators/MMTKTrajectoryConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/MMTKTrajectoryConfigurator.py
 # @brief     Implements module/class/test MMTKTrajectoryConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/McStasInstrumentConfigurator.py
+++ b/Src/Framework/Configurators/McStasInstrumentConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/McStasInstrumentConfigurator.py
 # @brief     Implements module/class/test McStasInstrumentConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/McStasOptionsConfigurator.py
+++ b/Src/Framework/Configurators/McStasOptionsConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/McStasOptionsConfigurator.py
 # @brief     Implements module/class/test McStasOptionsConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/McStasParametersConfigurator.py
+++ b/Src/Framework/Configurators/McStasParametersConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/McStasParametersConfigurator.py
 # @brief     Implements module/class/test McStasParametersConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/MultipleChoicesConfigurator.py
+++ b/Src/Framework/Configurators/MultipleChoicesConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/MultipleChoicesConfigurator.py
 # @brief     Implements module/class/test MultipleChoicesConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/NetCDFInputFileConfigurator.py
+++ b/Src/Framework/Configurators/NetCDFInputFileConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/NetCDFInputFileConfigurator.py
 # @brief     Implements module/class/test NetCDFInputFileConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/OutputDirectoryConfigurator.py
+++ b/Src/Framework/Configurators/OutputDirectoryConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/OutputDirectoryConfigurator.py
 # @brief     Implements module/class/test OutputDirectoryConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/OutputFilesConfigurator.py
+++ b/Src/Framework/Configurators/OutputFilesConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/OutputFilesConfigurator.py
 # @brief     Implements module/class/test OutputFilesConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/PartialChargeConfigurator.py
+++ b/Src/Framework/Configurators/PartialChargeConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/PartialChargeConfigurator.py
 # @brief     Implements module/class/test PartialChargeConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/ProjectionConfigurator.py
+++ b/Src/Framework/Configurators/ProjectionConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/ProjectionConfigurator.py
 # @brief     Implements module/class/test ProjectionConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/PythonObjectConfigurator.py
+++ b/Src/Framework/Configurators/PythonObjectConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/PythonObjectConfigurator.py
 # @brief     Implements module/class/test PythonObjectConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/PythonScriptConfigurator.py
+++ b/Src/Framework/Configurators/PythonScriptConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/PythonScriptConfigurator.py
 # @brief     Implements module/class/test PythonScriptConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/QVectorsConfigurator.py
+++ b/Src/Framework/Configurators/QVectorsConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/QVectorsConfigurator.py
 # @brief     Implements module/class/test QVectorsConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/RangeConfigurator.py
+++ b/Src/Framework/Configurators/RangeConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/RangeConfigurator.py
 # @brief     Implements module/class/test RangeConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/RunningModeConfigurator.py
+++ b/Src/Framework/Configurators/RunningModeConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/RunningModeConfigurator.py
 # @brief     Implements module/class/test RunningModeConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/SingleChoiceConfigurator.py
+++ b/Src/Framework/Configurators/SingleChoiceConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/SingleChoiceConfigurator.py
 # @brief     Implements module/class/test SingleChoiceConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/SingleOutputFileConfigurator.py
+++ b/Src/Framework/Configurators/SingleOutputFileConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/OutputFilesConfigurator.py
 # @brief     Implements module/class/test OutputFilesConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/StringConfigurator.py
+++ b/Src/Framework/Configurators/StringConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/StringConfigurator.py
 # @brief     Implements module/class/test StringConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/TrajectoryVariableConfigurator.py
+++ b/Src/Framework/Configurators/TrajectoryVariableConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/TrajectoryVariableConfigurator.py
 # @brief     Implements module/class/test TrajectoryVariableConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/VectorConfigurator.py
+++ b/Src/Framework/Configurators/VectorConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/VectorConfigurator.py
 # @brief     Implements module/class/test VectorConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/WeightsConfigurator.py
+++ b/Src/Framework/Configurators/WeightsConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/WeightsConfigurator.py
 # @brief     Implements module/class/test WeightsConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Configurators/__init__.py
+++ b/Src/Framework/Configurators/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Configurators/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Formats/ASCIIFormat.py
+++ b/Src/Framework/Formats/ASCIIFormat.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Formats/ASCIIFormat.py
 # @brief     Implements module/class/test ASCIIFormat
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Formats/HDFFormat.py
+++ b/Src/Framework/Formats/HDFFormat.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Formats/NetCDFFormat.py
 # @brief     Implements module/class/test NetCDFFormat
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Formats/IFormat.py
+++ b/Src/Framework/Formats/IFormat.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Formats/IFormat.py
 # @brief     Implements module/class/test IFormat
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Formats/NetCDFFormat.py
+++ b/Src/Framework/Formats/NetCDFFormat.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Formats/NetCDFFormat.py
 # @brief     Implements module/class/test NetCDFFormat
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Formats/SVGFormat.py
+++ b/Src/Framework/Formats/SVGFormat.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Formats/SVGFormat.py
 # @brief     Implements module/class/test SVGFormat
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Formats/__init__.py
+++ b/Src/Framework/Formats/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Formats/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Handlers/ColorizingStreamHandler.py
+++ b/Src/Framework/Handlers/ColorizingStreamHandler.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Handlers/ColorizingStreamHandler.py
 # @brief     Implements module/class/test ColorizingStreamHandler
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Handlers/IHandler.py
+++ b/Src/Framework/Handlers/IHandler.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Handlers/IHandler.py
 # @brief     Implements module/class/test IHandler
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Handlers/LogfileHandler.py
+++ b/Src/Framework/Handlers/LogfileHandler.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Handlers/LogfileHandler.py
 # @brief     Implements module/class/test LogfileHandler
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Handlers/__init__.py
+++ b/Src/Framework/Handlers/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Handlers/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InputData/EmptyData.py
+++ b/Src/Framework/InputData/EmptyData.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/EmptyData.py
 # @brief     Implements module/class/test EmptyData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InputData/IInputData.py
+++ b/Src/Framework/InputData/IInputData.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/IInputData.py
 # @brief     Implements module/class/test IInputData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InputData/InputFileData.py
+++ b/Src/Framework/InputData/InputFileData.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/InputFileData.py
 # @brief     Implements module/class/test InputFileData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InputData/MMTKTrajectoryInputData.py
+++ b/Src/Framework/InputData/MMTKTrajectoryInputData.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/MMTKTrajectoryInputData.py
 # @brief     Implements module/class/test MMTKTrajectoryInputData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InputData/MVITraceInputData.py
+++ b/Src/Framework/InputData/MVITraceInputData.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/MVITraceInputData.py
 # @brief     Implements module/class/test MVITraceInputData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InputData/NetCDFInputData.py
+++ b/Src/Framework/InputData/NetCDFInputData.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/NetCDFInputData.py
 # @brief     Implements module/class/test NetCDFInputData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InputData/PeriodicTableInputData.py
+++ b/Src/Framework/InputData/PeriodicTableInputData.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/PeriodicTableInputData.py
 # @brief     Implements module/class/test PeriodicTableInputData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InputData/__init__.py
+++ b/Src/Framework/InputData/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InstrumentResolutions/GaussianResolution.py
+++ b/Src/Framework/InstrumentResolutions/GaussianResolution.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InstrumentResolutions/GaussianResolution.py
 # @brief     Implements module/class/test GaussianResolution
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InstrumentResolutions/IInstrumentResolution.py
+++ b/Src/Framework/InstrumentResolutions/IInstrumentResolution.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InstrumentResolutions/IInstrumentResolution.py
 # @brief     Implements module/class/test IInstrumentResolution
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InstrumentResolutions/IdealResolution.py
+++ b/Src/Framework/InstrumentResolutions/IdealResolution.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InstrumentResolutions/IdealResolution.py
 # @brief     Implements module/class/test IdealResolution
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InstrumentResolutions/LorentzianResolution.py
+++ b/Src/Framework/InstrumentResolutions/LorentzianResolution.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InstrumentResolutions/LorentzianResolution.py
 # @brief     Implements module/class/test LorentzianResolution
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InstrumentResolutions/PseudoVoigtResolution.py
+++ b/Src/Framework/InstrumentResolutions/PseudoVoigtResolution.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InstrumentResolutions/PseudoVoigtResolution.py
 # @brief     Implements module/class/test PseudoVoigtResolution
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InstrumentResolutions/SquareResolution.py
+++ b/Src/Framework/InstrumentResolutions/SquareResolution.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InstrumentResolutions/SquareResolution.py
 # @brief     Implements module/class/test SquareResolution
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InstrumentResolutions/TriangularResolution.py
+++ b/Src/Framework/InstrumentResolutions/TriangularResolution.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InstrumentResolutions/TriangularResolution.py
 # @brief     Implements module/class/test TriangularResolution
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/InstrumentResolutions/__init__.py
+++ b/Src/Framework/InstrumentResolutions/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InstrumentResolutions/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/AngularCorrelation.py
+++ b/Src/Framework/Jobs/AngularCorrelation.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/AngularCorrelation.py
 # @brief     Implements module/class/test AngularCorrelation
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/AreaPerMolecule.py
+++ b/Src/Framework/Jobs/AreaPerMolecule.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/AreaPerMolecule.py
 # @brief     Implements module/class/test AreaPerMolecule
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/BoxTranslatedTrajectory.py
+++ b/Src/Framework/Jobs/BoxTranslatedTrajectory.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/BoxTranslatedTrajectory.py
 # @brief     Implements module/class/test BoxTranslatedTrajectory
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/CHARMM.py
+++ b/Src/Framework/Jobs/CHARMM.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/CHARMM.py
 # @brief     Implements module/class/test CHARMM
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/CP2K.py
+++ b/Src/Framework/Jobs/CP2K.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/VASP.py
 # @brief     Implements module/class/test VASP
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/Castep.py
+++ b/Src/Framework/Jobs/Castep.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/Castep.py
 # @brief     Implements module/class/test Castep
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/Src/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/CenterOfMassesTrajectory.py
 # @brief     Implements module/class/test CenterOfMassesTrajectory
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/Converter.py
+++ b/Src/Framework/Jobs/Converter.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/Converter.py
 # @brief     Implements module/class/test Converter
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/CoordinationNumber.py
+++ b/Src/Framework/Jobs/CoordinationNumber.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/CoordinationNumber.py
 # @brief     Implements module/class/test CoordinationNumber
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/CroppedTrajectory.py
+++ b/Src/Framework/Jobs/CroppedTrajectory.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/CroppedTrajectory.py
 # @brief     Implements module/class/test CroppedTrajectory
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/Src/Framework/Jobs/CurrentCorrelationFunction.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/CurrentCorrelationFunction.py
 # @brief     Implements module/class/test CurrentCorrelationFunction
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/DCDConverter.py
+++ b/Src/Framework/Jobs/DCDConverter.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/DCDConverter.py
 # @brief     Implements module/class/test DCDConverter
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/DFTB.py
+++ b/Src/Framework/Jobs/DFTB.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/DFTB.py
 # @brief     Implements module/class/test DFTB
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/DL_POLY.py
+++ b/Src/Framework/Jobs/DL_POLY.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/DL_POLY.py
 # @brief     Implements module/class/test DL_POLY
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/DMol.py
+++ b/Src/Framework/Jobs/DMol.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/DMol.py
 # @brief     Implements module/class/test DMol
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/Density.py
+++ b/Src/Framework/Jobs/Density.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/Density.py
 # @brief     Implements module/class/test Density
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/DensityOfStates.py
+++ b/Src/Framework/Jobs/DensityOfStates.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/DensityOfStates.py
 # @brief     Implements module/class/test DensityOfStates
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/DensityProfile.py
+++ b/Src/Framework/Jobs/DensityProfile.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/DensityProfile.py
 # @brief     Implements module/class/test DensityProfile
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/DipoleAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/DipoleAutoCorrelationFunction.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/DipoleAutoCorrelationFunction.py
 # @brief     Implements module/class/test DipoleAutoCorrelationFunction
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/Discover.py
+++ b/Src/Framework/Jobs/Discover.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/Discover.py
 # @brief     Implements module/class/test Discover
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/DistanceHistogram.py
+++ b/Src/Framework/Jobs/DistanceHistogram.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/DistanceHistogram.py
 # @brief     Implements module/class/test DistanceHistogram
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/DynamicCoherentStructureFactor.py
+++ b/Src/Framework/Jobs/DynamicCoherentStructureFactor.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/DynamicCoherentStructureFactor.py
 # @brief     Implements module/class/test DynamicCoherentStructureFactor
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/Src/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/DynamicIncoherentStructureFactor.py
 # @brief     Implements module/class/test DynamicIncoherentStructureFactor
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/Eccentricity.py
+++ b/Src/Framework/Jobs/Eccentricity.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/Eccentricity.py
 # @brief     Implements module/class/test Eccentricity
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/Src/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/ElasticIncoherentStructureFactor.py
 # @brief     Implements module/class/test ElasticIncoherentStructureFactor
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/Forcite.py
+++ b/Src/Framework/Jobs/Forcite.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/Forcite.py
 # @brief     Implements module/class/test Forcite
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/Src/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
 # @brief     Implements module/class/test GaussianDynamicIncoherentStructureFactor
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/GeneralAutoCorrelationFunction.py
 # @brief     Implements module/class/test GeneralAutoCorrelationFunction
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/Generic.py
+++ b/Src/Framework/Jobs/Generic.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/Generic.py
 # @brief     Implements module/class/test Generic
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/GlobalMotionFilteredTrajectory.py
+++ b/Src/Framework/Jobs/GlobalMotionFilteredTrajectory.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/GlobalMotionFilteredTrajectory.py
 # @brief     Implements module/class/test GlobalMotionFilteredTrajectory
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/Gromacs.py
+++ b/Src/Framework/Jobs/Gromacs.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/Gromacs.py
 # @brief     Implements module/class/test Gromacs
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/IJob.py
+++ b/Src/Framework/Jobs/IJob.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/IJob.py
 # @brief     Implements module/class/test IJob
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/JobStatus.py
+++ b/Src/Framework/Jobs/JobStatus.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/JobStatus.py
 # @brief     Implements module/class/test JobStatus
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/LAMMPS.py
+++ b/Src/Framework/Jobs/LAMMPS.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/LAMMPS.py
 # @brief     Implements module/class/test LAMMPS
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/MaterialsStudio.py
+++ b/Src/Framework/Jobs/MaterialsStudio.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/MaterialsStudio.py
 # @brief     Implements module/class/test MaterialsStudio
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/McStasVirtualInstrument.py
+++ b/Src/Framework/Jobs/McStasVirtualInstrument.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/McStasVirtualInstrument.py
 # @brief     Implements module/class/test McStasVirtualInstrument
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/MeanSquareDisplacement.py
+++ b/Src/Framework/Jobs/MeanSquareDisplacement.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/MeanSquareDisplacement.py
 # @brief     Implements module/class/test MeanSquareDisplacement
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/MolecularTrace.py
+++ b/Src/Framework/Jobs/MolecularTrace.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/MolecularTrace.py
 # @brief     Implements module/class/test MolecularTrace
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/NAMD.py
+++ b/Src/Framework/Jobs/NAMD.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/NAMD.py
 # @brief     Implements module/class/test NAMD
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
+++ b/Src/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
 # @brief     Implements module/class/test NeutronDynamicTotalStructureFactor
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/OrderParameter.py
+++ b/Src/Framework/Jobs/OrderParameter.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/OrderParameter.py
 # @brief     Implements module/class/test OrderParameter
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/PDB.py
+++ b/Src/Framework/Jobs/PDB.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/PDB.py
 # @brief     Implements module/class/test PDB
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/PairDistributionFunction.py
+++ b/Src/Framework/Jobs/PairDistributionFunction.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/PairDistributionFunction.py
 # @brief     Implements module/class/test PairDistributionFunction
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/PositionAutoCorrelationFunction.py
 # @brief     Implements module/class/test PositionAutoCorrelationFunction
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/RadiusOfGyration.py
+++ b/Src/Framework/Jobs/RadiusOfGyration.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/RadiusOfGyration.py
 # @brief     Implements module/class/test RadiusOfGyration
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/RefoldedMembraneTrajectory.py
+++ b/Src/Framework/Jobs/RefoldedMembraneTrajectory.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/RefoldedMembraneTrajectory.py
 # @brief     Implements module/class/test RefoldedMembraneTrajectory
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/RigidBodyTrajectory.py
+++ b/Src/Framework/Jobs/RigidBodyTrajectory.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/RigidBodyTrajectory.py
 # @brief     Implements module/class/test RigidBodyTrajectory
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/RootMeanSquareDeviation.py
+++ b/Src/Framework/Jobs/RootMeanSquareDeviation.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/RootMeanSquareDeviation.py
 # @brief     Implements module/class/test RootMeanSquareDeviation
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/Src/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/RootMeanSquareFluctuation.py
 # @brief     Implements module/class/test RootMeanSquareFluctuation
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/SolventAccessibleSurface.py
+++ b/Src/Framework/Jobs/SolventAccessibleSurface.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/SolventAccessibleSurface.py
 # @brief     Implements module/class/test SolventAccessibleSurface
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/SpatialDensity.py
+++ b/Src/Framework/Jobs/SpatialDensity.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/SpatialDensity.py
 # @brief     Implements module/class/test SpatialDensity
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/StaticStructureFactor.py
+++ b/Src/Framework/Jobs/StaticStructureFactor.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/StaticStructureFactor.py
 # @brief     Implements module/class/test StaticStructureFactor
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/StructureFactorFromScatteringFunction.py
+++ b/Src/Framework/Jobs/StructureFactorFromScatteringFunction.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/StructureFactorFromScatteringFunction.py
 # @brief     Implements module/class/test StructureFactorFromScatteringFunction
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/Temperature.py
+++ b/Src/Framework/Jobs/Temperature.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/Temperature.py
 # @brief     Implements module/class/test Temperature
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/UnfoldedTrajectory.py
+++ b/Src/Framework/Jobs/UnfoldedTrajectory.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/UnfoldedTrajectory.py
 # @brief     Implements module/class/test UnfoldedTrajectory
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/VASP.py
+++ b/Src/Framework/Jobs/VASP.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/VASP.py
 # @brief     Implements module/class/test VASP
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/Src/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/VelocityAutoCorrelationFunction.py
 # @brief     Implements module/class/test VelocityAutoCorrelationFunction
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/Voronoi.py
+++ b/Src/Framework/Jobs/Voronoi.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/Voronoi.py
 # @brief     Implements module/class/test Voronoi
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/XPLOR.py
+++ b/Src/Framework/Jobs/XPLOR.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/XPLOR.py
 # @brief     Implements module/class/test XPLOR
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/XRayStaticStructureFactor.py
+++ b/Src/Framework/Jobs/XRayStaticStructureFactor.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/XRayStaticStructureFactor.py
 # @brief     Implements module/class/test XRayStaticStructureFactor
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Jobs/__init__.py
+++ b/Src/Framework/Jobs/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Jobs/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/MMTKDefinitions.py
+++ b/Src/Framework/MMTKDefinitions.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/MMTKDefinitions.py
 # @brief     Implements module/class/test MMTKDefinitions
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/OutputVariables/IOutputVariable.py
+++ b/Src/Framework/OutputVariables/IOutputVariable.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/OutputVariables/IOutputVariable.py
 # @brief     Implements module/class/test IOutputVariable
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/OutputVariables/LineOutputVariable.py
+++ b/Src/Framework/OutputVariables/LineOutputVariable.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/OutputVariables/LineOutputVariable.py
 # @brief     Implements module/class/test LineOutputVariable
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/OutputVariables/SurfaceOutputVariable.py
+++ b/Src/Framework/OutputVariables/SurfaceOutputVariable.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/OutputVariables/SurfaceOutputVariable.py
 # @brief     Implements module/class/test SurfaceOutputVariable
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/OutputVariables/VolumeOutputVariable.py
+++ b/Src/Framework/OutputVariables/VolumeOutputVariable.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/OutputVariables/VolumeOutputVariable.py
 # @brief     Implements module/class/test VolumeOutputVariable
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/OutputVariables/__init__.py
+++ b/Src/Framework/OutputVariables/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/OutputVariables/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Projectors/AxialProjector.py
+++ b/Src/Framework/Projectors/AxialProjector.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Projectors/AxialProjector.py
 # @brief     Implements module/class/test AxialProjector
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Projectors/IProjector.py
+++ b/Src/Framework/Projectors/IProjector.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Projectors/IProjector.py
 # @brief     Implements module/class/test IProjector
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Projectors/NullProjector.py
+++ b/Src/Framework/Projectors/NullProjector.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Projectors/NullProjector.py
 # @brief     Implements module/class/test NullProjector
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Projectors/PlanarProjector.py
+++ b/Src/Framework/Projectors/PlanarProjector.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Projectors/PlanarProjector.py
 # @brief     Implements module/class/test PlanarProjector
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Projectors/__init__.py
+++ b/Src/Framework/Projectors/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Projectors/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/ApproximateDispersionLatticeQVectors.py
+++ b/Src/Framework/QVectors/ApproximateDispersionLatticeQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/ApproximateDispersionLatticeQVectors.py
 # @brief     Implements module/class/test ApproximateDispersionLatticeQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/CircularLatticeQVectors.py
+++ b/Src/Framework/QVectors/CircularLatticeQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/CircularLatticeQVectors.py
 # @brief     Implements module/class/test CircularLatticeQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/CircularQVectors.py
+++ b/Src/Framework/QVectors/CircularQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/CircularQVectors.py
 # @brief     Implements module/class/test CircularQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/DispersionLatticeQVectors.py
+++ b/Src/Framework/QVectors/DispersionLatticeQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/DispersionLatticeQVectors.py
 # @brief     Implements module/class/test DispersionLatticeQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/GridQVectors.py
+++ b/Src/Framework/QVectors/GridQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/GridQVectors.py
 # @brief     Implements module/class/test GridQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/IQVectors.py
+++ b/Src/Framework/QVectors/IQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/IQVectors.py
 # @brief     Implements module/class/test IQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/LatticeQvectors.py
+++ b/Src/Framework/QVectors/LatticeQvectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/LatticeQvectors.py
 # @brief     Implements module/class/test LatticeQvectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/LinearLatticeQVectors.py
+++ b/Src/Framework/QVectors/LinearLatticeQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/LinearLatticeQVectors.py
 # @brief     Implements module/class/test LinearLatticeQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/LinearQVectors.py
+++ b/Src/Framework/QVectors/LinearQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/LinearQVectors.py
 # @brief     Implements module/class/test LinearQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/MillerIndicesQVectors.py
+++ b/Src/Framework/QVectors/MillerIndicesQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/MillerIndicesQVectors.py
 # @brief     Implements module/class/test MillerIndicesQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/SphericalLatticeQVectors.py
+++ b/Src/Framework/QVectors/SphericalLatticeQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/SphericalLatticeQVectors.py
 # @brief     Implements module/class/test SphericalLatticeQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/SphericalQVectors.py
+++ b/Src/Framework/QVectors/SphericalQVectors.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/SphericalQVectors.py
 # @brief     Implements module/class/test SphericalQVectors
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/QVectors/__init__.py
+++ b/Src/Framework/QVectors/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/QVectors/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/All.py
+++ b/Src/Framework/Selectors/All.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/All.py
 # @brief     Implements module/class/test All
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/Amine.py
+++ b/Src/Framework/Selectors/Amine.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/Amine.py
 # @brief     Implements module/class/test Amine
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/AtomFullName.py
+++ b/Src/Framework/Selectors/AtomFullName.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/AtomFullName.py
 # @brief     Implements module/class/test AtomFullName
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/AtomIndex.py
+++ b/Src/Framework/Selectors/AtomIndex.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/AtomIndex.py
 # @brief     Implements module/class/test AtomIndex
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/AtomName.py
+++ b/Src/Framework/Selectors/AtomName.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/AtomName.py
 # @brief     Implements module/class/test AtomName
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/AtomPicked.py
+++ b/Src/Framework/Selectors/AtomPicked.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/AtomPicked.py
 # @brief     Implements module/class/test AtomPicked
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/AtomSymbol.py
+++ b/Src/Framework/Selectors/AtomSymbol.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/AtomSymbol.py
 # @brief     Implements module/class/test AtomSymbol
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/AtomType.py
+++ b/Src/Framework/Selectors/AtomType.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/AtomType.py
 # @brief     Implements module/class/test AtomType
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/Backbone.py
+++ b/Src/Framework/Selectors/Backbone.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/Backbone.py
 # @brief     Implements module/class/test Backbone
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/CarboHydrogen.py
+++ b/Src/Framework/Selectors/CarboHydrogen.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/CarboHydrogen.py
 # @brief     Implements module/class/test CarboHydrogen
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/CarbonAlpha.py
+++ b/Src/Framework/Selectors/CarbonAlpha.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/CarbonAlpha.py
 # @brief     Implements module/class/test CarbonAlpha
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/ChainName.py
+++ b/Src/Framework/Selectors/ChainName.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/ChainName.py
 # @brief     Implements module/class/test ChainName
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/Expression.py
+++ b/Src/Framework/Selectors/Expression.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/Expression.py
 # @brief     Implements module/class/test Expression
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/HeteroHydrogen.py
+++ b/Src/Framework/Selectors/HeteroHydrogen.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/HeteroHydrogen.py
 # @brief     Implements module/class/test HeteroHydrogen
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/Hydroxyl.py
+++ b/Src/Framework/Selectors/Hydroxyl.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/Hydroxyl.py
 # @brief     Implements module/class/test Hydroxyl
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/ISelector.py
+++ b/Src/Framework/Selectors/ISelector.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/ISelector.py
 # @brief     Implements module/class/test ISelector
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/Macromolecule.py
+++ b/Src/Framework/Selectors/Macromolecule.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/Macromolecule.py
 # @brief     Implements module/class/test Macromolecule
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/Methyl.py
+++ b/Src/Framework/Selectors/Methyl.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/Methyl.py
 # @brief     Implements module/class/test Methyl
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/MoleculeIndex.py
+++ b/Src/Framework/Selectors/MoleculeIndex.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/MoleculeIndex.py
 # @brief     Implements module/class/test MoleculeIndex
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/MoleculeName.py
+++ b/Src/Framework/Selectors/MoleculeName.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/MoleculeName.py
 # @brief     Implements module/class/test MoleculeName
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/NitroHydrogen.py
+++ b/Src/Framework/Selectors/NitroHydrogen.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/NitroHydrogen.py
 # @brief     Implements module/class/test NitroHydrogen
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/NucleotideBase.py
+++ b/Src/Framework/Selectors/NucleotideBase.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/NucleotideBase.py
 # @brief     Implements module/class/test NucleotideBase
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/NucleotideName.py
+++ b/Src/Framework/Selectors/NucleotideName.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/NucleotideName.py
 # @brief     Implements module/class/test NucleotideName
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/NucleotideType.py
+++ b/Src/Framework/Selectors/NucleotideType.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/NucleotideType.py
 # @brief     Implements module/class/test NucleotideType
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/OxyHydrogen.py
+++ b/Src/Framework/Selectors/OxyHydrogen.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/OxyHydrogen.py
 # @brief     Implements module/class/test OxyHydrogen
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/PDBFile.py
+++ b/Src/Framework/Selectors/PDBFile.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/PDBFile.py
 # @brief     Implements module/class/test PDBFile
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/Phosphate.py
+++ b/Src/Framework/Selectors/Phosphate.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/Phosphate.py
 # @brief     Implements module/class/test Phosphate
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/PythonScript.py
+++ b/Src/Framework/Selectors/PythonScript.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/PythonScript.py
 # @brief     Implements module/class/test PythonScript
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/ResidueClass.py
+++ b/Src/Framework/Selectors/ResidueClass.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/ResidueClass.py
 # @brief     Implements module/class/test ResidueClass
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/ResidueName.py
+++ b/Src/Framework/Selectors/ResidueName.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/ResidueName.py
 # @brief     Implements module/class/test ResidueName
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/ResidueType.py
+++ b/Src/Framework/Selectors/ResidueType.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/ResidueType.py
 # @brief     Implements module/class/test ResidueType
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/SideChain.py
+++ b/Src/Framework/Selectors/SideChain.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/SideChain.py
 # @brief     Implements module/class/test SideChain
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/Sulphate.py
+++ b/Src/Framework/Selectors/Sulphate.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/Sulphate.py
 # @brief     Implements module/class/test Sulphate
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/SulphurHydrogen.py
+++ b/Src/Framework/Selectors/SulphurHydrogen.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/SulphurHydrogen.py
 # @brief     Implements module/class/test SulphurHydrogen
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/Thiol.py
+++ b/Src/Framework/Selectors/Thiol.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/Thiol.py
 # @brief     Implements module/class/test Thiol
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/Within.py
+++ b/Src/Framework/Selectors/Within.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/Within.py
 # @brief     Implements module/class/test Within
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Selectors/__init__.py
+++ b/Src/Framework/Selectors/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Selectors/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/Status.py
+++ b/Src/Framework/Status.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/Status.py
 # @brief     Implements module/class/test Status
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/UserDefinitionStore.py
+++ b/Src/Framework/UserDefinitionStore.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/UserDefinitionStore.py
 # @brief     Implements module/class/test UserDefinitionStore
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Framework/__init__.py
+++ b/Src/Framework/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Apps.py
+++ b/Src/GUI/Apps.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Apps.py
 # @brief     Implements module/class/test Apps
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/ComboWidgets/ComboCheckbox.py
+++ b/Src/GUI/ComboWidgets/ComboCheckbox.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/ComboWidgets/ComboCheckbox.py
 # @brief     Implements module/class/test ComboCheckbox
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/ComboWidgets/ConfigurationPanel.py
+++ b/Src/GUI/ComboWidgets/ConfigurationPanel.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/ComboWidgets/ConfigurationPanel.py
 # @brief     Implements module/class/test ConfigurationPanel
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/ComboWidgets/JobHelpFrame.py
+++ b/Src/GUI/ComboWidgets/JobHelpFrame.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/ComboWidgets/JobHelpFrame.py
 # @brief     Implements module/class/test JobHelpFrame
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/ComboWidgets/ProgressBar.py
+++ b/Src/GUI/ComboWidgets/ProgressBar.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/ComboWidgets/ProgressBar.py
 # @brief     Implements module/class/test ProgressBar
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/ComboWidgets/__init__.py
+++ b/Src/GUI/ComboWidgets/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/ComboWidgets/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/ControllerPanel.py
+++ b/Src/GUI/ControllerPanel.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/ControllerPanel.py
 # @brief     Implements module/class/test ControllerPanel
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/DataController.py
+++ b/Src/GUI/DataController.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/DataController.py
 # @brief     Implements module/class/test DataController
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/DataTreePanel.py
+++ b/Src/GUI/DataTreePanel.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/DataTreePanel.py
 # @brief     Implements module/class/test DataTreePanel
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/ElementsDatabaseEditor.py
+++ b/Src/GUI/ElementsDatabaseEditor.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/ElementsDatabaseEditor.py
 # @brief     Implements module/class/test ElementsDatabaseEditor
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Events/JobControllerEvent.py
+++ b/Src/GUI/Events/JobControllerEvent.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Events/JobControllerEvent.py
 # @brief     Implements module/class/test JobControllerEvent
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Events/__init__.py
+++ b/Src/GUI/Events/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Events/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Handlers/ConsoleHandler.py
+++ b/Src/GUI/Handlers/ConsoleHandler.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Handlers/ConsoleHandler.py
 # @brief     Implements module/class/test ConsoleHandler
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Handlers/DialogHandler.py
+++ b/Src/GUI/Handlers/DialogHandler.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Handlers/DialogHandler.py
 # @brief     Implements module/class/test DialogHandler
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Handlers/__init__.py
+++ b/Src/GUI/Handlers/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Handlers/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Icons/__init__.py
+++ b/Src/GUI/Icons/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Icons/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/JobControllerPanel.py
+++ b/Src/GUI/JobControllerPanel.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/JobControllerPanel.py
 # @brief     Implements module/class/test JobControllerPanel
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/JobTemplateEditor.py
+++ b/Src/GUI/JobTemplateEditor.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/JobTemplateEditor.py
 # @brief     Implements module/class/test JobTemplateEditor
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/LogfileFrame.py
+++ b/Src/GUI/LogfileFrame.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/LogfileFrame.py
 # @brief     Implements module/class/test LogfileFrame
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/MainFrame.py
+++ b/Src/GUI/MainFrame.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/MainFrame.py
 # @brief     Implements module/class/test MainFrame
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now
@@ -383,7 +383,7 @@ Authors:
 
     def on_open_mdanse_url(self, event):
 
-        webbrowser.open('http://mdanse.org')
+        webbrowser.open('https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx')
 
     def on_quit(self, event=None):
         

--- a/Src/GUI/PeriodicTableViewer.py
+++ b/Src/GUI/PeriodicTableViewer.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/PeriodicTableViewer.py
 # @brief     Implements module/class/test PeriodicTableViewer
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/AnimationPlugin.py
+++ b/Src/GUI/Plugins/AnimationPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/AnimationPlugin.py
 # @brief     Implements module/class/test AnimationPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/AtomSelectionPlugin.py
+++ b/Src/GUI/Plugins/AtomSelectionPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/AtomSelectionPlugin.py
 # @brief     Implements module/class/test AtomSelectionPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/AtomsListPlugin.py
+++ b/Src/GUI/Plugins/AtomsListPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/AtomsListPlugin.py
 # @brief     Implements module/class/test AtomsListPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/ComponentPlugin.py
+++ b/Src/GUI/Plugins/ComponentPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/ComponentPlugin.py
 # @brief     Implements module/class/test ComponentPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/DataInfoPlugin.py
+++ b/Src/GUI/Plugins/DataInfoPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/DataInfoPlugin.py
 # @brief     Implements module/class/test DataInfoPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/DataPlugin.py
+++ b/Src/GUI/Plugins/DataPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/DataPlugin.py
 # @brief     Implements module/class/test DataPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/DensitySuperpositionPlugin.py
+++ b/Src/GUI/Plugins/DensitySuperpositionPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/DensitySuperpositionPlugin.py
 # @brief     Implements module/class/test DensitySuperpositionPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/IPlugin.py
+++ b/Src/GUI/Plugins/IPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/IPlugin.py
 # @brief     Implements module/class/test IPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/JobPlugin.py
+++ b/Src/GUI/Plugins/JobPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/JobPlugin.py
 # @brief     Implements module/class/test JobPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/MolecularViewerPlugin.py
+++ b/Src/GUI/Plugins/MolecularViewerPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/MolecularViewerPlugin.py
 # @brief     Implements module/class/test MolecularViewerPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/MviViewerPlugin.py
+++ b/Src/GUI/Plugins/MviViewerPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/MviViewerPlugin.py
 # @brief     Implements module/class/test MviViewerPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/PartialChargesPlugin.py
+++ b/Src/GUI/Plugins/PartialChargesPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/PartialChargesPlugin.py
 # @brief     Implements module/class/test PartialChargesPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/Plotter1D.py
+++ b/Src/GUI/Plugins/Plotter1D.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/Plotter1D.py
 # @brief     Implements module/class/test Plotter1D
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/Plotter2D.py
+++ b/Src/GUI/Plugins/Plotter2D.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/Plotter2D.py
 # @brief     Implements module/class/test Plotter2D
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/Plotter3D.py
+++ b/Src/GUI/Plugins/Plotter3D.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/Plotter3D.py
 # @brief     Implements module/class/test Plotter3D
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/PlotterPlugin.py
+++ b/Src/GUI/Plugins/PlotterPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/PlotterPlugin.py
 # @brief     Implements module/class/test PlotterPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/PlotterSettings.py
+++ b/Src/GUI/Plugins/PlotterSettings.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/PlotterSettings.py
 # @brief     Implements module/class/test PlotterSettings
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/PlotterTicker.py
+++ b/Src/GUI/Plugins/PlotterTicker.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/PlotterTicker.py
 # @brief     Implements module/class/test PlotterTicker
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/QVectorsPlugin.py
+++ b/Src/GUI/Plugins/QVectorsPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/QVectorsPlugin.py
 # @brief     Implements module/class/test QVectorsPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/TrajectoryViewerPlugin.py
+++ b/Src/GUI/Plugins/TrajectoryViewerPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/AtomSelectionPlugin.py
 # @brief     Implements module/class/test AtomSelectionPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @authors   Scientific Computing Group at ILL (see AUTHORS)

--- a/Src/GUI/Plugins/UserDefinitionPlugin.py
+++ b/Src/GUI/Plugins/UserDefinitionPlugin.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/UserDefinitionPlugin.py
 # @brief     Implements module/class/test UserDefinitionPlugin
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Plugins/__init__.py
+++ b/Src/GUI/Plugins/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Plugins/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/PluginsTreePanel.py
+++ b/Src/GUI/PluginsTreePanel.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/PluginsTreePanel.py
 # @brief     Implements module/class/test PluginsTreePanel
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/RegistryViewer.py
+++ b/Src/GUI/RegistryViewer.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/RegistryViewer.py
 # @brief     Implements module/class/test RegistryViewer
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/UnitsEditor.py
+++ b/Src/GUI/UnitsEditor.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/UserDefinitionViewer.py
 # @brief     Implements module/class/test UserDefinitionViewer
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/UserDefinitionViewer.py
+++ b/Src/GUI/UserDefinitionViewer.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/UserDefinitionViewer.py
 # @brief     Implements module/class/test UserDefinitionViewer
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/AtomSelectionWidget.py
+++ b/Src/GUI/Widgets/AtomSelectionWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/AtomSelectionWidget.py
 # @brief     Implements module/class/test AtomSelectionWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/AtomTransmutationWidget.py
+++ b/Src/GUI/Widgets/AtomTransmutationWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/AtomTransmutationWidget.py
 # @brief     Implements module/class/test AtomTransmutationWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/AtomsListWidget.py
+++ b/Src/GUI/Widgets/AtomsListWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/AtomsListWidget.py
 # @brief     Implements module/class/test AtomsListWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/BooleanWidget.py
+++ b/Src/GUI/Widgets/BooleanWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/BooleanWidget.py
 # @brief     Implements module/class/test BooleanWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/FloatWidget.py
+++ b/Src/GUI/Widgets/FloatWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/FloatWidget.py
 # @brief     Implements module/class/test FloatWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/FramesWidget.py
+++ b/Src/GUI/Widgets/FramesWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/FramesWidget.py
 # @brief     Implements module/class/test FramesWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/GroupingLevelWidget.py
+++ b/Src/GUI/Widgets/GroupingLevelWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/GroupingLevelWidget.py
 # @brief     Implements module/class/test GroupingLevelWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/IWidget.py
+++ b/Src/GUI/Widgets/IWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/IWidget.py
 # @brief     Implements module/class/test IWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/InputDirectoryWidget.py
+++ b/Src/GUI/Widgets/InputDirectoryWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/InputDirectoryWidget.py
 # @brief     Implements module/class/test InputDirectoryWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/InputFileWidget.py
+++ b/Src/GUI/Widgets/InputFileWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/InputFileWidget.py
 # @brief     Implements module/class/test InputFileWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/InstrumentResolutionWidget.py
+++ b/Src/GUI/Widgets/InstrumentResolutionWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/InstrumentResolutionWidget.py
 # @brief     Implements module/class/test InstrumentResolutionWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/IntegerWidget.py
+++ b/Src/GUI/Widgets/IntegerWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/IntegerWidget.py
 # @brief     Implements module/class/test IntegerWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/InterpolationOrderWidget.py
+++ b/Src/GUI/Widgets/InterpolationOrderWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/InterpolationOrderWidget.py
 # @brief     Implements module/class/test InterpolationOrderWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/MMTKTrajectoryWidget.py
+++ b/Src/GUI/Widgets/MMTKTrajectoryWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/MMTKTrajectoryWidget.py
 # @brief     Implements module/class/test MMTKTrajectoryWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/McStasInstrumentWidget.py
+++ b/Src/GUI/Widgets/McStasInstrumentWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/McStasInstrumentWidget.py
 # @brief     Implements module/class/test McStasInstrumentWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/McStasOptionsWidget.py
+++ b/Src/GUI/Widgets/McStasOptionsWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/McStasOptionsWidget.py
 # @brief     Implements module/class/test McStasOptionsWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/McStasParametersWidget.py
+++ b/Src/GUI/Widgets/McStasParametersWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/McStasParametersWidget.py
 # @brief     Implements module/class/test McStasParametersWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/MultipleChoicesWidget.py
+++ b/Src/GUI/Widgets/MultipleChoicesWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/MultipleChoicesWidget.py
 # @brief     Implements module/class/test MultipleChoicesWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/NetCDFInputFileWidget.py
+++ b/Src/GUI/Widgets/NetCDFInputFileWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/NetCDFInputFileWidget.py
 # @brief     Implements module/class/test NetCDFInputFileWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/OutputDirectoryWidget.py
+++ b/Src/GUI/Widgets/OutputDirectoryWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/OutputDirectoryWidget.py
 # @brief     Implements module/class/test OutputDirectoryWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/OutputFilesWidget.py
+++ b/Src/GUI/Widgets/OutputFilesWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/OutputFilesWidget.py
 # @brief     Implements module/class/test OutputFilesWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/PartialChargesWidget.py
+++ b/Src/GUI/Widgets/PartialChargesWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/PartialChargesWidget.py
 # @brief     Implements module/class/test PartialChargesWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/ProjectionWidget.py
+++ b/Src/GUI/Widgets/ProjectionWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/ProjectionWidget.py
 # @brief     Implements module/class/test ProjectionWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/PythonObjectWidgets.py
+++ b/Src/GUI/Widgets/PythonObjectWidgets.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/PythonObjectWidgets.py
 # @brief     Implements module/class/test PythonObjectWidgets
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/QVectorsWidget.py
+++ b/Src/GUI/Widgets/QVectorsWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/QVectorsWidget.py
 # @brief     Implements module/class/test QVectorsWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/RangeWidget.py
+++ b/Src/GUI/Widgets/RangeWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/RangeWidget.py
 # @brief     Implements module/class/test RangeWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/RunningModeWidget.py
+++ b/Src/GUI/Widgets/RunningModeWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/RunningModeWidget.py
 # @brief     Implements module/class/test RunningModeWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/SingleChoiceWidget.py
+++ b/Src/GUI/Widgets/SingleChoiceWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/SingleChoiceWidget.py
 # @brief     Implements module/class/test SingleChoiceWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/SingleOutputFileWidget.py
+++ b/Src/GUI/Widgets/SingleOutputFileWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/OutputFilesWidget.py
 # @brief     Implements module/class/test OutputFilesWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/StringWidget.py
+++ b/Src/GUI/Widgets/StringWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/StringWidget.py
 # @brief     Implements module/class/test StringWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/TrajectoryVariableWidget.py
+++ b/Src/GUI/Widgets/TrajectoryVariableWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/TrajectoryVariableWidget.py
 # @brief     Implements module/class/test TrajectoryVariableWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/UserDefinitionWidget.py
+++ b/Src/GUI/Widgets/UserDefinitionWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/UserDefinitionWidget.py
 # @brief     Implements module/class/test UserDefinitionWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/VectorWidget.py
+++ b/Src/GUI/Widgets/VectorWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/VectorWidget.py
 # @brief     Implements module/class/test VectorWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/WeightsWidget.py
+++ b/Src/GUI/Widgets/WeightsWidget.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/WeightsWidget.py
 # @brief     Implements module/class/test WeightsWidget
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/Widgets/__init__.py
+++ b/Src/GUI/Widgets/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/Widgets/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/WorkingPanel.py
+++ b/Src/GUI/WorkingPanel.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/WorkingPanel.py
 # @brief     Implements module/class/test WorkingPanel
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/GUI/__init__.py
+++ b/Src/GUI/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/GUI/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/IO/HDF5.py
+++ b/Src/IO/HDF5.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/IInputData.py
 # @brief     Implements module/class/test IInputData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/IO/IOUtils.py
+++ b/Src/IO/IOUtils.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/IInputData.py
 # @brief     Implements module/class/test IInputData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/IO/NetCDF.py
+++ b/Src/IO/NetCDF.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/IInputData.py
 # @brief     Implements module/class/test IInputData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/IO/__init__.py
+++ b/Src/IO/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Framework/InputData/NetCDFInputData.py
 # @brief     Implements module/class/test NetCDFInputData
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Logging/Formatters.py
+++ b/Src/Logging/Formatters.py
@@ -5,7 +5,7 @@
 # @file      Src/Logging/Formatters.py
 # @brief     Implements module/class/test Formatters
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Logging/Logger.py
+++ b/Src/Logging/Logger.py
@@ -5,7 +5,7 @@
 # @file      Src/Logging/Logger.py
 # @brief     Implements module/class/test Logger
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Logging/__init__.py
+++ b/Src/Logging/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Logging/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Mathematics/Arithmetic.py
+++ b/Src/Mathematics/Arithmetic.py
@@ -5,7 +5,7 @@
 # @file      Src/Mathematics/Arithmetic.py
 # @brief     Implements module/class/test Arithmetic
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Mathematics/Geometry.py
+++ b/Src/Mathematics/Geometry.py
@@ -5,7 +5,7 @@
 # @file      Src/Mathematics/Geometry.py
 # @brief     Implements module/class/test Geometry
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Mathematics/Graph.py
+++ b/Src/Mathematics/Graph.py
@@ -5,7 +5,7 @@
 # @file      Src/Mathematics/Graph.py
 # @brief     Implements module/class/test Graph
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Mathematics/Signal.py
+++ b/Src/Mathematics/Signal.py
@@ -5,7 +5,7 @@
 # @file      Src/Mathematics/Signal.py
 # @brief     Implements module/class/test Signal
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/Mathematics/__init__.py
+++ b/Src/Mathematics/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/Mathematics/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/MolecularDynamics/Analysis.py
+++ b/Src/MolecularDynamics/Analysis.py
@@ -5,7 +5,7 @@
 # @file      Src/MolecularDynamics/Analysis.py
 # @brief     Implements module/class/test Analysis
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/MolecularDynamics/Trajectory.py
+++ b/Src/MolecularDynamics/Trajectory.py
@@ -5,7 +5,7 @@
 # @file      Src/MolecularDynamics/Trajectory.py
 # @brief     Implements module/class/test Trajectory
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @authors   Scientific Computing Group at ILL (see AUTHORS)

--- a/Src/MolecularDynamics/__init__.py
+++ b/Src/MolecularDynamics/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/MolecularDynamics/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/__init__.py
+++ b/Src/__init__.py
@@ -5,7 +5,7 @@
 # @file      Src/__init__.py
 # @brief     Implements module/class/test __init__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Src/__pkginfo__.py
+++ b/Src/__pkginfo__.py
@@ -5,7 +5,7 @@
 # @file      Src/__pkginfo__.py
 # @brief     Implements module/class/test __pkginfo__
 #
-# @homepage  https://mdanse.org
+# @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now
@@ -35,7 +35,7 @@ __maintainer_email__ = "perenon@ill.fr, sanghamitra.mukhopadhyay@stfc.ac.uk"
 
 __former_contributors__ = "G. Goret, B. Aoun, E.C. Pellegrini"
 
-__url__              = "https://mdanse.org/"
+__url__              = "https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx"
 
 __repo__             = "https://github.com/ISISNeutronMuon/MDANSE"
 

--- a/Tests/DependenciesTests/AllTests.py
+++ b/Tests/DependenciesTests/AllTests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/AllTests.py
 # @brief     Implements module/class/test AllTests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_basic_tests.py
+++ b/Tests/DependenciesTests/mmtk_basic_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_basic_tests.py
 # @brief     Implements module/class/test mmtk_basic_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_energy_tests.py
+++ b/Tests/DependenciesTests/mmtk_energy_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_energy_tests.py
 # @brief     Implements module/class/test mmtk_energy_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_enm_tests.py
+++ b/Tests/DependenciesTests/mmtk_enm_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_enm_tests.py
 # @brief     Implements module/class/test mmtk_enm_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_internal_coordinate_tests.py
+++ b/Tests/DependenciesTests/mmtk_internal_coordinate_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_internal_coordinate_tests.py
 # @brief     Implements module/class/test mmtk_internal_coordinate_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_normal_mode_tests.py
+++ b/Tests/DependenciesTests/mmtk_normal_mode_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_normal_mode_tests.py
 # @brief     Implements module/class/test mmtk_normal_mode_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_pickle_tests.py
+++ b/Tests/DependenciesTests/mmtk_pickle_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_pickle_tests.py
 # @brief     Implements module/class/test mmtk_pickle_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_restraint_tests.py
+++ b/Tests/DependenciesTests/mmtk_restraint_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_restraint_tests.py
 # @brief     Implements module/class/test mmtk_restraint_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_subsets.py
+++ b/Tests/DependenciesTests/mmtk_subsets.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_subsets.py
 # @brief     Implements module/class/test mmtk_subsets
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_subspace_tests.py
+++ b/Tests/DependenciesTests/mmtk_subspace_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_subspace_tests.py
 # @brief     Implements module/class/test mmtk_subspace_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_trajectory_tests.py
+++ b/Tests/DependenciesTests/mmtk_trajectory_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_trajectory_tests.py
 # @brief     Implements module/class/test mmtk_trajectory_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/mmtk_universe_tests.py
+++ b/Tests/DependenciesTests/mmtk_universe_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/mmtk_universe_tests.py
 # @brief     Implements module/class/test mmtk_universe_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/scientific_clustering_tests.py
+++ b/Tests/DependenciesTests/scientific_clustering_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/scientific_clustering_tests.py
 # @brief     Implements module/class/test scientific_clustering_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/scientific_intepolation_tests.py
+++ b/Tests/DependenciesTests/scientific_intepolation_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/scientific_intepolation_tests.py
 # @brief     Implements module/class/test scientific_intepolation_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/scientific_signal_tests.py
+++ b/Tests/DependenciesTests/scientific_signal_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/scientific_signal_tests.py
 # @brief     Implements module/class/test scientific_signal_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/DependenciesTests/scientific_vector_tests.py
+++ b/Tests/DependenciesTests/scientific_vector_tests.py
@@ -5,7 +5,7 @@
 # @file      Tests/DependenciesTests/scientific_vector_tests.py
 # @brief     Implements module/class/test scientific_vector_tests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/FunctionalTests/Jobs/AllTests.py
+++ b/Tests/FunctionalTests/Jobs/AllTests.py
@@ -5,7 +5,7 @@
 # @file      Tests/FunctionalTests/Jobs/AllTests.py
 # @brief     Implements module/class/test AllTests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/FunctionalTests/Jobs/BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/BuildJobTests.py
@@ -5,7 +5,7 @@
 # @file      Tests/FunctionalTests/Jobs/BuildJobTests.py
 # @brief     Implements module/class/test BuildJobTests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/FunctionalTests/Jobs/Comparator.py
+++ b/Tests/FunctionalTests/Jobs/Comparator.py
@@ -5,7 +5,7 @@
 # @file      Tests/FunctionalTests/Jobs/Comparator.py
 # @brief     Implements module/class/test Comparator
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/FunctionalTests/Jobs/test_BuildJobTests.py
+++ b/Tests/FunctionalTests/Jobs/test_BuildJobTests.py
@@ -5,7 +5,7 @@
 # @file      Tests/FunctionalTests/Jobs/test_BuildJobTests.py
 # @brief     Implements module/class/test test_BuildJobTests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/UnitTests/AllTests.py
+++ b/Tests/UnitTests/AllTests.py
@@ -5,7 +5,7 @@
 # @file      Tests/UnitTests/AllTests.py
 # @brief     Implements module/class/test AllTests
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/UnitTests/TestConfigurator.py
+++ b/Tests/UnitTests/TestConfigurator.py
@@ -5,7 +5,7 @@
 # @file      Tests/UnitTests/TestConfigurator.py
 # @brief     Implements module/class/test TestConfigurator
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/UnitTests/TestElementsDatabase.py
+++ b/Tests/UnitTests/TestElementsDatabase.py
@@ -5,7 +5,7 @@
 # @file      Tests/UnitTests/TestElementsDatabase.py
 # @brief     Implements module/class/test TestElementsDatabase
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/UnitTests/TestGeometry.py
+++ b/Tests/UnitTests/TestGeometry.py
@@ -5,7 +5,7 @@
 # @file      Tests/UnitTests/TestGeometry.py
 # @brief     Implements module/class/test TestGeometry
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/UnitTests/TestMolecularDynamics.py
+++ b/Tests/UnitTests/TestMolecularDynamics.py
@@ -5,7 +5,7 @@
 # @file      Tests/UnitTests/TestMolecularDynamics.py
 # @brief     Implements module/class/test TestMolecularDynamics
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now

--- a/Tests/UnitTests/TestUnits.py
+++ b/Tests/UnitTests/TestUnits.py
@@ -5,7 +5,7 @@
 # @file      Tests/UnitTests/TestGeometry.py
 # @brief     Implements module/class/test TestGeometry
 #
-# @homepage  https://mdanse.org
+# @homepage https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
 # @license   GNU General Public License v3 or higher (see LICENSE)
 # @copyright Institut Laue Langevin 2013-now
 # @copyright ISIS Neutron and Muon Source, STFC, UKRI 2021-now


### PR DESCRIPTION
I added MDANSE project links to the documentation and the interface.
Read the Docs front page now contains a link to https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
Read the Docs reference 8 is now https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
The MDANSE GUI homepage button links to https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
