### PR TITLE
Remove failing analysis

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/CroppedTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CroppedTrajectory.py
@@ -27,6 +27,8 @@ class CroppedTrajectory(IJob):
     Crop a trajectory in terms of the contents of the simulation box (selected atoms or molecules) and the trajectory length.
     """
 
+    enabled = False
+
     label = "Cropped Trajectory"
 
     category = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
@@ -49,6 +49,8 @@ class CurrentCorrelationFunction(IJob):
     in space and time)'
     """
 
+    enabled = False
+
     label = "Current Correlation Function"
 
     category = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
@@ -25,6 +25,8 @@ from MDANSE.Mathematics.Signal import correlation
 class DipoleAutoCorrelationFunction(IJob):
     """ """
 
+    enabled = False
+
     label = "Dipole AutoCorrelation Function"
 
     category = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GlobalMotionFilteredTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GlobalMotionFilteredTrajectory.py
@@ -47,6 +47,8 @@ class GlobalMotionFilteredTrajectory(IJob):
     In the global motion filtered trajectory, the universe is made infinite and all the configurations contiguous.
     """
 
+    enabled = False
+
     label = "Global Motion Filtered Trajectory"
 
     category = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/McStasVirtualInstrument.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/McStasVirtualInstrument.py
@@ -56,6 +56,8 @@ class McStasVirtualInstrument(IJob):
         instrument resolution, self-shielding and multiple scattering.
     """
 
+    enabled = False
+
     label = "McStas Virtual Instrument"
 
     category = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RigidBodyTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RigidBodyTrajectory.py
@@ -46,6 +46,8 @@ class RigidBodyTrajectory(IJob):
     doi: 10.1080/08927029108022453.
     """
 
+    enabled = False
+
     label = "Rigid Body Trajectory"
 
     category = (

--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -32,7 +32,7 @@ def qvector_spherical_lattice(trajectory):
     )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def dcsf():
     temp_name = tempfile.mktemp()
     parameters = {}
@@ -54,7 +54,7 @@ def dcsf():
     os.remove(temp_name + ".mda")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def disf():
     temp_name = tempfile.mktemp()
     parameters = {}

--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -45,7 +45,7 @@ def dcsf():
         "SphericalLatticeQVectors",
         {"seed": 0, "shells": (5.0, 36, 10.0), "n_vectors": 10, "width": 9.0},
     )
-    parameters["running_mode"] = ("monoprocessor",)
+    parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
     parameters["weights"] = "b_coherent"
     dcsf = IJob.create("DynamicCoherentStructureFactor")
@@ -67,7 +67,7 @@ def disf():
         "SphericalLatticeQVectors",
         {"seed": 0, "shells": (5.0, 36, 10.0), "n_vectors": 10, "width": 9.0},
     )
-    parameters["running_mode"] = ("monoprocessor",)
+    parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
     parameters["weights"] = "b_incoherent2"
     disf = IJob.create("DynamicIncoherentStructureFactor")
@@ -151,21 +151,16 @@ def test_gdisf(trajectory):
     os.remove(temp_name + ".mda")
 
 
-@pytest.mark.xfail(reason="see docstring")
 def test_ndtsf(disf, dcsf, qvector_spherical_lattice):
-    """A known problem that will have to be fixed."""
     temp_name = tempfile.mktemp()
     parameters = {}
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
-    parameters["frames"] = (0, 10, 1)
     parameters["disf_input_file"] = disf
     parameters["dcsf_input_file"] = dcsf
-    parameters["q_vectors"] = qvector_spherical_lattice
-    parameters["running_mode"] = ("monoprocessor",)
+    parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
     parameters["output_files"] = (temp_name, ("MDAFormat",))
-    parameters["weights"] = "b_incoherent2"
     ndtsf = IJob.create("NeutronDynamicTotalStructureFactor")
     ndtsf.run(parameters, status=True)
     assert path.exists(temp_name + ".mda")
@@ -173,13 +168,12 @@ def test_ndtsf(disf, dcsf, qvector_spherical_lattice):
     os.remove(temp_name + ".mda")
 
 
-@pytest.mark.xfail(reason="see docstring")
 def test_ssfsf(disf):
     """Also fails at the moment. Must be fixed soon"""
     temp_name = tempfile.mktemp()
     parameters = {}
     parameters["sample_inc"] = disf
-    parameters["running_mode"] = ("monoprocessor",)
+    parameters["running_mode"] = ("single-core",)
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["output_files"] = (temp_name, ("MDAFormat",))
     ndtsf = IJob.create("StructureFactorFromScatteringFunction")
@@ -203,7 +197,7 @@ def test_ccf(qvector_spherical_lattice):
     parameters["interpolation_mode"] = "automatic"
     parameters["output_files"] = (temp_name, ("MDAFormat",))
     parameters["q_vectors"] = qvector_spherical_lattice
-    parameters["running_mode"] = ("monoprocessor",)
+    parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
     parameters["weights"] = "b_coherent"
     ndtsf = IJob.create("CurrentCorrelationFunction")


### PR DESCRIPTION
**Description of work**
Not all the jobs will be ready for the release next week. Those that clearly require more work are now not visible in the GUI.

**Fixes**
1. Corrected the scattering unit tests,
2. Disabled the following jobs:
- Cropped Trajectory
- RigidBodyTrajectory
- GlobalMotionFilteredTrajectory
- DipoleAutoCorrelationFunction
- McStasVirtualInstrument
- CurrentCorrelationFunction

**To test**
Run the unit tests. Start the GUI and confirm that the jobs listed above are not visible.
