### PR TITLE
Updated so that the HDFInputFileConfigurator map to InputFileWidget

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFInputFileConfigurator.py
@@ -28,7 +28,13 @@ class HDFInputFileConfigurator(InputFileConfigurator):
 
     _default = "INPUT_FILENAME.mda"
 
-    def __init__(self, name, variables=None, **kwargs):
+    def __init__(
+        self,
+        name,
+        variables=None,
+        wildcard="MDA analysis results (*.mda)|*.mda|HDF5 files (*.h5)|*.h5|All files|*",
+        **kwargs,
+    ):
         """
         Initializes the configurator.
 
@@ -43,6 +49,7 @@ class HDFInputFileConfigurator(InputFileConfigurator):
 
         self._variables = variables if variables is not None else []
         self._units = {}
+        self._wildcard = wildcard
 
     def configure(self, value):
         """
@@ -78,6 +85,17 @@ class HDFInputFileConfigurator(InputFileConfigurator):
                 )
                 return
         self.error_status = "OK"
+
+    @property
+    def wildcard(self):
+        """
+        Returns the wildcard used to filter the input file.
+
+        :return: the wildcard used to filter the input file.
+        :rtype: str
+        """
+
+        return self._wildcard
 
     @property
     def variables(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InputFileWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InputFileWidget.py
@@ -42,7 +42,10 @@ class InputFileWidget(WidgetBase):
             tooltip_text = self._tooltip
         else:
             tooltip_text = "Specify a path to an existing file."
-        file_association = kwargs.get("wildcard", "")
+        try:
+            file_association = configurator.wildcard
+        except AttributeError:
+            file_association = kwargs.get("wildcard", "")
         self._qt_file_association = translate_file_associations(file_association)
         field = QLineEdit(self._base)
         self._field = field

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -33,6 +33,7 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "IntegerConfigurator": IntegerWidget,
     "FramesConfigurator": FramesWidget,
     "RangeConfigurator": RangeWidget,
+    "HDFInputFileConfigurator": InputFileWidget,
     "HDFTrajectoryConfigurator": HDFTrajectoryWidget,
     "InterpolationOrderConfigurator": InterpolationOrderWidget,
     "OutputFilesConfigurator": OutputFilesWidget,


### PR DESCRIPTION
**Description of work**
Updated so that the HDFInputFileConfigurator map to InputFileWidget.

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/9712465e-a918-4b91-85c0-712dae9ff41a)


**To test**
Load up the GUI and check that structure factor inputs are file input widgets.
