### PR TITLE
Correct RMSD documentation and remove RMSD weight setting.

### DIFF
--- a/Doc/pages/structure.rst
+++ b/Doc/pages/structure.rst
@@ -256,10 +256,10 @@ the difference between two structures. It can be defined as:
 .. math::
    :label: pfx131
 
-   {\mathit{RMSD}{(t) = \sqrt{\frac{\sum\limits_{\alpha = 1}^{N_{\alpha}}\left( {r_{\alpha}{(t) - r_{\alpha}}\left( t_{\mathit{ref}} \right)} \right)}{N_{\alpha}}}}}
+   {\mathit{RMSD}{(t) = \sqrt{\frac{\sum\limits_{\alpha}^{N_{\alpha}}\vert {r_{\alpha}{(t) - r_{\alpha}}\left( t_{\mathrm{ref}} \right)} \vert^{2}}{N_{\alpha}}}}}
 
-where N\_ is the number of atoms of the system, and r_(t) and r_(tref )
-are respectively the position of atom :math:`\alpha` at time t and tref where tref is
+where :math:`N_{\alpha}` is the number of selected atoms of the system and :math:`r_{\alpha}(t)` and :math:`r_{\alpha}(t_{\mathrm{ref}})`
+are respectively the position of atom :math:`\alpha` at time :math:`t` and :math:`t_{\mathrm{ref}}` where :math:`t_{\mathrm{ref}}` is
 a reference time usually chosen as the first step of the simulation.
 Typically, *RMSD* is used to quantify the structural evolution of the
 system during the simulation. It can provide precious information about
@@ -268,23 +268,18 @@ structural changes occurred during the simulation.
 
 In Molecular Dynamics Analysis for Neutron Scattering Experiments
 (*MDANSE*), *RMSD* is computed using the discretized version of equation
-:math:numref:`pfx130`:
+:math:numref:`pfx131`:
 
 .. math::
    :label: pfx132
 
-   {\mathit{RMSD}{\left( {n\cdot\Delta t} \right) = \sqrt{\frac{\sum\limits_{\alpha = 1}^{N_{\alpha}}\left( {r_{\alpha}{(t) - r_{\mathit{ref}}}(t)} \right)}{N_{\alpha}}}},{n = 0}\ldots{N_{t} - 1}.}
+   {\mathit{RMSD}{\left( {n\Delta t} \right) = \sqrt{\frac{\sum\limits_{\alpha}^{N_{\alpha}}\vert {r_{\alpha}{(t) - r_{\alpha}}(t_{\mathrm{ref}})} \vert^{2}}{N_{\alpha}}}} \qquad {n = 0}\ldots{N_{t} - 1}.}
 
-where Nt is the number of frames and
+where :math:`N_{t}` is the number of frames and :math:`\mathrm{\Delta}t` is the time step.
+Additionally MDANSE will also calculate the RMSD of individual atoms types,
+for example, the RMSD of the oxygen atoms in addition to the RMSD of all
+atoms of the system.
 
-.. math::
-   :label: pfx133
-   
-   {\mathrm{\Delta}t}
-
-\ is the time step.
-
-.
 
 Root Mean Square Fluctuation
 ''''''''''''''''''''''''''''

--- a/Doc/pages/structure.rst
+++ b/Doc/pages/structure.rst
@@ -256,29 +256,21 @@ the difference between two structures. It can be defined as:
 .. math::
    :label: pfx131
 
-   {\mathit{RMSD}{(t) = \sqrt{\frac{\sum\limits_{\alpha}^{N_{\alpha}}\vert {r_{\alpha}{(t) - r_{\alpha}}\left( t_{\mathrm{ref}} \right)} \vert^{2}}{N_{\alpha}}}}}
+   {\mathrm{RMSD}{\left( {n\Delta t} \right) = \sqrt{\frac{\sum\limits_{\alpha}^{N_{\alpha}}\vert {\mathbf{r}_{\alpha}{(n\Delta t) - \mathbf{r}_{\alpha}}(n_{\mathrm{ref}}\Delta t)} \vert^{2}}{N_{\alpha}}}} \qquad {n = 0}\ldots{N_{t} - 1}}
 
-where :math:`N_{\alpha}` is the number of selected atoms of the system and :math:`r_{\alpha}(t)` and :math:`r_{\alpha}(t_{\mathrm{ref}})`
-are respectively the position of atom :math:`\alpha` at time :math:`t` and :math:`t_{\mathrm{ref}}` where :math:`t_{\mathrm{ref}}` is
-a reference time usually chosen as the first step of the simulation.
+where :math:`N_{t}` is the number of frames, :math:`\mathrm{\Delta}t`
+is the time step, :math:`N_{\alpha}` is the number of selected atoms of
+the system and :math:`\mathbf{r}_{\alpha}(n\Delta t)` and
+:math:`\mathbf{r}_{\alpha}(n_{\mathrm{ref}}\Delta t)`
+are respectively the position of atom :math:`\alpha` at time :math:`n\Delta t` and :math:`n_{\mathrm{ref}}\Delta t` where :math:`n_{\mathrm{ref}}` is
+a reference frame usually chosen as the zeroth frame of the simulation.
+
 Typically, *RMSD* is used to quantify the structural evolution of the
 system during the simulation. It can provide precious information about
 the system especially if it reached equilibrium or conversely if major
-structural changes occurred during the simulation.
-
-In Molecular Dynamics Analysis for Neutron Scattering Experiments
-(*MDANSE*), *RMSD* is computed using the discretized version of equation
-:math:numref:`pfx131`:
-
-.. math::
-   :label: pfx132
-
-   {\mathit{RMSD}{\left( {n\Delta t} \right) = \sqrt{\frac{\sum\limits_{\alpha}^{N_{\alpha}}\vert {r_{\alpha}{(t) - r_{\alpha}}(t_{\mathrm{ref}})} \vert^{2}}{N_{\alpha}}}} \qquad {n = 0}\ldots{N_{t} - 1}.}
-
-where :math:`N_{t}` is the number of frames and :math:`\mathrm{\Delta}t` is the time step.
-Additionally MDANSE will also calculate the RMSD of individual atoms types,
-for example, the RMSD of the oxygen atoms in addition to the RMSD of all
-atoms of the system.
+structural changes occurred during the simulation. MDANSE calculates the
+*RMSD* of individual atoms types, for example, the *RMSD* of the oxygen
+atoms in addition to the RMSD of all atoms of the system.
 
 
 Root Mean Square Fluctuation
@@ -299,24 +291,25 @@ or any molecular system subject to temporal variations.
 Radius Of Gyration
 ''''''''''''''''''
 
-Radius Of Gyration (*ROG*) is calculated as a root (mass weighted) mean
+Radius Of Gyration (*ROG*) is calculated as a root (atomic mass weighted) mean
 square distance of the components of a system relative to either its centre of
 mass or a given axis of rotation. The *ROG* serves as a quantitative
-measure which can be used to characterizes the spatial distribution of
+measure which can be used to characterize the spatial distribution of
 a system such as a molecule or a cluster of atoms.
 
 In MDANSE *ROG* is calculated relative to the systems centre of mass.
-Mathematically, it can be defined as:
+It can be defined as:
 
 .. math::
    :label: pfx134
 
-    {\mathrm{ROG}{(t) = \sqrt{\frac{\sum_{i}^{N}m_{i}\vert {\mathbf{r}_{i}{(t) - \mathbf{r}_{\mathrm{CM}}}(t)} \vert^{2}}{\sum_{i}^{N}m_{i}}}}}
+    {\mathrm{ROG}{({n\Delta t}) = \sqrt{\frac{\sum_{i}^{N}m_{i}\vert {\mathbf{r}_{i}{(n\Delta t) - \mathbf{r}_{\mathrm{CM}}}(n\Delta t)} \vert^{2}}{\sum_{i}^{N}m_{i}}}} \qquad {n = 0}\ldots{N_{t} - 1}}
 
-where :math:`N` is the number of atoms of the system,
-:math:`r_{i}(t)` are the positions of the
-atoms :math:`i`, :math:`r_{\mathrm{CM}}(t)` is the centre of mass of
-the system and :math:`t` is the time of the simulation.
+where :math:`N_{t}` is the number of frames, :math:`\mathrm{\Delta}t`
+is the time step, :math:`N` is the number of atoms of the system,
+:math:`\mathbf{r}_{i}(n\Delta t)` are the positions of the
+atoms :math:`i`, :math:`\mathbf{r}_{\mathrm{CM}}(n\Delta t)` is the centre of mass of
+the system and :math:`n\Delta t` is the time of the simulation.
 
 *ROG* can be used to describe the overall spread of the molecule and
 as such is a good measure for the molecule compactness. For example,

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomSelectionConfigurator.py
@@ -93,6 +93,13 @@ class AtomSelectionConfigurator(IConfigurator):
         self.error_status = "OK"
 
     def get_natoms(self):
+        """
+        Returns
+        -------
+        dict
+            A dictionary with the atom name for the key and
+            number of atoms selected for its value.
+        """
         nAtomsPerElement = {}
         for v in self["names"]:
             if v in nAtomsPerElement:
@@ -101,6 +108,15 @@ class AtomSelectionConfigurator(IConfigurator):
                 nAtomsPerElement[v] = 1
 
         return nAtomsPerElement
+
+    def get_total_natoms(self):
+        """
+        Returns
+        -------
+        int
+            The total number of atoms selected.
+        """
+        return len(self["names"])
 
     def get_indexes(self):
         indexesPerElement = {}

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
@@ -161,7 +161,9 @@ class RootMeanSquareDeviation(IJob):
                 self._outputData["rmsd_{}".format(element)]
             )
 
-        self._outputData["rmsd_all"] /= self.configuration["atom_selection"].get_total_natoms()
+        self._outputData["rmsd_all"] /= self.configuration[
+            "atom_selection"
+        ].get_total_natoms()
         self._outputData["rmsd_all"] = np.sqrt(self._outputData["rmsd_all"])
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
@@ -162,7 +162,7 @@ class RootMeanSquareDeviation(IJob):
             )
 
         self._outputData["rmsd_all"] /= self.configuration["atom_selection"].get_total_natoms()
-        self._outputData["rmsd_all"] = np.sqrt(self._outputData["rmsd_total"])
+        self._outputData["rmsd_all"] = np.sqrt(self._outputData["rmsd_all"])
 
         self._outputData.write(
             self.configuration["output_files"]["root"],


### PR DESCRIPTION
**Description of work**
Updated and corrected RMSD documentation, the equations in the current version are not correct, see the new version below. Also updated the ROG documentation.

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/ad1b1776-84c2-4127-9239-2f4466f9fa74)

I've also removed the weight setting from the RMSD calculation. Here are two reason for why I've decided that the weight setting should be remove from the RMSD calculation.

- RMSD weight setting does not follow the documentation on how the weight setting is applied. In RMSD it is applied inside the property calculation before the application of the root. 
- Keeping the weight setting would mean doing similar things for other calculations or we'd have to have RMSD as some special case which will be confusing for users.

I've also changed the result name from rmsd_total to rmsd_all to make it clear that rmsd_all is not the sum of the atom rmsds.

**Fixes**
Closes #381

**To test**
The weight setting on the RMSD job should be removed. Run RMSD and check the results, this should be the same as the results calculated on the protos branch with equal weight setting.
