### PR TITLE
Add configuration files for issues and pull requests on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug_report.md
+++ b/.github/ISSUE_TEMPLATES/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report an error which requires fixing
+title: ''
+labels: bug
+assignees:
+
+---
+
+**Description of the error**
+A clear and concise description of what the problem is, including steps to reproduce it and the environment you are running MDMC in.
+
+**Describe the expected result**
+What is the result you expect from running the steps described above?
+
+**Describe the actual result**
+What was the actual result.
+
+**Suggested fix**
+
+**Additional details**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATES/feature_request.md
+++ b/.github/ISSUE_TEMPLATES/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees:
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+**Description of work**
+A clear and concise description of the change.  Please include motivation and context.
+
+**Fixes**
+A list of fixes.
+
+**To test**
+Please describe the tests that were run to verify the changes.


### PR DESCRIPTION
These changes are meant to standardise the format of Issues and Pull Requests on GitHub. I am largely copying the approach used in the MDMC project, since it seems to work quite well, and is better than what we have now.