### PR TITLE
ROG remove weight setting

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/RadiusOfGyration.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RadiusOfGyration.py
@@ -47,10 +47,6 @@ class RadiusOfGyration(IJob):
         "AtomSelectionConfigurator",
         {"dependencies": {"trajectory": "trajectory"}},
     )
-    settings["weights"] = (
-        "WeightsConfigurator",
-        {"dependencies": {"atom_selection": "atom_selection"}},
-    )
     settings["output_files"] = (
         "OutputFilesConfigurator",
         {"formats": ["MDAFormat", "TextFormat"]},


### PR DESCRIPTION
**Description of work**
Removed the weight setting from the ROG analysis job since is not used and also does not makes sense for it to be included.

**Fixes**
Fixes #377

**To test**
Open the GUI and check that the weight setting has been removed in the ROG analysis job.
