### PR TITLE
Action tab analysis loading performance update

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/selector.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/selector.py
@@ -156,7 +156,7 @@ class Selector:
                 if not switch:
                     continue
 
-                idxs = idxs | self._funcs[k](self.system, **args)
+                idxs.update(self._funcs[k](self.system, **args))
 
         if self.settings["invert"]:
             return self.all_idxs - idxs

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -12,7 +12,7 @@
 # @authors   Scientific Computing Group at ILL (see AUTHORS)
 #
 # **************************************************************************
-from typing import Union
+from typing import Union, Iterator
 from itertools import count, groupby
 from qtpy.QtCore import Qt, QEvent, Slot, QObject
 from qtpy.QtGui import QStandardItem
@@ -26,7 +26,6 @@ from qtpy.QtWidgets import (
     QHBoxLayout,
     QGroupBox,
     QLabel,
-    QApplication,
     QTextEdit,
 )
 from MDANSE.Framework.AtomSelector import Selector
@@ -111,12 +110,12 @@ class CheckableComboBox(QComboBox):
         """
         item = QStandardItem()
         item.setText(text)
-        item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
-        item.setData(Qt.Unchecked, Qt.CheckStateRole)
+        item.setEnabled(True)
+        item.setCheckable(True)
         self.model().appendRow(item)
         self._items.append(item)
 
-    def getItems(self) -> QStandardItem:
+    def getItems(self) -> Iterator[QStandardItem]:
         """
         Yields
         ------
@@ -240,7 +239,11 @@ class HelperDialog(QDialog):
                 combo_layout = QHBoxLayout()
                 combo = CheckableComboBox()
                 items = [i for i in v.keys() if match_exists[k][i]]
+                # we blocksignals here as there can be some
+                # performance issues with a large number of items
+                combo.model().blockSignals(True)
                 combo.addItems(items)
+                combo.model().blockSignals(False)
                 combo.setObjectName(k)
                 combo.model().dataChanged.connect(self.update)
                 label = QLabel(self._cbox_text[k])
@@ -293,12 +296,12 @@ class HelperDialog(QDialog):
         idxs = self.selector.get_idxs()
         num_sel = len(idxs)
 
-        text = f"Number of atoms selected:\n{num_sel}\n\nSelected atoms:\n"
-        for at in self.selector.system.atom_list:
-            if at.index in idxs:
-                text += f"{at.index})  {at.full_name}\n"
+        text = [f"Number of atoms selected:\n{num_sel}\n\nSelected atoms:\n"]
+        atoms = self.selector.system.atom_list
+        for idx in idxs:
+            text.append(f"{idx})  {atoms[idx].full_name}\n")
 
-        self.right.setText(text)
+        self.right.setText("".join(text))
 
     def apply(self) -> None:
         """Set the field of the AtomSelectionWidget to the currently

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
@@ -2,7 +2,7 @@
 #
 # MDANSE: Molecular Dynamics Analysis for Neutron Scattering Experiments
 #
-# @file      Src/PyQtGUI/InputWidgets/HDFTrajectoryWidget.py
+# @file      MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
 # @brief     Implements module/class/test HDFTrajectoryWidget
 #
 # @homepage  https://www.isis.stfc.ac.uk/Pages/MDANSEproject.aspx
@@ -12,18 +12,15 @@
 # @authors   Scientific Computing Group at ILL (see AUTHORS)
 #
 # **************************************************************************
-
 import os
 
-from qtpy.QtWidgets import QLineEdit, QSpinBox, QLabel
-from qtpy.QtCore import Slot, Signal
-from qtpy.QtGui import QIntValidator
+from qtpy.QtWidgets import QLabel
 
-from MDANSE.Framework.InputData.HDFTrajectoryInputData import HDFTrajectoryInputData
 from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
 
 
 class HDFTrajectoryWidget(WidgetBase):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         source_object = kwargs.get("source_object", None)
@@ -32,19 +29,15 @@ class HDFTrajectoryWidget(WidgetBase):
         except AttributeError:
             filename = None
         if filename is not None:
-            trajectory = HDFTrajectoryInputData(filename)
             label = QLabel(filename, self._base)
             self._layout.addWidget(label)
-            self._configurator.configure(filename)
             trajectory_path, _ = os.path.split(filename)
             self.default_path = trajectory_path
         else:
             label = QLabel("No Trajectory available", self._base)
             self._layout.addWidget(label)
-        self._trajectory = trajectory
         self.default_labels()
         self.update_labels()
-        self.updateValue()
         if self._tooltip:
             tooltip_text = self._tooltip
         else:
@@ -65,7 +58,7 @@ class HDFTrajectoryWidget(WidgetBase):
             self._tooltip = "The input trajectory to be processed"
 
     def get_value(self):
-        return self._configurator["value"]
+        return self.default_path
 
     def get_widget_value(self):
         return self.get_value()

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
@@ -29,6 +29,7 @@ class HDFTrajectoryWidget(WidgetBase):
         except AttributeError:
             filename = None
         if filename is not None:
+            self._configurator.configure(filename)
             label = QLabel(filename, self._base)
             self._layout.addWidget(label)
             trajectory_path, _ = os.path.split(filename)
@@ -58,7 +59,7 @@ class HDFTrajectoryWidget(WidgetBase):
             self._tooltip = "The input trajectory to be processed"
 
     def get_value(self):
-        return self.default_path
+        return self._configurator["value"]
 
     def get_widget_value(self):
         return self.get_value()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -146,7 +146,6 @@ class Action(QWidget):
             dtype = value[0]
             ddict = value[1]
             configurator = job_instance.configuration[key]
-            configurator.configure(self._input_trajectory)
             if not "label" in ddict.keys():
                 ddict["label"] = key
             ddict["configurator"] = configurator


### PR DESCRIPTION
**Description of work**
Some performance updates to the action tab analysis job loading. Made optimisations to the atom selection object and its widget.  

Previously when you selected an analysis job it would reload the trajectory four times! This has been updated so that it only reload it once. We have to reload it once so that it configures the HDF configurators which other configurators depend on.

**To test**
Load up a few trajectories and run a analysis job.
