### PR TITLE
Change colour parsing in plot_1d_model

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Plotter/models/plot_1d_model.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Plotter/models/plot_1d_model.py
@@ -190,12 +190,10 @@ class Plot1DModel(QtCore.QAbstractListModel):
         elif role == QtCore.Qt.ItemDataRole.ForegroundRole:
             matplotlib_color = line.get_color()
             try:
-                color = matplotlib_color.lstrip("#")
-                r, g, b = tuple(int(color[i : i + 2], 16) / 255.0 for i in (0, 2, 4))
-            except AttributeError:
+                color = QtGui.QColor(matplotlib_color)
+            except TypeError:
                 r, g, b = matplotlib_color
-            finally:
-                color = QtGui.QColor(r * 255, g * 255, b * 255)
+                color = QtGui.QColor(int(r * 255), int(g * 255), int(b * 255))
             return color
 
         elif role == Plot1DModel.LineRole:


### PR DESCRIPTION
**Description of work**
Changes the translation between the matplotlib and Qt colour scheme.

closes #391

**Fixes**
Changed the sequence of colour formats used by the plotter code.

**To test**
1. Load an MDA file into the plotter.
2. Plot a 1D curve.
3. Right-click the plot and pick "Lines settings".
4. Change the colour of the curve.
All this should complete without the GUI crashing.