### PR TITLE
Discard the parameter label in Configurable.setup

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurable.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurable.py
@@ -165,7 +165,7 @@ class Configurable(object):
 
                 if conf.check_dependencies(configured):
                     if not conf.optional:
-                        conf.configure(parameters[name])
+                        conf.configure(parameters[name][0])
                         self._info.append(conf.get_information())
                     else:
                         if parameters[name]:


### PR DESCRIPTION
**Description of work**
A recent change created a problem with configuration parsing. Instead of the value a tuple of (value, label) was being passed to each configurator.

**Fixes**
- The first element of the tuple is now passed instead of the entire tuple.

**To test**
Try running a converter and an analysis.
