### PR TITLE
Change the PACF so it is independent from the origin

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -14,7 +14,7 @@
 # **************************************************************************
 
 import collections
-
+import numpy as np
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import weight
 from MDANSE.Mathematics.Signal import correlation, normalize
@@ -129,6 +129,7 @@ class PositionAutoCorrelationFunction(IJob):
             step=self.configuration["frames"]["step"],
         )
 
+        series = series - np.average(series, axis=0)
         series = self.configuration["projection"]["projector"](series)
 
         atomicPACF = correlation(series, axis=0, average=1)


### PR DESCRIPTION
**Description of work**
Change the PACF so that the correlation is calculated using positions which are relative to the atoms average positions across the trajectory. See https://github.com/ISISNeutronMuon/MDANSE/issues/212#issuecomment-1908542480 for details.

**Fixes**
Fixes the strange behaviour of the PACF seen in #212 for the end timesteps seen in both the newer and older versions of MDANSE. 
Fixes #212

**To test**
Calculate the PACF from a trajectory.