### PR TITLE
Update to the DOS calculation.

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
@@ -78,6 +78,7 @@ class InstrumentResolutionConfigurator(IConfigurator):
         )
         self["n_omegas"] = len(self["omega"])
 
+        # generate the rfftfreq for the positive frequency only results
         self["romega"] = (
             2.0 * np.pi * np.fft.rfftfreq(2 * self["n_frames"] - 1, self["time_step"])
         )

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
@@ -79,9 +79,7 @@ class InstrumentResolutionConfigurator(IConfigurator):
         self["n_omegas"] = len(self["omega"])
 
         self["romega"] = (
-            2.0
-            * np.pi
-            * np.fft.rfftfreq(2 * self["n_frames"] - 1, self["time_step"])
+            2.0 * np.pi * np.fft.rfftfreq(2 * self["n_frames"] - 1, self["time_step"])
         )
         self["n_romegas"] = len(self["romega"])
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
@@ -76,23 +76,30 @@ class InstrumentResolutionConfigurator(IConfigurator):
                 np.fft.fftfreq(2 * self["n_frames"] - 1, self["time_step"])
             )
         )
-
         self["n_omegas"] = len(self["omega"])
 
+        self["romega"] = (
+            2.0
+            * np.pi
+            * np.fft.rfftfreq(2 * self["n_frames"] - 1, self["time_step"])
+        )
+        self["n_romegas"] = len(self["romega"])
+
         kernel, parameters = value
-
-        resolution = IInstrumentResolution.create(kernel)
-
-        resolution.setup(parameters)
-
-        resolution.set_kernel(self["omega"], self["time_step"])
-
-        self["omega_window"] = resolution.omegaWindow
-
-        self["time_window"] = resolution.timeWindow.real
-
         self["kernel"] = kernel
         self["parameters"] = parameters
+
+        resolution = IInstrumentResolution.create(kernel)
+        resolution.setup(parameters)
+        resolution.set_kernel(self["omega"], self["time_step"])
+        self["omega_window"] = resolution.omegaWindow
+        self["time_window"] = resolution.timeWindow.real
+
+        rresolution = IInstrumentResolution.create(kernel)
+        rresolution.setup(parameters)
+        rresolution.set_kernel(self["romega"], self["time_step"], fft="rfft")
+        self["romega_window"] = rresolution.omegaWindow
+        self["rtime_window"] = rresolution.timeWindow.real
 
     def get_information(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Gaussian.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Gaussian.py
@@ -31,13 +31,11 @@ class Gaussian(IInstrumentResolution):
     settings["mu"] = ("FloatConfigurator", {"default": 0.0})
     settings["sigma"] = ("FloatConfigurator", {"default": 1.0})
 
-    def set_kernel(self, omegas, dt):
+    def set_kernel(self, omegas, dt, fft="fft"):
         mu = self._configuration["mu"]["value"]
         sigma = self._configuration["sigma"]["value"]
 
         self._omegaWindow = (np.sqrt(2.0 * np.pi) / sigma) * np.exp(
             -0.5 * ((omegas - mu) / sigma) ** 2
         )
-        self._timeWindow = np.fft.fftshift(
-            np.fft.ifft(np.fft.ifftshift(self._omegaWindow)) / dt
-        )
+        self._timeWindow = self.apply_fft(self._omegaWindow, dt, fft)

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/IInstrumentResolution.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/IInstrumentResolution.py
@@ -16,6 +16,8 @@
 
 import abc
 
+import numpy as np
+
 from MDANSE.Core.Error import Error
 from MDANSE.Framework.Configurable import Configurable
 
@@ -35,8 +37,19 @@ class IInstrumentResolution(Configurable, metaclass=SubclassFactory):
         self._timeWindow = None
 
     @abc.abstractmethod
-    def set_kernel(self, omegas, dt):
+    def set_kernel(self, omegas, dt, fft="fft"):
         pass
+
+    def apply_fft(self, omegaWindow, dt, fft="fft"):
+        if fft == "fft":
+            timeWindow = np.fft.fftshift(
+                np.fft.ifft(np.fft.ifftshift(omegaWindow)) / dt
+            )
+        elif fft == "rfft":
+            timeWindow = np.fft.irfft(np.fft.ifftshift(omegaWindow)) / dt
+        else:
+            raise ValueError("fft variable should be fft or rfft.")
+        return timeWindow
 
     @property
     def omegaWindow(self):

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Ideal.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Ideal.py
@@ -29,7 +29,7 @@ class Ideal(IInstrumentResolution):
 
     settings = collections.OrderedDict()
 
-    def set_kernel(self, omegas, dt):
+    def set_kernel(self, omegas, dt, fft="fft"):
         nOmegas = len(omegas)
         self._omegaWindow = np.zeros(nOmegas, dtype=np.float64)
         self._omegaWindow[int(nOmegas / 2)] = 1.0

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Lorentzian.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Lorentzian.py
@@ -33,11 +33,9 @@ class Lorentzian(IInstrumentResolution):
     settings["mu"] = ("FloatConfigurator", {"default": 0.0})
     settings["sigma"] = ("FloatConfigurator", {"default": 1.0})
 
-    def set_kernel(self, omegas, dt):
+    def set_kernel(self, omegas, dt, fft="fft"):
         mu = self._configuration["mu"]["value"]
         sigma = self._configuration["sigma"]["value"]
 
         self._omegaWindow = (2.0 * sigma) / ((omegas - mu) ** 2 + sigma**2)
-        self._timeWindow = np.fft.fftshift(
-            np.fft.ifft(np.fft.ifftshift(self._omegaWindow)) / dt
-        )
+        self._timeWindow = self.apply_fft(self._omegaWindow, dt, fft)

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/PseudoVoigt.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/PseudoVoigt.py
@@ -34,7 +34,7 @@ class PseudoVoigt(IInstrumentResolution):
     settings["mu_gaussian"] = ("FloatConfigurator", {"default": 0.0})
     settings["sigma_gaussian"] = ("FloatConfigurator", {"default": 1.0})
 
-    def set_kernel(self, omegas, dt):
+    def set_kernel(self, omegas, dt, fft="fft"):
         eta = self._configuration["eta"]["value"]
         muL = self._configuration["mu_lorentzian"]["value"]
         sigmaL = self._configuration["sigma_lorentzian"]["value"]
@@ -48,6 +48,4 @@ class PseudoVoigt(IInstrumentResolution):
         lorentzian = (2.0 * sigmaL) / ((omegas - muL) ** 2 + sigmaL**2)
 
         self._omegaWindow = eta * lorentzian + (1.0 - eta) * gaussian
-        self._timeWindow = np.fft.fftshift(
-            np.fft.ifft(np.fft.ifftshift(self._omegaWindow)) / dt
-        )
+        self._timeWindow = self.apply_fft(self._omegaWindow, dt, fft)

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Square.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Square.py
@@ -31,7 +31,7 @@ class Square(IInstrumentResolution):
     settings["mu"] = ("FloatConfigurator", {"default": 0.0})
     settings["sigma"] = ("FloatConfigurator", {"default": 1.0})
 
-    def set_kernel(self, omegas, dt):
+    def set_kernel(self, omegas, dt, fft="fft"):
         mu = self._configuration["mu"]["value"]
         sigma = self._configuration["sigma"]["value"]
 
@@ -41,6 +41,4 @@ class Square(IInstrumentResolution):
             * np.where((np.abs(omegas - mu) - sigma) > 0, 0.0, 1.0 / (2.0 * sigma))
         )
 
-        self._timeWindow = np.fft.fftshift(
-            np.fft.ifft(np.fft.ifftshift(self._omegaWindow)) / dt
-        )
+        self._timeWindow = self.apply_fft(self._omegaWindow, dt, fft)

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Triangular.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Triangular.py
@@ -31,7 +31,7 @@ class Triangular(IInstrumentResolution):
     settings["mu"] = ("FloatConfigurator", {"default": 0.0})
     settings["sigma"] = ("FloatConfigurator", {"default": 1.0})
 
-    def set_kernel(self, omegas, dt):
+    def set_kernel(self, omegas, dt, fft="fft"):
         mu = self._configuration["mu"]["value"]
         sigma = self._configuration["sigma"]["value"]
 
@@ -39,6 +39,4 @@ class Triangular(IInstrumentResolution):
 
         self._omegaWindow = 2.0 * np.pi * np.where(val >= 0, 0.0, -val / sigma**2)
 
-        self._timeWindow = np.fft.fftshift(
-            np.fft.ifft(np.fft.ifftshift(self._omegaWindow)) / dt
-        )
+        self._timeWindow = self.apply_fft(self._omegaWindow, dt, fft)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -73,7 +73,9 @@ class DensityOfStates(IJob):
     )
     settings["weights"] = (
         "WeightsConfigurator",
-        {"dependencies": {"atom_selection": "atom_selection"}},
+        {
+            "default": "atomic_weight",
+            "dependencies": {"atom_selection": "atom_selection"}},
     )
     settings["output_files"] = (
         "OutputFilesConfigurator",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -75,7 +75,8 @@ class DensityOfStates(IJob):
         "WeightsConfigurator",
         {
             "default": "atomic_weight",
-            "dependencies": {"atom_selection": "atom_selection"}},
+            "dependencies": {"atom_selection": "atom_selection"},
+        },
     )
     settings["output_files"] = (
         "OutputFilesConfigurator",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -221,12 +221,21 @@ class DensityOfStates(IJob):
                 self._outputData["vacf_%s" % element],
                 self.configuration["instrument_resolution"]["time_window"],
                 self.configuration["instrument_resolution"]["time_step"],
-                fft="rfft"
+                fft="rfft",
             )
 
         weights = self.configuration["weights"].get_weights()
-        weight(weights, self._outputData, nAtomsPerElement, 1, "vacf_%s", update_values=True)
-        weight(weights, self._outputData, nAtomsPerElement, 1, "dos_%s", update_values=True)
+        weight(
+            weights,
+            self._outputData,
+            nAtomsPerElement,
+            1,
+            "vacf_%s",
+            update_values=True,
+        )
+        weight(
+            weights, self._outputData, nAtomsPerElement, 1, "dos_%s", update_values=True
+        )
 
         self._outputData.write(
             self.configuration["output_files"]["root"],

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -47,7 +47,7 @@ def get_weights(props, contents, dim):
     return weights, normFactor
 
 
-def weight(props, values, contents, dim, key, symmetric=True):
+def weight(props, values, contents, dim, key, symmetric=True, update_values=False):
     weights = get_weights(props, contents, dim)[0]
     weightedSum = None
     matches = dict([(key % k, k) for k in list(weights.keys())])
@@ -66,5 +66,9 @@ def weight(props, values, contents, dim, key, symmetric=True):
             weightedSum = w * val
         else:
             weightedSum += w * val
+
+        if update_values:
+            values[key % "total"] += w * val
+            values[k][:] = w * val
 
     return weightedSum

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -256,7 +256,7 @@ def symmetrize(signal, axis=0):
     return signal
 
 
-def get_spectrum(signal, window=None, timeStep=1.0, axis=0):
+def get_spectrum(signal, window=None, timeStep=1.0, axis=0, fft="fft"):
     signal = symmetrize(signal, axis)
 
     if window is None:
@@ -275,13 +275,24 @@ def get_spectrum(signal, window=None, timeStep=1.0, axis=0):
     # For information about the manipulation around fftshift and ifftshift
     # http://www.mathworks.com/matlabcentral/newsreader/view_thread/285244
 
-    fftSignal = (
-        0.5
-        * np.fft.fftshift(
-            np.fft.fft(np.fft.ifftshift(signal * window[s], axes=axis), axis=axis),
-            axes=axis,
+    if fft == "fft":
+        fftSignal = (
+            0.5
+            * np.fft.fftshift(
+                np.fft.fft(np.fft.ifftshift(signal * window[s], axes=axis), axis=axis),
+                axes=axis,
+            )
+            * timeStep
+            / np.pi
         )
-        * timeStep
-        / np.pi
-    )
+    elif fft == "rfft":
+        fftSignal = (
+            0.5
+            * np.fft.rfft(np.fft.ifftshift(signal * window[s], axes=axis), axis=axis)
+            * timeStep
+            / np.pi
+        )
+    else:
+        raise ValueError("fft variable should be fft or rfft.")
+
     return fftSignal.real

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -269,8 +269,9 @@ def get_spectrum(signal, window=None, timeStep=1.0, axis=0, fft="fft"):
 
     s = tuple(s)
 
-    # We compute the unitary inverse fourier transform with angular frequencies as described in
-    # https://en.wikipedia.org/wiki/Fourier_transform#Discrete_Fourier_Transforms_and_Fast_Fourier_Transforms
+    # We compute the non-unitary fourier transform with angular
+    # frequencies with a 1/2pi factor applied to the forward transform.
+    # This is done for some historical reason see the git history.
 
     # For information about the manipulation around fftshift and ifftshift
     # http://www.mathworks.com/matlabcentral/newsreader/view_thread/285244


### PR DESCRIPTION
**Description of work**
Updated the DOS calculation so that results are a bit more clear for new users.

- Removal of the negative frequency part of the DOS.
- Setting of the DOS to arb units. Since MDANSE DOS is actually the FT of a weighted VACF some actual units could be specified like previously. However A.U. are less confusing for new users since you would expect either A.U. or states per unit energy not the previous units of nm2/ps. 
- Set the default weighting scheme to atomic_weight so that the results are now proportional to the actual density of states.
- Changed the DOS so that the sum of atomic density of states equal to the total.

**Fixes**
Closes #408, Closes #353

**To test**
Run a density of states calculation on the protos branch and then on the dos-weight-update branch the total DOS should be the same except the new result should only include positive frequency results and the DOS units should now be au.

**Water diffusion constant DOS(0) test**
Since we know that DOS(0) with equal weighting is proportional to the diffusion constant (D) and d/dt MSD = 6D. I ran the MSD with the long DLPOLY H2O trajectory runs and got the following plot.

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/fafbc8a0-c094-422c-8a38-8d48389dd2a0)

Doing a simple two point gradient at the endpoints I get a approximate diffusion of 0.633738624175695 / (6 * 50) = 0.00211246208058565 nm^2/ps. Running DOS (equal weight) on the same trajectory I get.

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/be18a6c5-2d9a-4b92-b7ea-2bd5af9db5b8)

DOS(0) = 0.0007601503675207263 and pi * DOS(0) = 0.002388082810226695 (The pi factor occurs because of the 1/2pi factor used in MDANSE for the foward FT). Which is similar to the MSD result above.  


**Total DOS now a sum of atomic**
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/71b1f113-3c64-4fa5-aa76-49b4084d0d70)