### PR TITLE
Added unitless unit and fixed data not plottable for eccentricity jobs

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
@@ -123,7 +123,7 @@ class Eccentricity(IJob):
                 "LineOutputVariable",
                 npoints,
                 axis="time",
-                units="uma*nm2",
+                units="uma nm2",
             )
         for axis in ["a", "b", "c"]:
             self._outputData.add(

--- a/MDANSE/Src/MDANSE/Framework/Units.py
+++ b/MDANSE/Src/MDANSE/Framework/Units.py
@@ -692,12 +692,13 @@ class UnitsManager(metaclass=Singleton):
         UnitsManager._UNITS.clear()
 
         d = {}
+        with open(UnitsManager._DEFAULT_DATABASE, "r") as fin:
+            d.update(json.load(fin))
         try:
             with open(UnitsManager._USER_DATABASE, "r") as fin:
                 d.update(json.load(fin))
         except:
-            with open(UnitsManager._DEFAULT_DATABASE, "r") as fin:
-                d.update(json.load(fin))
+            self.save()
         finally:
             for uname, udict in list(d.items()):
                 factor = udict.get("factor", 1.0)

--- a/MDANSE/Src/MDANSE/Framework/units.json
+++ b/MDANSE/Src/MDANSE/Framework/units.json
@@ -96,7 +96,21 @@
             0
         ], 
         "factor": 1.0
-    }, 
+    },
+    "unitless": {
+        "dimension": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ],
+        "factor": 1.0
+    },
     "au": {
         "dimension": [
             0, 


### PR DESCRIPTION
**Description of work**
Added unitless unit and fixed data not plottable for eccentricity jobs

**Fixes**
Fixes #363

**To test**
Run the eccentricity job and load up plot. All results should be plottable.
