### PR TITLE
atom selection performance fix

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -165,7 +165,7 @@ class HelperDialog(QDialog):
         the helper dialog.
     """
 
-    _cbox_text  = {
+    _cbox_text = {
         "all": "All atoms:",
         "hs_on_heteroatom": "Hs on heteroatoms:",
         "primary_amine": "Primary amine groups:",

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -110,6 +110,7 @@ class CheckableComboBox(QComboBox):
         item.setText(text)
         item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
         item.setData(Qt.Unchecked, Qt.CheckStateRole)
+        self.model().appendRow(item)
         self._items.append(item)
 
     def getItems(self) -> QStandardItem:


### PR DESCRIPTION
**Description of work**
With a large number of atoms the it can take a while to load up the actions dialog. This is because of the atom selections checkable combobox. I've made some updates to improve its performance.

**Fixes**
Long action dialog loading times (1-2 mins).

**To test**
Load up a trajectory with a lot of atoms. (convert the Cu_10steps_ASEformat.traj) and load up and open an action dialog which has an atom selection section e.g. positionautocorrelationfunction. This should only take a few seconds now. Check that the atom selection helper behaves correctly.
