### PR TITLE
Fix pip install

### DIFF
--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "cython", "numpy"]
+requires = ["setuptools", "cython", "numpy", "pip", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy"]
+requires = ["setuptools", "numpy", "pip", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
**Description of work**
This addresses the issue https://github.com/ISISNeutronMuon/MDANSE/issues/248

**Fixes**
'pip' and 'wheel' have been added to the build system requirements in pyproject.toml

**To test**
`python3 -m pip install  "git+https://github.com/ISISNeutronMuon/MDANSE@protos#egg=MDANSE&subdirectory=MDANSE"`
should correctly install MDANSE now.