### PR TITLE
Velocity interpolation order 0 fix

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
@@ -52,7 +52,7 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
         :type value: str one of *'no interpolation'*,*'1st order'*,*'2nd order'*,*'3rd order'*,*'4th order'* or *'5th order'*.
         """
 
-        if value is None:
+        if value is None or value == "":
             value = self._default
 
         IntegerConfigurator.configure(self, value)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
@@ -66,6 +66,12 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
 
             self["variable"] = "velocities"
 
+        elif value > 5:
+            self.error_status = (
+                f"Use an interpolation order greater than 5 is not implemented."
+            )
+            return
+
         else:
             self["variable"] = "coordinates"
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
@@ -52,7 +52,7 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
         :type value: str one of *'no interpolation'*,*'1st order'*,*'2nd order'*,*'3rd order'*,*'4th order'* or *'5th order'*.
         """
 
-        if not value:
+        if value is None:
             value = self._default
 
         IntegerConfigurator.configure(self, value)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -166,8 +166,7 @@ class DensityOfStates(IJob):
         indexes = self.configuration["atom_selection"]["indexes"][index]
 
         if self.configuration["interpolation_order"]["value"] == 0:
-            series = trajectory.read_configuration_variable(
-                self.configuration["trajectory"]["instance"],
+            series = trajectory.read_configuration_trajectory(
                 indexes[0],
                 first=self.configuration["frames"]["first"],
                 last=self.configuration["frames"]["last"] + 1,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -121,8 +121,7 @@ class Temperature(IJob):
         trajectory = self.configuration["trajectory"]["instance"]
 
         if self.configuration["interpolation_order"]["value"] == 0:
-            series = trajectory.read_configuration_variable(
-                self.configuration["trajectory"]["instance"],
+            series = trajectory.read_configuration_trajectory(
                 index,
                 first=self.configuration["frames"]["first"],
                 last=self.configuration["frames"]["last"] + 1,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -152,8 +152,7 @@ class VelocityAutoCorrelationFunction(IJob):
         indexes = self.configuration["atom_selection"]["indexes"][index]
 
         if self.configuration["interpolation_order"]["value"] == 0:
-            series = trajectory.read_configuration_variable(
-                self.configuration["trajectory"]["instance"],
+            series = trajectory.read_configuration_trajectory(
                 indexes[0],
                 first=self.configuration["frames"]["first"],
                 last=self.configuration["frames"]["last"] + 1,

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -391,9 +391,9 @@ class Trajectory:
             True if variable exists.
         """
         if variable in self._h5_file["/configuration"]:
-            return False
-        else:
             return True
+        else:
+            return False
 
     @property
     def chemical_system(self):

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -366,7 +366,7 @@ class Trajectory:
         if last is None:
             last = len(self)
 
-        if self.has_variable(variable):
+        if not self.has_variable(variable):
             raise TrajectoryError(
                 "The variable {} is not stored in the trajectory".format(variable)
             )

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -390,7 +390,7 @@ class Trajectory:
         bool
             True if variable exists.
         """
-        if variable not in self._h5_file["/configuration"]:
+        if variable in self._h5_file["/configuration"]:
             return False
         else:
             return True

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -366,16 +366,34 @@ class Trajectory:
         if last is None:
             last = len(self)
 
-        grp = self._h5_file["/configuration"]
-
-        if variable not in grp:
+        if self.has_variable(variable):
             raise TrajectoryError(
                 "The variable {} is not stored in the trajectory".format(variable)
             )
 
+        grp = self._h5_file["/configuration"]
         variable = grp[variable][first:last:step, index, :].astype(np.float64)
 
         return variable
+
+    def has_variable(self, variable: str) -> bool:
+        """Check if the trajectory has a specific variable e.g.
+        velocities.
+
+        Parameters
+        ----------
+        variable : str
+            The variable to check the existence of.
+
+        Returns
+        -------
+        bool
+            True if variable exists.
+        """
+        if variable not in self._h5_file["/configuration"]:
+            return False
+        else:
+            return True
 
     @property
     def chemical_system(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InterpolationOrderWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InterpolationOrderWidget.py
@@ -37,6 +37,7 @@ class InterpolationOrderWidget(WidgetBase):
         source_object = kwargs.get("source_object", None)
 
         self._field = QSpinBox(self._base)
+        self._field.setMaximum(5)
         self._field.setValue(1)
         label = QLabel("Interpolation order", self._base)
         self.numerator = QLabel("st order")

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InterpolationOrderWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InterpolationOrderWidget.py
@@ -38,7 +38,13 @@ class InterpolationOrderWidget(WidgetBase):
 
         self._field = QSpinBox(self._base)
         self._field.setMaximum(5)
-        self._field.setValue(1)
+        configurator = self._configurator
+        trajectory = configurator._configurable[
+            configurator._dependencies["trajectory"]
+        ]["instance"]
+        if not trajectory.has_variable("velocities"):
+            self._field.setMinimum(1)
+            self._field.setValue(1)
         label = QLabel("Interpolation order", self._base)
         self.numerator = QLabel("st order")
 


### PR DESCRIPTION
**Description of work**
 Fixed temperature, DOS and vacf jobs so that they use velocities with order=0. Updated GUI so that the interpolation order choices go from 0-5. Order=0 is only available when velocity data is available. Order=0 is the default if available.

**Fixes**
Fixes #360

**To test**
- Load up a trajectory without velocity data in the GUI and check that the possible values of the interpolations order is 1-5.
- Check again but with a trajectory with velocity data. The interpolations order values choices should be 0-5. Defaults should be 0.
- Run a job e.g. temperature with order=0. This should work with issues.
