### PR TITLE
Add the basic About button with version information

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -27,6 +27,7 @@ from qtpy.QtWidgets import (
     QTabWidget,
     QMenuBar,
     QMessageBox,
+    QApplication,
 )
 
 import MDANSE
@@ -128,12 +129,16 @@ class TabbedWindow(QMainWindow):
         file_group = menubar.addMenu("File")
         help_group = menubar.addMenu("Help")
         self.exitAct = QAction("Exit", parent=menubar)
-        self.exitAct.triggered.connect(self.destroy)
+        self.exitAct.triggered.connect(self.shut_down)
         file_group.addAction(self.exitAct)
-        self.aboutAct = QAction("About", parent=menubar)
+        self.aboutAct = QAction("About MDANSE", parent=menubar)
         self.aboutAct.triggered.connect(self.version_information)
         help_group.addAction(self.aboutAct)
         self.setMenuBar(menubar)
+
+    def shut_down(self):
+        QApplication.quit()
+        self.destroy(True, True)
 
     def version_information(self):
         version = ""

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -15,16 +15,21 @@
 
 import os
 from collections import defaultdict
+from importlib import metadata
 
 from icecream import ic
-from qtpy.QtCore import (
-    Slot,
-    QTimer,
-    Signal,
-    QMessageLogger,
-)
+from qtpy.QtCore import Slot, QTimer, Signal, QMessageLogger, Qt
 from qtpy.QtGui import QAction
-from qtpy.QtWidgets import QMainWindow, QFileDialog, QToolBar, QTabWidget
+from qtpy.QtWidgets import (
+    QMainWindow,
+    QFileDialog,
+    QToolBar,
+    QTabWidget,
+    QMenuBar,
+    QMessageBox,
+)
+
+import MDANSE
 
 from MDANSE_GUI.Session.LocalSession import LocalSession
 from MDANSE_GUI.Tabs.Settings.LocalSettings import LocalSettings
@@ -116,12 +121,25 @@ class TabbedWindow(QMainWindow):
         self.destroyed.connect(self.settings_timer.stop)
 
     def setupMenubar(self):
-        self._menuBar = self.menuBar()
-        self._menuBar.setObjectName("main menubar")
-        self._menuBar.setVisible(True)
-        self.exitAct = QAction("Exit", parent=self._menuBar)
+        menubar = QMenuBar()
+        menubar.setNativeMenuBar(False)  # this works around PyQt problems on MacOS
+        menubar.setObjectName("main menubar")
+        menubar.setVisible(True)
+        file_group = menubar.addMenu("File")
+        help_group = menubar.addMenu("Help")
+        self.exitAct = QAction("Exit", parent=menubar)
         self.exitAct.triggered.connect(self.destroy)
-        self._menuBar.addAction(self.exitAct)
+        file_group.addAction(self.exitAct)
+        self.aboutAct = QAction("About", parent=menubar)
+        self.aboutAct.triggered.connect(self.version_information)
+        help_group.addAction(self.aboutAct)
+        self.setMenuBar(menubar)
+
+    def version_information(self):
+        version = ""
+        version += f"MDANSE version: {metadata.version('MDANSE')}\n"
+        version += f"MDANSE_GUI version: {metadata.version('MDANSE_GUI')}\n"
+        popup = QMessageBox.about(self, "MDANSE Version Information", version)
 
     def setupToolbar(self):
         self._toolBar = QToolBar("Main MDANSE toolbar", self)


### PR DESCRIPTION
**Description of work**
In order to make the MDANSE GUI more standard, a menu entry named "About MDANSE" has been added.
 
**Fixes**
1. "About MDANSE" shows version information.
2. "Exit" now shuts down the GUI.
3. A Menu Bar appears in the window also on a Mac.

**To test**
Please start the GUI and try out the menu bar buttons.
