### PR TITLE
Atom selection dummy update

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/all_selector.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/all_selector.py
@@ -5,7 +5,8 @@ from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem
 def select_all(
     system: ChemicalSystem, check_exists: bool = False
 ) -> Union[set[int], bool]:
-    """Selects all atoms in the chemical system.
+    """Selects all atoms in the chemical system except for the dummy
+    atoms.
 
     Parameters
     ----------
@@ -17,9 +18,10 @@ def select_all(
     Returns
     -------
     Union[set[int], bool]
-        All atom indices or a bool if checking match.
+        All atom indices except for dummy atoms or a bool if checking
+        match.
     """
     if check_exists:
         return True
     else:
-        return set([at.index for at in system.atom_list])
+        return set([at.index for at in system.atom_list if at.element != "dummy"])

--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/atom_selectors.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/atom_selectors.py
@@ -38,7 +38,9 @@ def select_element(
         return system.get_substructure_matches(pattern)
 
 
-def select_dummy(system: ChemicalSystem, check_exists: bool = False) -> Union[set[int], bool]:
+def select_dummy(
+    system: ChemicalSystem, check_exists: bool = False
+) -> Union[set[int], bool]:
     """Selects all dummy atoms in the chemical system.
 
     Parameters

--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/atom_selectors.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/atom_selectors.py
@@ -5,6 +5,7 @@ from MDANSE.Chemistry import ATOMS_DATABASE
 
 __all__ = [
     "select_element",
+    "select_dummy",
     "select_hs_on_element",
     "select_hs_on_heteroatom",
     "select_index",
@@ -35,6 +36,30 @@ def select_element(
         return system.has_substructure_match(pattern)
     else:
         return system.get_substructure_matches(pattern)
+
+
+def select_dummy(system: ChemicalSystem, check_exists: bool = False) -> Union[set[int], bool]:
+    """Selects all dummy atoms in the chemical system.
+
+    Parameters
+    ----------
+    system : ChemicalSystem
+        The MDANSE chemical system.
+    check_exists : bool, optional
+        Check if a match exists.
+
+    Returns
+    -------
+    Union[set[int], bool]
+        All dummy atom indices or a bool if checking match.
+    """
+    if check_exists:
+        for atm in system.atom_list:
+            if atm.element == "dummy":
+                return True
+        return False
+    else:
+        return set([at.index for at in system.atom_list if at.element == "dummy"])
 
 
 def select_hs_on_element(

--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/selector.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/selector.py
@@ -24,6 +24,7 @@ class Selector:
     _default = {
         # True selects atoms
         "all": True,
+        "dummy": False,
         "hs_on_heteroatom": False,
         "primary_amine": False,
         "hydroxy": False,
@@ -43,6 +44,7 @@ class Selector:
 
     _funcs = {
         "all": select_all,
+        "dummy": select_dummy,
         "hs_on_heteroatom": select_hs_on_heteroatom,
         "primary_amine": select_primary_amine,
         "hydroxy": select_hydroxy,
@@ -70,7 +72,7 @@ class Selector:
             The chemical system to apply the selection to.
         """
         self.system = system
-        self.all_idxs = select_all(system)
+        self.all_idxs = set([at.index for at in system.atom_list])
         self.settings = copy.deepcopy(self._default)
 
         symbols = set([at.symbol for at in system.atom_list])

--- a/MDANSE/Tests/UnitTests/AtomSelector/test_atom_selectors.py
+++ b/MDANSE/Tests/UnitTests/AtomSelector/test_atom_selectors.py
@@ -5,6 +5,7 @@ from MDANSE.Framework.AtomSelector.atom_selectors import (
     select_element,
     select_hs_on_heteroatom,
     select_hs_on_element,
+    select_dummy
 )
 
 
@@ -34,50 +35,57 @@ def test_select_element_returns_false_as_match_does_not_exist(
     assert not exists
 
 
-def test_select_element_returns_correct_number_of_atoms_matches(
+def test_select_element_returns_correct_number_of_atom_matches(
     protein_chemical_system,
 ):
     selection = select_element(protein_chemical_system, "S")
     assert len(selection) == 10
 
 
-def test_select_hs_on_carbon_returns_correct_number_of_atoms_matches(
+def test_select_hs_on_carbon_returns_correct_number_of_atom_matches(
     protein_chemical_system,
 ):
     selection = select_hs_on_element(protein_chemical_system, "C")
     assert len(selection) == 696
 
 
-def test_select_hs_on_nitrogen_returns_correct_number_of_atoms_matches(
+def test_select_hs_on_nitrogen_returns_correct_number_of_atom_matches(
     protein_chemical_system,
 ):
     selection = select_hs_on_element(protein_chemical_system, "N")
     assert len(selection) == 243
 
 
-def test_select_hs_on_oxygen_returns_correct_number_of_atoms_matches(
+def test_select_hs_on_oxygen_returns_correct_number_of_atom_matches(
     protein_chemical_system,
 ):
     selection = select_hs_on_element(protein_chemical_system, "O")
     assert len(selection) == 19184
 
 
-def test_select_hs_on_sulfur_returns_correct_number_of_atoms_matches(
+def test_select_hs_on_sulfur_returns_correct_number_of_atom_matches(
     protein_chemical_system,
 ):
     selection = select_hs_on_element(protein_chemical_system, "S")
     assert len(selection) == 0
 
 
-def test_select_hs_on_silicon_returns_correct_number_of_atoms_matches(
+def test_select_hs_on_silicon_returns_correct_number_of_atom_matches(
     protein_chemical_system,
 ):
     selection = select_hs_on_element(protein_chemical_system, "Si")
     assert len(selection) == 0
 
 
-def test_select_hs_on_heteroatom_returns_correct_number_of_atoms_matches(
+def test_select_hs_on_heteroatom_returns_correct_number_of_atom_matches(
     protein_chemical_system,
 ):
     selection = select_hs_on_heteroatom(protein_chemical_system)
     assert len(selection) == 19427
+
+
+def test_select_dummy_returns_correct_number_of_atom_matches(
+    protein_chemical_system,
+):
+    selection = select_dummy(protein_chemical_system)
+    assert len(selection) == 0

--- a/MDANSE/Tests/UnitTests/AtomSelector/test_group_selectors.py
+++ b/MDANSE/Tests/UnitTests/AtomSelector/test_group_selectors.py
@@ -47,33 +47,33 @@ def test_select_sulphate_returns_false_as_match_does_not_exist(
     assert not exists
 
 
-def test_select_primary_amine_returns_correct_number_of_atoms_matches(
+def test_select_primary_amine_returns_correct_number_of_atom_matches(
     protein_chemical_system,
 ):
     selection = select_primary_amine(protein_chemical_system)
     assert len(selection) == 117
 
 
-def test_select_hydroxy_returns_correct_number_of_atoms_matches(
+def test_select_hydroxy_returns_correct_number_of_atom_matches(
     protein_chemical_system,
 ):
     selection = select_hydroxy(protein_chemical_system)
     assert len(selection) == 28786
 
 
-def test_select_methyl_returns_correct_number_of_atoms_matches(protein_chemical_system):
+def test_select_methyl_returns_correct_number_of_atom_matches(protein_chemical_system):
     selection = select_methly(protein_chemical_system)
     assert len(selection) == 244
 
 
-def test_select_phosphate_returns_correct_number_of_atoms_matches(
+def test_select_phosphate_returns_correct_number_of_atom_matches(
     nucleic_acid_chemical_system,
 ):
     selection = select_phosphate(nucleic_acid_chemical_system)
     assert len(selection) == 110
 
 
-def test_select_sulphate_returns_correct_number_of_atoms_matches(
+def test_select_sulphate_returns_correct_number_of_atom_matches(
     nucleic_acid_chemical_system,
 ):
     selection = select_sulphate(nucleic_acid_chemical_system)

--- a/MDANSE/Tests/UnitTests/AtomSelector/test_molecule_selectors.py
+++ b/MDANSE/Tests/UnitTests/AtomSelector/test_molecule_selectors.py
@@ -23,7 +23,7 @@ def test_select_water_returns_true_as_match_exists(
     assert exists
 
 
-def test_select_water_returns_correct_number_of_atoms_matches(
+def test_select_water_returns_correct_number_of_atom_matches(
     protein_chemical_system,
 ):
     selection = select_water(protein_chemical_system)

--- a/MDANSE/Tests/UnitTests/AtomSelector/test_selector.py
+++ b/MDANSE/Tests/UnitTests/AtomSelector/test_selector.py
@@ -16,13 +16,13 @@ def protein_chemical_system():
     return protein_chemical_system
 
 
-def test_selector_returns_all_atoms_idxs(protein_chemical_system):
+def test_selector_returns_all_atom_idxs(protein_chemical_system):
     selector = Selector(protein_chemical_system)
     atm_idxs = selector.get_idxs()
     assert len(atm_idxs) == 30714
 
 
-def test_selector_returns_all_atoms_idxs_with_all_and_sulfurs_selected(
+def test_selector_returns_all_atom_idxs_with_all_and_sulfurs_selected(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
@@ -32,7 +32,7 @@ def test_selector_returns_all_atoms_idxs_with_all_and_sulfurs_selected(
     assert len(atm_idxs) == 30714
 
 
-def test_selector_returns_correct_number_of_atoms_idxs_when_sulfur_atoms_are_selected(
+def test_selector_returns_correct_number_of_atom_idxs_when_sulfur_atoms_are_selected(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
@@ -42,7 +42,7 @@ def test_selector_returns_correct_number_of_atoms_idxs_when_sulfur_atoms_are_sel
     assert len(atm_idxs) == 10
 
 
-def test_selector_returns_correct_number_of_atoms_idxs_when_sulfur_atoms_are_removed(
+def test_selector_returns_correct_number_of_atom_idxs_when_sulfur_atoms_are_removed(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
@@ -53,7 +53,7 @@ def test_selector_returns_correct_number_of_atoms_idxs_when_sulfur_atoms_are_rem
     assert len(atm_idxs) == 30714 - 10
 
 
-def test_selector_returns_correct_number_of_atoms_idxs_when_sulfur_atoms_are_removed_when_get_idxs_is_called_twice(
+def test_selector_returns_correct_number_of_atom_idxs_when_sulfur_atoms_are_removed_when_get_idxs_is_called_twice(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
@@ -66,7 +66,7 @@ def test_selector_returns_correct_number_of_atoms_idxs_when_sulfur_atoms_are_rem
     assert len(atm_idxs) == 30714 - 10
 
 
-def test_selector_returns_correct_number_of_atoms_idxs_when_waters_are_selected(
+def test_selector_returns_correct_number_of_atom_idxs_when_waters_are_selected(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
@@ -76,7 +76,7 @@ def test_selector_returns_correct_number_of_atoms_idxs_when_waters_are_selected(
     assert len(atm_idxs) == 28746
 
 
-def test_selector_returns_correct_number_of_atoms_idxs_when_waters_are_removed(
+def test_selector_returns_correct_number_of_atom_idxs_when_waters_are_removed(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
@@ -87,7 +87,7 @@ def test_selector_returns_correct_number_of_atoms_idxs_when_waters_are_removed(
     assert len(atm_idxs) == 30714 - 28746
 
 
-def test_selector_returns_correct_number_of_atoms_idxs_when_water_is_turned_on_and_off(
+def test_selector_returns_correct_number_of_atom_idxs_when_water_is_turned_on_and_off(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
@@ -101,7 +101,7 @@ def test_selector_returns_correct_number_of_atoms_idxs_when_water_is_turned_on_a
     assert len(atm_idxs) == 30714
 
 
-def test_selector_returns_correct_number_of_atoms_idxs_when_waters_and_sulfurs_are_removed(
+def test_selector_returns_correct_number_of_atom_idxs_when_waters_and_sulfurs_are_removed(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
@@ -113,7 +113,7 @@ def test_selector_returns_correct_number_of_atoms_idxs_when_waters_and_sulfurs_a
     assert len(atm_idxs) == 30714 - 28746 - 10
 
 
-def test_selector_returns_correct_number_of_atoms_idxs_when_waters_and_sulfurs_are_removed_with_settings_loaded_as_a_dict(
+def test_selector_returns_correct_number_of_atom_idxs_when_waters_and_sulfurs_are_removed_with_settings_loaded_as_a_dict(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
@@ -202,7 +202,7 @@ def test_selector_json_dump_with_fourth_update(protein_chemical_system):
     assert json_dump == '{"all": false, "element": {"O": true}}'
 
 
-def test_selector_returns_correct_number_of_atoms_idxs_after_setting_settings_again_with_reset_first(
+def test_selector_returns_correct_number_of_atom_idxs_after_setting_settings_again_with_reset_first(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
@@ -253,7 +253,7 @@ def test_selector_json_dump_and_load_1(protein_chemical_system):
     assert len(atm_idxs) == 30714 - 28746 - 10
 
 
-def test_selector_returns_correct_number_of_atoms_idxs_when_indexes_0_and_1_are_removed(
+def test_selector_returns_correct_number_of_atom_idxs_when_indexes_0_and_1_are_removed(
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -170,7 +170,7 @@ class HelperDialog(QDialog):
 
     _cbox_text = {
         "all": "All atoms (excl. dummy atoms):",
-        "dummy": "Dummy atoms",
+        "dummy": "All dummy atoms",
         "hs_on_heteroatom": "Hs on heteroatoms:",
         "primary_amine": "Primary amine groups:",
         "hydroxy": "Hydroxy groups:",

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -169,7 +169,8 @@ class HelperDialog(QDialog):
     """
 
     _cbox_text = {
-        "all": "All atoms:",
+        "all": "All atoms (excl. dummy atoms):",
+        "dummy": "Dummy atoms",
         "hs_on_heteroatom": "Hs on heteroatoms:",
         "primary_amine": "Primary amine groups:",
         "hydroxy": "Hydroxy groups:",

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -170,7 +170,7 @@ class HelperDialog(QDialog):
 
     _cbox_text = {
         "all": "All atoms (excl. dummy atoms):",
-        "dummy": "All dummy atoms",
+        "dummy": "All dummy atoms:",
         "hs_on_heteroatom": "Hs on heteroatoms:",
         "primary_amine": "Primary amine groups:",
         "hydroxy": "Hydroxy groups:",


### PR DESCRIPTION
**Description of work**
Changed the all selector so that it does not include dummy atoms. Added a selector for dummy atoms. The default is now changed so that all atoms except dummy atoms are selected.

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/ad743e28-9b5b-4822-9464-1c2548276a38)

**Fixes**
Closes #352.

**To test**
1. Load a trajectory with dummy atoms. 
2. Using the atom selection run a analysis with and without dummy atoms. 
3. Load up the MDA file and check that dummy are or are not included.
4. Load a trajectory without dummy atoms.
5. The option to select dummy atoms in the atom selection helper should be greyed out.
