### PR TITLE
Remove the calculation of formatted time string from Status

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/JobStatus.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/JobStatus.py
@@ -16,7 +16,7 @@
 
 import collections
 import pickle
-import datetime
+import time
 import os
 import threading
 import time
@@ -36,11 +36,8 @@ class JobStatus(Status):
         self._state = JobState()
         self._state["pid"] = PLATFORM.pid()
         self._state["type"] = job.__class__.__name__
-        self._state["start"] = datetime.datetime.strftime(
-            datetime.datetime.today(), "%d-%m-%Y %H:%M:%S"
-        )
+        self._state["start"] = str(time.time())
         self._state["elapsed"] = "N/A"
-        self._state["eta"] = "N/A"
         self._state["current_step"] = 0
         self._state["n_steps"] = 0
         self._state["progress"] = 0
@@ -87,10 +84,8 @@ class JobStatus(Status):
         self._state["elapsed"] = self.elapsedTime
         self._state["current_step"] = self.currentStep
         if self._nSteps is not None:
-            self._state["eta"] = self.eta
             self._state["progress"] = 100 * self.currentStep / self.nSteps
         else:
-            self._eta = "N/A"
             self._state["progress"] = 0
 
         self.save_status()


### PR DESCRIPTION
**Description of work**
The calculation of "timedelta" in the Status object causes an occasional random crash with an OverflowError. At the same time, the result of the calculation is not used anywhere.

Note: an individual analysis job should not be spending time calculating its own elapsed time and predicted remaining time. If any process (e.g. GUI) needs this information, they can get the timing information from the Status and do the calculation on their side.

**Fixes**
1. The calculation and formatting of the "timedelta" has been removed from the code.
2. The ._deltas list does not grow indefinitely, and contains only two elements instead. These are [start_time, last_update_time].

**To test**
Unit tests should pass. Please run a converter job and an analysis job from the GUI to be sure that no side effects have been introduced into the status-gui interaction.
