### PR TITLE
Group level configurator fix

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
@@ -110,7 +110,7 @@ class GroupingLevelConfigurator(SingleChoiceConfigurator):
         trajConfig = self._configurable[self._dependencies["trajectory"]]
         atomSelectionConfig = self._configurable[self._dependencies["atom_selection"]]
 
-        allAtoms = sorted_atoms(trajConfig["chemical_system"].atom_list)
+        allAtoms = sorted_atoms(trajConfig["instance"].chemical_system.atom_list)
 
         groups = collections.OrderedDict()
         for i in range(atomSelectionConfig["selection_length"]):
@@ -119,7 +119,7 @@ class GroupingLevelConfigurator(SingleChoiceConfigurator):
             mass = atomSelectionConfig["masses"][i][0]
             at = allAtoms[idx]
             lvl = LEVELS[value][
-                at.top_level_chemical_entity().__class__.__name__.lower()
+                at.top_level_chemical_entity.__class__.__name__.lower()
             ]
             parent = self.find_parent(at, lvl)
             d = groups.setdefault(parent, {})

--- a/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
@@ -118,9 +118,7 @@ class GroupingLevelConfigurator(SingleChoiceConfigurator):
             el = atomSelectionConfig["elements"][i][0]
             mass = atomSelectionConfig["masses"][i][0]
             at = allAtoms[idx]
-            lvl = LEVELS[value][
-                at.top_level_chemical_entity.__class__.__name__.lower()
-            ]
+            lvl = LEVELS[value][at.top_level_chemical_entity.__class__.__name__.lower()]
             parent = self.find_parent(at, lvl)
             d = groups.setdefault(parent, {})
             d.setdefault("indexes", []).append(idx)


### PR DESCRIPTION
**Description of work**
Fixed the group level configurator.

**Fixes**
Fixes #304

**To test**
Run an analysis type with the group level configurator setting. Try this for different setting - the jobs should complete without crashing.
