### PR TITLE
Add resolution helper

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
@@ -69,7 +69,7 @@ class InstrumentResolutionWidget(WidgetBase):
         # first row
         for num in range(1, 3):
             label = QLabel("", parent=self._base)
-            field = QLineEdit("0.0", parent=self._base)
+            field = QLineEdit("N/A", parent=self._base)
             field.setEnabled(False)
             self._layout.addWidget(label, 0, 2 * num)
             self._layout.addWidget(field, 0, 2 * num + 1)
@@ -81,7 +81,7 @@ class InstrumentResolutionWidget(WidgetBase):
         # first row
         for num in range(0, 3):
             label = QLabel("", parent=self._base)
-            field = QLineEdit("0.0", parent=self._base)
+            field = QLineEdit("N/A", parent=self._base)
             field.setEnabled(False)
             self._layout.addWidget(label, 1, 2 * num)
             self._layout.addWidget(field, 1, 2 * num + 1)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
@@ -27,6 +27,7 @@ from qtpy.QtCore import Qt, Slot
 from qtpy.QtGui import QDoubleValidator
 
 from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
+from MDANSE_GUI.Widgets.ResolutionDialog import ResolutionDialog, widget_text_map
 
 
 init_parameters = {
@@ -45,23 +46,19 @@ init_parameters = {
 }
 
 
-widget_text_map = {
-    "ideal": "ideal",
-    "Gaussian": "gaussian",
-    "Lorentzian": "lorentzian",
-    "triangular": "triangular",
-    "square": "square",
-    "pseudo-Voigt": "pseudovoigt",
-}
-
-
 class InstrumentResolutionWidget(WidgetBase):
     def __init__(self, *args, **kwargs):
         kwargs["layout_type"] = "QGridLayout"
         super().__init__(*args, **kwargs)
         self._layout.addWidget(QLabel("Resolution function", self._base), 0, 0)
         self._type_combo = QComboBox(parent=self._base)
+        self._dialog_button = QPushButton("Helper Dialog", self._base)
+        self._dialog_button.clicked.connect(self.helper_dialog)
+        self._dialog_button.setEnabled(True)
+        self.helper = ResolutionDialog(self._base)
+        self.helper.parameters_changed.connect(self.set_parameters_from_dialog)
         self._layout.addWidget(self._type_combo, 0, 1)
+        self._layout.addWidget(self._dialog_button, 1, 0)
         self._labels = []
         self._fields = []
         self._defaults = []
@@ -107,9 +104,7 @@ class InstrumentResolutionWidget(WidgetBase):
     def configure_using_default(self):
         """This is too complex to have a default value"""
 
-    @Slot(str)
-    def change_function(self, function: str):
-        new_params = init_parameters[function]
+    def set_field_values(self, new_params: dict):
         np = list(new_params.items())
         for index in range(5):
             try:
@@ -125,6 +120,11 @@ class InstrumentResolutionWidget(WidgetBase):
                 self._fields[index].setPlaceholderText("N/A")
                 self._fields[index].setEnabled(False)
                 self._defaults[index] = 0.0
+
+    @Slot(str)
+    def change_function(self, function: str):
+        new_params = init_parameters[function]
+        self.set_field_values(new_params)
 
     def get_widget_value(self):
         function = widget_text_map[self._type_combo.currentText()]
@@ -143,3 +143,21 @@ class InstrumentResolutionWidget(WidgetBase):
                     self._fields[index].setStyleSheet("")
                 params[key] = value
         return (function, params)
+
+    @Slot(dict)
+    def set_parameters_from_dialog(self, input: dict):
+        peak_function = input.get("function", None)
+        if peak_function is None:
+            return
+        self._type_combo.setCurrentText(peak_function)
+        temp_parameters = init_parameters[peak_function]
+        for key in temp_parameters.keys():
+            temp_parameters[key] = input.get(key, 0.0)
+        self.set_field_values(temp_parameters)
+
+    @Slot()
+    def helper_dialog(self):
+        if self.helper.isVisible():
+            self.helper.close()
+        else:
+            self.helper.show()

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
@@ -142,6 +142,7 @@ class InstrumentResolutionWidget(WidgetBase):
                 else:
                     self._fields[index].setStyleSheet("")
                 params[key] = value
+        self.helper.update_fields((function, params))
         return (function, params)
 
     @Slot(dict)
@@ -160,5 +161,4 @@ class InstrumentResolutionWidget(WidgetBase):
         if self.helper.isVisible():
             self.helper.close()
         else:
-            self.helper.update_fields(self.get_widget_value())
             self.helper.show()

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
@@ -50,7 +50,7 @@ class InstrumentResolutionWidget(WidgetBase):
     def __init__(self, *args, **kwargs):
         kwargs["layout_type"] = "QGridLayout"
         super().__init__(*args, **kwargs)
-        self._layout.addWidget(QLabel("Resolution function", self._base), 0, 0)
+        # self._layout.addWidget(QLabel("Resolution function", self._base), 0, 0)
         self._type_combo = QComboBox(parent=self._base)
         self._dialog_button = QPushButton("Helper Dialog", self._base)
         self._dialog_button.clicked.connect(self.helper_dialog)
@@ -58,7 +58,7 @@ class InstrumentResolutionWidget(WidgetBase):
         self.helper = ResolutionDialog(self._base)
         self.helper.parameters_changed.connect(self.set_parameters_from_dialog)
         self._layout.addWidget(self._type_combo, 0, 1)
-        self._layout.addWidget(self._dialog_button, 1, 0)
+        self._layout.addWidget(self._dialog_button, 0, 0)
         self._labels = []
         self._fields = []
         self._defaults = []

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
@@ -160,4 +160,5 @@ class InstrumentResolutionWidget(WidgetBase):
         if self.helper.isVisible():
             self.helper.close()
         else:
+            self.helper.update_fields(self.get_widget_value())
             self.helper.show()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/ResolutionDialog.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/ResolutionDialog.py
@@ -1,0 +1,145 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Union, Iterable, Optional
+from collections import OrderedDict
+import copy
+
+from icecream import ic
+
+from qtpy.QtWidgets import (
+    QDialog,
+    QPushButton,
+    QGridLayout,
+    QVBoxLayout,
+    QWidget,
+    QLabel,
+    QComboBox,
+    QMenu,
+    QLineEdit,
+    QTableView,
+    QFormLayout,
+    QHBoxLayout,
+    QCheckBox,
+    QTextEdit,
+    QApplication,
+)
+from qtpy.QtCore import Signal, Slot, Qt, QPoint, QSize, QSortFilterProxyModel, QObject
+from qtpy.QtGui import (
+    QFont,
+    QEnterEvent,
+    QStandardItem,
+    QStandardItemModel,
+    QIntValidator,
+    QDoubleValidator,
+    QValidator,
+)
+
+import matplotlib.pyplot as mpl
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+from matplotlib.backends.backend_qt5agg import (
+    NavigationToolbar2QT as NavigationToolbar2QTAgg,
+)
+
+from MDANSE.Framework.InstrumentResolutions.IInstrumentResolution import (
+    IInstrumentResolution,
+)
+from MDANSE_GUI.InputWidgets.InstrumentResolutionWidget import widget_text_map
+
+
+class ResolutionDialog(QDialog):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        layout = QGridLayout(self)
+        self._resolution = None
+        self.setLayout(layout)
+        self._peak_selector = QComboBox(self)
+        self._peak_selector.addItems(widget_text_map.keys())
+        self._unit_selector = QComboBox(self)
+        self._unit_selector.addItems(["meV", "cm-1", "THz"])
+        self._fwhm = QLineEdit("1.0", self)
+        self._centre = QLineEdit("0.0", self)
+        self._eta = QLineEdit("N/A", self)
+        self._eta.setEnabled(False)
+        text_labels = ["Peak function", "Energy unit", "FWHM", "Centre", "eta"]
+        for number, widget in enumerate(
+            [
+                self._peak_selector,
+                self._unit_selector,
+                self._fwhm,
+                self._centre,
+                self._eta,
+            ]
+        ):
+            layout.addWidget(QLabel(text_labels[number], self), number, 0)
+            layout.addWidget(widget, number, 1)
+        canvas = self.make_canvas()
+        layout.addWidget(canvas, 0, 2, 5, 1)
+        for widget in [self._fwhm, self._centre, self._eta]:
+            widget.textChanged.connect(self.update_plot)
+        self._peak_selector.currentTextChanged.connect(self.update_model)
+
+    def make_canvas(self, width=8.0, height=6.0, dpi=300):
+        canvas = QWidget(self)
+        layout = QVBoxLayout(canvas)
+        figure = mpl.figure(figsize=[width, height], dpi=dpi)  # , frameon = False)
+        figAgg = FigureCanvasQTAgg(figure)
+        figAgg.setParent(canvas)
+        figAgg.updateGeometry()
+        toolbar = NavigationToolbar2QTAgg(figAgg, canvas)
+        toolbar.update()
+        layout.addWidget(figAgg)
+        layout.addWidget(toolbar)
+        self._figure = figure
+        return canvas
+
+    @Slot(str)
+    def update_model(self, new_model: str):
+        self._resolution_name = new_model
+        self._resolution = IInstrumentResolution.create(widget_text_map[new_model])
+        if "oigt" in new_model:
+            self._eta.setEnabled(True)
+            self._eta.setText("0.0")
+        else:
+            self._eta.setEnabled(False)
+            self._eta.setText("N/A")
+
+    @Slot()
+    def update_plot(self):
+        try:
+            fwhm = float(self._fwhm.text())
+        except:
+            return
+        try:
+            centre = float(self._centre.text())
+        except:
+            return
+        if "oigt" in self._resolution_name:
+            try:
+                eta = float(self._eta.text())
+            except:
+                return
+        unit = self._unit_selector.currentText()
+
+
+if __name__ == "__main__":
+    import sys
+
+    app = QApplication(sys.argv)
+    root = ResolutionDialog()
+    root.show()
+    app.exec()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/ResolutionDialog.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/ResolutionDialog.py
@@ -245,7 +245,7 @@ class ResolutionDialog(QDialog):
         of points around the peak centre.
         """
         try:
-            fwhm = float(self._fwhm.text())
+            fwhm = abs(float(self._fwhm.text()))
         except:
             return
         try:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/ResolutionDialog.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/ResolutionDialog.py
@@ -207,12 +207,21 @@ class ResolutionDialog(QDialog):
     def set_peak_parameter(self, value: float, key: str):
         self._resolution._configuration[key].configure(value)
 
-    def update_text_output(self):
+    def update_text_output(self, rounding_precision=3):
         text = "Parameters in MDANSE internal units\n"
         results = {"function": self._resolution_name}
         for key, value in self._resolution._configuration.items():
-            text += f"settings[{key}] = {value['value']}\n"
-            results[key] = value["value"]
+            original_value = value["value"]
+            if abs(original_value) < 1e-12:
+                rounded_value = 0.0
+            else:
+                rounded_value = round(
+                    original_value,
+                    abs(math.floor(math.log10(abs(original_value))))
+                    + rounding_precision,
+                )
+            text += f"settings[{key}] = {rounded_value}\n"
+            results[key] = rounded_value
         self._output_field.setText(text)
         self.parameters_changed.emit(results)
 


### PR DESCRIPTION
**Description of work**
Adds a helper dialog for defining the instrument resolution function. It uses FWHM as the input parameter, and allows the user to pick a unit of energy of the FWHM. Also provides a preview of the peak function.

closes #343

**Fixes**
1. A new dialog has been added to the InstrumentResolutionWidget.
2. If the user changes the main GUI input fields manually, the helper dialog is updated too.

**To test**
Please try running the DynamicIncoherentStructureFactor analysis, and change the resolution function type and peak parameters both in the main GUI and in the helper dialog.
