### PR TITLE
Trajectory and job tab right click fix

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/RunTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/RunTab.py
@@ -49,7 +49,7 @@ class RunTab(GeneralTab):
             model=JobHolder(),
             view=RunTable(),
             visualiser=TextInfo(
-                header="MDANSE Analysis Output",
+                header="MDANSE Jobs",
                 footer="Look up our Read The Docs page:"
                 + "https://mdanse.readthedocs.io/en/protos/",
             ),
@@ -77,7 +77,7 @@ class RunTab(GeneralTab):
             model=kwargs.get("model", JobHolder()),
             view=RunTable(),
             visualiser=TextInfo(
-                header="MDANSE Analysis",
+                header="MDANSE Jobs",
                 footer="Look up our "
                 + '<a href="https://mdanse.readthedocs.io/en/protos/">Read The Docs</a>'
                 + " page.",

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
@@ -30,6 +30,9 @@ class RunTable(QTableView):
 
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
         index = self.indexAt(event.pos())
+        if index.row() == -1:
+            # block right click when it's not on a job
+            return
         model = self.model()
         item = model.itemData(index)
         menu = QMenu()
@@ -46,6 +49,9 @@ class RunTable(QTableView):
         model = self.model()
         index = self.currentIndex()
         model.removeRow(index.row())
+        if model.rowCount() == 0:
+            for i in reversed(range(model.columnCount())):
+                model.removeColumn(i)
         self.item_details.emit("")
 
     @Slot(QModelIndex)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/TrajectoryView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/TrajectoryView.py
@@ -34,6 +34,9 @@ class TrajectoryView(QListView):
 
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
         index = self.indexAt(event.pos())
+        if index.row() == -1:
+            # block right click when it's not on a trajectory
+            return
         model = self.model()
         item = model.itemData(index)
         menu = QMenu()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -10,6 +10,7 @@ class TextInfo(QTextBrowser):
         self._footer = kwargs.pop("footer", "")
         super().__init__(*args, **kwargs)
         self.setOpenExternalLinks(True)
+        self.setHtml(self.filter(""))
 
     @Slot(object)
     def update_panel(self, incoming: object):


### PR DESCRIPTION
**Description of work**
Changed so that the right click is blocked when the mouse is not over an item. Adjusted the textinfo so that the some initial information is shown. The jobs table clears when there are when they are all deleted.

**Fixes**
Fixes #308 

**To test**
- The right click on the trajectory and running jobs tab should be blocked.
- After loading a trajectory or running a job the right click on the trajectory or job items should allow for a delete.
- Delete should work as expected.
- When there is nothing else to delete the right click should be blocked again.
- When all jobs are deleted in the jobs tab the table should be cleared.
