### PR TITLE
Add the enabled property to configurable and test for it

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurable.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurable.py
@@ -40,6 +40,8 @@ class Configurable(object):
             #.. 2-value is the dictionary of the keywords used when initializing the configurator.  
     """
 
+    enabled = True
+
     settings = collections.OrderedDict()
 
     def __init__(self, settings=None, trajectory_input="mdasne"):

--- a/MDANSE/Src/MDANSE/Framework/Converters/ImprovedASE.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/ImprovedASE.py
@@ -49,6 +49,8 @@ class ImprovedASE(Converter):
 
     label = "ImprovedASE"
 
+    enabled = False
+
     settings = collections.OrderedDict()
     settings["trajectory_file"] = (
         "AseInputFileConfigurator",

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobTree.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobTree.py
@@ -44,7 +44,8 @@ class JobTree(QStandardItemModel):
             parent_class = IJob
         full_dict = parent_class.indirect_subclass_dictionary()
         for class_name, class_object in full_dict.items():
-            self.createNode(class_name, class_object, filter)
+            if class_object.enabled:
+                self.createNode(class_name, class_object, filter)
 
     def createNode(self, name: str, thing, filter: str = ""):
         """Creates a new QStandardItem. It will store


### PR DESCRIPTION
**Description of work**
Every class derived from Configurable now has the property `enabled = True`. JobTree model only shows the classes for which enabled is True.
closes #324

**Fixes**
ImprovedASE converter is now disabled.

**To test**
Start the `mdanse_gui` and confirm that ImprovedASE does not appear in the Converter tab, but all the other options are still there.
