### PR TITLE
Fix ase converter box

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
@@ -136,6 +136,9 @@ class ASE(Converter):
         try:
             frame = self._input[index]
         except TypeError:
+            frame = next(self._input)
+        else:
+            print("ASE using the slower way")
             frame = read(self.configuration["trajectory_file"]["value"], index=index)
         time = self._timeaxis[index]
 
@@ -195,15 +198,15 @@ class ASE(Converter):
         try:
             self._input = ASETrajectory(self.configuration["trajectory_file"]["value"])
         except:
-            self._input = iread(
-                self.configuration["trajectory_file"]["value"], index="[:]"
-            )
             first_frame = read(self.configuration["trajectory_file"]["value"], index=0)
             last_iterator = 0
             generator = iread(self.configuration["trajectory_file"]["value"])
             for _ in generator:
                 last_iterator += 1
             generator.close()
+            self._input = iread(
+                self.configuration["trajectory_file"]["value"]  # , index="[:]"
+            )
             self._total_number_of_steps = last_iterator
         else:
             first_frame = self._input[0]

--- a/MDANSE/Src/MDANSE/Framework/InputData/HDFTrajectoryInputData.py
+++ b/MDANSE/Src/MDANSE/Framework/InputData/HDFTrajectoryInputData.py
@@ -43,11 +43,7 @@ class HDFTrajectoryInputData(InputFileData):
         val.append("Number of steps:")
         val.append("%s\n" % len(self._data))
         val.append("Configuration:")
-        val.append(
-            "\tIs periodic: {}\n".format(
-                "unit_cell" in self._data.file["/configuration"]
-            )
-        )
+        val.append("\tIs periodic: {}\n".format("unit_cell" in self._data.file))
         val.append("Variables:")
         for k, v in self._data.file["/configuration"].items():
             val.append("\t- {}: {}".format(k, v.shape))

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -646,36 +646,42 @@ class MolecularViewer(QtWidgets.QWidget):
         if self._cell_visible:
             # update the unit cell
             uc = self._reader.read_pbc(self._current_frame)
-            a = uc.a_vector
-            b = uc.b_vector
-            c = uc.c_vector
-            uc_points = vtk.vtkPoints()
-            uc_points.SetNumberOfPoints(8)
-            for i, v in enumerate([[0, 0, 0], a, b, c, a + b, a + c, b + c, a + b + c]):
-                x, y, z = v
-                uc_points.SetPoint(i, x, y, z)
-            self._uc_polydata.SetPoints(uc_points)
+            if uc is not None:
+                a = uc.a_vector
+                b = uc.b_vector
+                c = uc.c_vector
+                uc_points = vtk.vtkPoints()
+                uc_points.SetNumberOfPoints(8)
+                for i, v in enumerate(
+                    [[0, 0, 0], a, b, c, a + b, a + c, b + c, a + b + c]
+                ):
+                    x, y, z = v
+                    uc_points.SetPoint(i, x, y, z)
+                self._uc_polydata.SetPoints(uc_points)
 
-            uc_lines = vtk.vtkCellArray()
-            for i, j in [
-                (0, 1),
-                (0, 2),
-                (0, 3),
-                (1, 4),
-                (1, 5),
-                (4, 7),
-                (2, 4),
-                (2, 6),
-                (5, 7),
-                (3, 5),
-                (3, 6),
-                (6, 7),
-            ]:
-                line = vtk.vtkLine()
-                line.GetPointIds().SetId(0, i)
-                line.GetPointIds().SetId(1, j)
-                uc_lines.InsertNextCell(line)
-            self._uc_polydata.SetLines(uc_lines)
+                uc_lines = vtk.vtkCellArray()
+                for i, j in [
+                    (0, 1),
+                    (0, 2),
+                    (0, 3),
+                    (1, 4),
+                    (1, 5),
+                    (4, 7),
+                    (2, 4),
+                    (2, 6),
+                    (5, 7),
+                    (3, 5),
+                    (3, 6),
+                    (6, 7),
+                ]:
+                    line = vtk.vtkLine()
+                    line.GetPointIds().SetId(0, i)
+                    line.GetPointIds().SetId(1, j)
+                    uc_lines.InsertNextCell(line)
+                self._uc_polydata.SetLines(uc_lines)
+            else:
+                uc_lines = vtk.vtkCellArray()
+                self._uc_polydata.SetLines(uc_lines)
         else:
             uc_lines = vtk.vtkCellArray()
             self._uc_polydata.SetLines(uc_lines)

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/readers/hdf5wrapper.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/readers/hdf5wrapper.py
@@ -37,5 +37,8 @@ class HDF5Wrapper(IReader):
         return np.array(coords)
 
     def read_pbc(self, frame: int) -> "np.array":
-        unit_cell = self._chemical_system.configuration.unit_cell
+        try:
+            unit_cell = self._chemical_system.configuration.unit_cell
+        except AttributeError:
+            unit_cell = None
         return unit_cell


### PR DESCRIPTION
**Description of work**
The ASE converter has been assigning wrong dimensions to the unit cell of the simulation. This is now fixed.

closes #344 

**Fixes**
1. The unit cell dimensions are saved correctly.
2. Systems without periodic boundary conditions are not given a unit cell.
3. Reading performance has been improved.

**To test**
Apart from the normal unit tests, it should be tested on one ASE trajectory (.traj) like the copper trajectory, and on a trajectory without periodic boundary conditions (probably hexane).

