### PR TITLE
Save input parameters in output files

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurable.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurable.py
@@ -14,6 +14,7 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+from typing import Dict
 import collections
 
 from MDANSE.Core.Error import Error
@@ -195,6 +196,14 @@ class Configurable(object):
                 )
 
         self._configured = True
+
+    def output_configuration(self) -> Dict[str, str]:
+        if not self._configured:
+            return
+        result = {}
+        for name, conf in list(self._configuration.items()):
+            result[name] = conf.to_json()
+        return result
 
     def __str__(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AseInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AseInputFileConfigurator.py
@@ -55,6 +55,7 @@ class AseInputFileConfigurator(InputFileConfigurator):
         :param value: the input file.
         :type value: str
         """
+        self._original_input = values
         try:
             value, file_format = values
         except ValueError:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
@@ -39,6 +39,7 @@ class AtomMappingConfigurator(IConfigurator):
         """
         if value is None:
             value = self._default
+        self._original_input = value
 
         if not isinstance(value, str):
             self.error_status = "Invalid input value."

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomSelectionConfigurator.py
@@ -50,6 +50,7 @@ class AtomSelectionConfigurator(IConfigurator):
         :param value: the input value
         :type value: str
         """
+        self._original_input = value
 
         trajConfig = self._configurable[self._dependencies["trajectory"]]
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomTransmutationConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomTransmutationConfigurator.py
@@ -57,6 +57,7 @@ class AtomTransmutationConfigurator(IConfigurator):
         """
 
         self["value"] = value
+        self._original_input = value
 
         # if the input value is None, do not perform any transmutation
         if value is None:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomsListConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomsListConfigurator.py
@@ -60,6 +60,7 @@ class AtomsListConfigurator(IConfigurator):
         :type value: str
         """
 
+        self._original_input = value
         traj_configurator = self._configurable[self._dependencies["trajectory"]]
 
         if UD_STORE.has_definition(

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AxisSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AxisSelectionConfigurator.py
@@ -47,6 +47,7 @@ class AxisSelectionConfigurator(IConfigurator):
         :param value: the input value
         :type value: tuple or str 
         """
+        self._original_input = value
 
         trajConfig = self._configurable[self._dependencies["trajectory"]]
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/BasisSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/BasisSelectionConfigurator.py
@@ -47,6 +47,7 @@ class BasisSelectionConfigurator(IConfigurator):
 
         :note: this configurator depends on 'trajectory' configurator to be configured
         """
+        self._original_input = value
 
         trajConfig = self._configurable[self._dependencies["trajectory"]]
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/BooleanConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/BooleanConfigurator.py
@@ -57,6 +57,7 @@ class BooleanConfigurator(IConfigurator):
         :param value: the input value
         :type value: one of True/False, 'true'/'false', 'yes'/'no', 'y'/'n', '1'/'0', 1/0
         """
+        self._original_input = value
 
         if value not in self._shortCuts:
             self.error_status = "Input is not recognised as a true/false value"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
@@ -28,6 +28,7 @@ class FileWithAtomDataConfigurator(InputFileConfigurator):
         filepath : str
             The file path.
         """
+        self._original_input = filepath
         super().configure(filepath)
         if self.error_status != "OK":
             return

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FloatConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FloatConfigurator.py
@@ -59,6 +59,7 @@ class FloatConfigurator(IConfigurator):
         :type value: float
         """
         self["value"] = self._default
+        self._original_input = value
 
         try:
             value = float(value)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FramesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FramesConfigurator.py
@@ -52,6 +52,7 @@ class FramesConfigurator(RangeConfigurator):
         :param value: the input value
         :type value: 3-tuple, 'all' or None
         """
+        self._original_input = value
 
         trajConfig = self._configurable[self._dependencies["trajectory"]]
         n_steps = trajConfig["length"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
@@ -97,6 +97,7 @@ class GroupingLevelConfigurator(SingleChoiceConfigurator):
         :param value: the level of granularity at which the atoms should be grouped
         :type value: str
         """
+        self._original_input = value
 
         if value is None:
             value = "atom"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFInputFileConfigurator.py
@@ -61,6 +61,7 @@ class HDFInputFileConfigurator(InputFileConfigurator):
         :param value: the path for the HDF file.
         :type value: str
         """
+        self._original_input = value
 
         InputFileConfigurator.configure(self, value)
         if not self._valid:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -45,6 +45,7 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
         :param value: the path for the HDF trajectory file.
         :type value: str
         """
+        self._original_input = value
 
         InputFileConfigurator.configure(self, value)
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
@@ -15,6 +15,7 @@
 #
 
 import abc
+import json
 
 from MDANSE.Core.Error import Error
 
@@ -81,6 +82,9 @@ class IConfigurator(dict, metaclass=SubclassFactory):
 
     _default = None
 
+    _encoder = json.encoder.JSONEncoder()
+    _decoder = json.decoder.JSONDecoder()
+
     _doc_ = "undocumented"
 
     def __init__(self, name, **kwargs):
@@ -129,6 +133,8 @@ class IConfigurator(dict, metaclass=SubclassFactory):
         self._valid = True
 
         self._error_status = "OK"
+
+        self._original_input = ""
 
     @property
     def configurable(self):
@@ -252,6 +258,12 @@ class IConfigurator(dict, metaclass=SubclassFactory):
 
         :note: this is an abstract method.
         """
+
+    def to_json(self) -> str:
+        return self._encoder.encode(self._original_input)
+
+    def from_json(self, json_input: str):
+        self.configure(self._decoder.decode(json_input))
 
     def set_configured(self, configured):
         self._configured = configured

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InputDirectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InputDirectoryConfigurator.py
@@ -38,6 +38,7 @@ class InputDirectoryConfigurator(IConfigurator):
         :param value: the input directory.
         :type value: str
         """
+        self._original_input = value
 
         value = PLATFORM.get_path(value)
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InputFileConfigurator.py
@@ -53,6 +53,7 @@ class InputFileConfigurator(IConfigurator):
         :param value: the input file.
         :type value: str
         """
+        self._original_input = value
 
         value = PLATFORM.get_path(value)
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
@@ -59,6 +59,7 @@ class InstrumentResolutionConfigurator(IConfigurator):
         is a dictionary that stores the parameters for this kernel.
         :type value: 2-tuple
         """
+        self._original_input = value
 
         framesCfg = self._configurable[self._dependencies["frames"]]
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IntegerConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IntegerConfigurator.py
@@ -62,6 +62,7 @@ class IntegerConfigurator(IConfigurator):
         :param value: the integer to be configured.
         :type value: int
         """
+        self._original_input = value
         self["value"] = self._default
 
         try:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
@@ -52,6 +52,7 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
         :type value: str one of *'no interpolation'*,*'1st order'*,*'2nd order'*,*'3rd order'*,*'4th order'* or *'5th order'*.
         """
 
+        self._original_input = value
         if value is None or value == "":
             value = self._default
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDMCTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDMCTrajectoryConfigurator.py
@@ -51,6 +51,7 @@ class MDMCTrajectoryConfigurator(IConfigurator):
         :param value: an instance of the MdanseTrajectory class
         :type value: MdanseTrajectory from MDMC
         """
+        self._original_input = value
 
         self["value"] = value
         self["filename"] = "MDMC.temp"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/McStasOptionsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/McStasOptionsConfigurator.py
@@ -69,6 +69,7 @@ class McStasOptionsConfigurator(IConfigurator):
         :param value: the McStas options.
         :type value: dict
         """
+        self._original_input = value
 
         options = self._default.copy()
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/McStasParametersConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/McStasParametersConfigurator.py
@@ -70,6 +70,7 @@ class McStasParametersConfigurator(IConfigurator):
         :param value: the McStas instrument parameters.
         :type value: dict
         """
+        self._original_input = value
 
         instrConfig = self._configurable[self._dependencies["instrument"]]
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MockTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MockTrajectoryConfigurator.py
@@ -54,6 +54,7 @@ class MockTrajectoryConfigurator(IConfigurator):
         :param value: a JSON file with a MockTrajectory definition
         :type value: str
         """
+        self._original_input = value
 
         self["value"] = value
         self["filename"] = "Mock"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MoleculeSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MoleculeSelectionConfigurator.py
@@ -52,6 +52,7 @@ class MoleculeSelectionConfigurator(IConfigurator):
         value : str
             The atom map setting JSON string.
         """
+        self._original_input = value
         if value is None:
             value = self._default
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MultipleChoicesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MultipleChoicesConfigurator.py
@@ -57,6 +57,7 @@ class MultipleChoicesConfigurator(IConfigurator):
         :param value: the input selection list.
         :type value: list
         """
+        self._original_input = value
 
         if self._nChoices is not None:
             if len(value) != self._nChoices:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputDirectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputDirectoryConfigurator.py
@@ -53,6 +53,7 @@ class OutputDirectoryConfigurator(IConfigurator):
         :param value: the path for the output directory.
         :type value: str
         """
+        self._original_input = value
 
         value = PLATFORM.get_path(value)
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputFilesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputFilesConfigurator.py
@@ -64,6 +64,7 @@ class OutputFilesConfigurator(IConfigurator):
         is the output directory, 2nd element the basename and 3rd element a list of file formats.
         :type value: 3-tuple
         """
+        self._original_input = value
 
         root, formats = value
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
@@ -58,6 +58,7 @@ class OutputTrajectoryConfigurator(IConfigurator):
         self._compression = "none"
 
     def configure(self, value: tuple):
+        self._original_input = value
 
         root, dtype, compression = value
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/PartialChargeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/PartialChargeConfigurator.py
@@ -38,6 +38,7 @@ class PartialChargeConfigurator(IConfigurator):
         :param value: the path for the python script.
         :type value: str
         """
+        self._original_input = value
 
         trajConfig = self._configurable[self._dependencies["trajectory"]]
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/ProjectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/ProjectionConfigurator.py
@@ -44,6 +44,7 @@ class ProjectionConfigurator(IConfigurator):
         :type value: 2-tuple
         """
         self["axis"] = None
+        self._original_input = value
 
         if value is None:
             value = ("NullProjector", None)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/PythonObjectConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/PythonObjectConfigurator.py
@@ -41,6 +41,7 @@ class PythonObjectConfigurator(IConfigurator):
         :param value: the python object to be configured and evaluated.
         :type value: strings, numbers, tuples, lists, dicts, booleans or None type.
         """
+        self._original_input = value
 
         try:
             value = ast.literal_eval(repr(value))

--- a/MDANSE/Src/MDANSE/Framework/Configurators/PythonScriptConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/PythonScriptConfigurator.py
@@ -50,6 +50,7 @@ class PythonScriptConfigurator(InputFileConfigurator):
         :param value: the path for the python script.
         :type value: str
         """
+        self._original_input = value
 
         InputFileConfigurator.configure(self, value)
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/QVectorsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/QVectorsConfigurator.py
@@ -57,6 +57,7 @@ class QVectorsConfigurator(IConfigurator):
         and 2nd element the parameters for this configurator or a string that matches a Q vectors user definition.
         :type value: 2-tuple or str
         """
+        self._original_input = value
 
         trajConfig = self._configurable[self._dependencies["trajectory"]]
         if isinstance(value, str):

--- a/MDANSE/Src/MDANSE/Framework/Configurators/RangeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/RangeConfigurator.py
@@ -84,6 +84,8 @@ class RangeConfigurator(IConfigurator):
         :type value: 3-tuple
         """
 
+        self._original_input = value
+
         first, last, step = value
 
         if step == 0:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
@@ -44,6 +44,7 @@ class RunningModeConfigurator(IConfigurator):
         must be *'multicore'* and 2nd element the number of slots allocated for running the analysis.
         :type value: *'single-core'* or 2-tuple
         """
+        self._original_input = value
 
         if isinstance(value, str):
             mode = value

--- a/MDANSE/Src/MDANSE/Framework/Configurators/SingleChoiceConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/SingleChoiceConfigurator.py
@@ -49,6 +49,7 @@ class SingleChoiceConfigurator(IConfigurator):
         :param value: the input selection list.
         :type value: list
         """
+        self._original_input = value
 
         try:
             self["index"] = self._choices.index(value)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/SingleOutputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/SingleOutputFileConfigurator.py
@@ -60,6 +60,7 @@ class SingleOutputFileConfigurator(IConfigurator):
         is the output directory, 2nd element the basename and 3rd element a list of file formats.
         :type value: 3-tuple
         """
+        self._original_input = value
 
         root, format = value
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/StringConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/StringConfigurator.py
@@ -55,6 +55,7 @@ class StringConfigurator(IConfigurator):
         :param value: the input string
         :type value: str
         """
+        self._original_input = value
 
         value = str(value)
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryVariableConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryVariableConfigurator.py
@@ -39,6 +39,7 @@ class TrajectoryVariableConfigurator(IConfigurator):
         :param value: the name of the trajectory variable as it should appear in the configuration
         :type value: str
         """
+        self._original_input = value
 
         trajConfig = self._configurable[self._dependencies["trajectory"]]
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/VectorConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/VectorConfigurator.py
@@ -67,6 +67,7 @@ class VectorConfigurator(IConfigurator):
         :param value: the vector components.
         :type value: sequence-like object
         """
+        self._original_input = value
 
         if not isinstance(value, (list, tuple)):
             self.error_status = "Invalid input type"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/WeightsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/WeightsConfigurator.py
@@ -51,6 +51,7 @@ class WeightsConfigurator(SingleChoiceConfigurator):
         :param value: the name of the weight to use.
         :type value: one of the numeric properties of MDANSE.Data.ElementsDatabase.ElementsDatabase
         """
+        self._original_input = value
 
         if not isinstance(value, str):
             self.error_status = "Invalid type for weight. Must be a string."

--- a/MDANSE/Src/MDANSE/Framework/Converters/Converter.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Converter.py
@@ -196,10 +196,13 @@ class Converter(IJob, metaclass=SubclassFactory):
         string_dt = h5py.special_dtype(vlen=str)
         meta = output_file.create_group("metadata")
         meta.create_dataset(
-            "task_name", data=str(self.__class__.__name__), dtype=string_dt
+            "task_name", (1,), data=str(self.__class__.__name__), dtype=string_dt
         )
         meta.create_dataset(
-            "MDANSE_version", data=str(metadata.version("MDANSE")), dtype=string_dt
+            "MDANSE_version",
+            (1,),
+            data=str(metadata.version("MDANSE")),
+            dtype=string_dt,
         )
 
         inputs = self.output_configuration()
@@ -208,44 +211,45 @@ class Converter(IJob, metaclass=SubclassFactory):
             print(inputs)
             dgroup = meta.create_group("inputs")
             for key, value in inputs.items():
-                dgroup.create_dataset(key, data=value, dtype=string_dt)
+                dgroup.create_dataset(key, (1,), data=value, dtype=string_dt)
 
     def finalize(self):
         if not hasattr(self, "_trajectory"):
             return
 
         try:
-            output_file = h5py.File(self._trajectory.filename, "a")
+            output_file = h5py.File(self.configuration["output_file"]["file"], "a")
             # f = netCDF4.Dataset(self._trajectory.filename,'a')
         except:
+            print("Skipping the finalize call in Converter")
             return
 
         self.write_metadata(output_file)
 
         try:
-            if "time" in output_file.variables:
-                output_file.variables["time"].units = "ps"
-                output_file.variables["time"].axis = "time"
-                output_file.variables["time"].name = "time"
+            if "time" in output_file:
+                output_file["time"].attrs["units"] = "ps"
+                output_file["time"].attrs["axis"] = "time"
+                output_file["time"].attrs["name"] = "time"
 
-            if "box_size" in output_file.variables:
-                output_file.variables["box_size"].units = "nm"
-                output_file.variables["box_size"].axis = "time"
-                output_file.variables["box_size"].name = "box_size"
+            if "box_size" in output_file:
+                output_file["box_size"].attrs["units"] = "nm"
+                output_file["box_size"].attrs["axis"] = "time"
+                output_file["box_size"].attrs["name"] = "box_size"
 
-            if "configuration" in output_file.variables:
-                output_file.variables["configuration"].units = "nm"
-                output_file.variables["configuration"].axis = "time"
-                output_file.variables["configuration"].name = "configuration"
+            if "configuration" in output_file:
+                output_file["configuration"].attrs["units"] = "nm"
+                output_file["configuration"].attrs["axis"] = "time"
+                output_file["configuration"].attrs["name"] = "configuration"
 
-            if "velocities" in output_file.variables:
-                output_file.variables["velocities"].units = "nm/ps"
-                output_file.variables["velocities"].axis = "time"
-                output_file.variables["velocities"].name = "velocities"
+            if "velocities" in output_file:
+                output_file["velocities"].attrs["units"] = "nm/ps"
+                output_file["velocities"].attrs["axis"] = "time"
+                output_file["velocities"].attrs["name"] = "velocities"
 
-            if "gradients" in output_file.variables:
-                output_file.variables["gradients"].units = "amu*nm/ps"
-                output_file.variables["gradients"].axis = "time"
-                output_file.variables["gradients"].name = "gradients"
+            if "gradients" in output_file:
+                output_file["gradients"].attrs["units"] = "amu*nm/ps"
+                output_file["gradients"].attrs["axis"] = "time"
+                output_file["gradients"].attrs["name"] = "gradients"
         finally:
             output_file.close()

--- a/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
@@ -81,10 +81,16 @@ class HDFFormat(IFormat):
         meta = outputFile.create_group("metadata")
         if run_instance is not None:
             meta.create_dataset(
-                "task_name", data=str(run_instance.__class__.__name__), dtype=string_dt
+                "task_name",
+                (1,),
+                data=str(run_instance.__class__.__name__),
+                dtype=string_dt,
             )
             meta.create_dataset(
-                "MDANSE_version", data=str(metadata.version("MDANSE")), dtype=string_dt
+                "MDANSE_version",
+                (1,),
+                data=str(metadata.version("MDANSE")),
+                dtype=string_dt,
             )
 
             inputs = run_instance.output_configuration()
@@ -93,7 +99,7 @@ class HDFFormat(IFormat):
                 print(inputs)
                 dgroup = meta.create_group("inputs")
                 for key, value in inputs.items():
-                    dgroup.create_dataset(key, data=value, dtype=string_dt)
+                    dgroup.create_dataset(key, (1,), data=value, dtype=string_dt)
 
         # Loop over the OutputVariable instances to write.
 

--- a/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
@@ -75,6 +75,7 @@ class HDFFormat(IFormat):
             outputFile.attrs["header"] = header
 
         if inputs is not None:
+            print(inputs)
             dgroup = outputFile.create_group("inputs")
             string_dt = h5py.special_dtype(vlen=str)
             for key, value in inputs.items():

--- a/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
@@ -14,9 +14,14 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 import os
+from typing import TYPE_CHECKING, Dict
+
 import h5py
+
 from MDANSE.Framework.Formats.IFormat import IFormat
-from MDANSE.Framework.OutputVariables import IOutputVariable
+
+if TYPE_CHECKING:
+    from MDANSE.Framework.OutputVariables.IOutputVariable import IOutputVariable
 
 
 class HDFFormat(IFormat):
@@ -38,8 +43,9 @@ class HDFFormat(IFormat):
     def write(
         cls,
         filename: str,
-        data: dict[str, IOutputVariable],
+        data: Dict[str, "IOutputVariable"],
         header: str = "",
+        inputs: Dict[str, str] = None,
         extension: str = extensions[0],
     ) -> None:
         """Write a set of output variables into an HDF file.
@@ -67,6 +73,12 @@ class HDFFormat(IFormat):
             header = str(header)
 
             outputFile.attrs["header"] = header
+
+        if inputs is not None:
+            dgroup = outputFile.create_group("inputs")
+            string_dt = h5py.special_dtype(vlen=str)
+            for key, value in inputs.items():
+                dgroup.create_dataset(key, data=value, dtype=string_dt)
 
         # Loop over the OutputVariable instances to write.
 

--- a/MDANSE/Src/MDANSE/Framework/Formats/IFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/IFormat.py
@@ -27,7 +27,7 @@ class IFormat(metaclass=SubclassFactory):
     """
 
     @classmethod
-    def write(cls, filename, data, header=""):
+    def write(cls, filename, data, header="", inputs=None):
         """
         Write a set of output variables into filename using a given file format.
 
@@ -37,6 +37,8 @@ class IFormat(metaclass=SubclassFactory):
         :type data: dict of Framework.OutputVariables.IOutputVariable
         :param header: the header to add to the output file.
         :type header: str
+        :param inputs: the verbatim values of the parameter inputs
+        :type inputs: dict[str, str]
         """
 
         pass

--- a/MDANSE/Src/MDANSE/Framework/Formats/IFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/IFormat.py
@@ -14,7 +14,12 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+from typing import TYPE_CHECKING
+
 from MDANSE.Core.SubclassFactory import SubclassFactory
+
+if TYPE_CHECKING:
+    from MDANSE.Framework.Jobs.IJob import IJob
 
 
 class IFormat(metaclass=SubclassFactory):
@@ -27,7 +32,7 @@ class IFormat(metaclass=SubclassFactory):
     """
 
     @classmethod
-    def write(cls, filename, data, header="", inputs=None):
+    def write(cls, filename, data, header="", run_instance: "IJob" = None):
         """
         Write a set of output variables into filename using a given file format.
 
@@ -37,8 +42,8 @@ class IFormat(metaclass=SubclassFactory):
         :type data: dict of Framework.OutputVariables.IOutputVariable
         :param header: the header to add to the output file.
         :type header: str
-        :param inputs: the verbatim values of the parameter inputs
-        :type inputs: dict[str, str]
+        :param run_instance: the instance of the job, to be queried for parameters
+        :type run_instance: IJob
         """
 
         pass

--- a/MDANSE/Src/MDANSE/Framework/Formats/MDAFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/MDAFormat.py
@@ -60,4 +60,4 @@ class MDAFormat(IFormat):
         extension : str
             The extension of the file.
         """
-        HDFFormat.write(filename, data, header, extension)
+        HDFFormat.write(filename, data, header, inputs, extension)

--- a/MDANSE/Src/MDANSE/Framework/Formats/MDAFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/MDAFormat.py
@@ -15,7 +15,7 @@
 #
 from MDANSE.Framework.Formats.IFormat import IFormat
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     from MDANSE.Framework.OutputVariables.IOutputVariable import IOutputVariable
@@ -41,8 +41,9 @@ class MDAFormat(IFormat):
     def write(
         cls,
         filename: str,
-        data: dict[str, "IOutputVariable"],
+        data: Dict[str, "IOutputVariable"],
         header: str = "",
+        inputs: Dict[str, str] = None,
         extension: str = extensions[0],
     ) -> None:
         """Write a set of output variables into an HDF file with the

--- a/MDANSE/Src/MDANSE/Framework/Formats/MDAFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/MDAFormat.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     from MDANSE.Framework.OutputVariables.IOutputVariable import IOutputVariable
+    from MDANSE.Framework.Jobs.IJob import IJob
 from .HDFFormat import HDFFormat
 
 
@@ -43,7 +44,7 @@ class MDAFormat(IFormat):
         filename: str,
         data: Dict[str, "IOutputVariable"],
         header: str = "",
-        inputs: Dict[str, str] = None,
+        run_instance: "IJob" = None,
         extension: str = extensions[0],
     ) -> None:
         """Write a set of output variables into an HDF file with the
@@ -60,4 +61,4 @@ class MDAFormat(IFormat):
         extension : str
             The extension of the file.
         """
-        HDFFormat.write(filename, data, header, inputs, extension)
+        HDFFormat.write(filename, data, header, run_instance, extension)

--- a/MDANSE/Src/MDANSE/Framework/Formats/MDTFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/MDTFormat.py
@@ -61,4 +61,4 @@ class MDTFormat(IFormat):
         extension : str
             The extension of the file.
         """
-        HDFFormat.write(filename, data, header, extension)
+        HDFFormat.write(filename, data, header, inputs, extension)

--- a/MDANSE/Src/MDANSE/Framework/Formats/MDTFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/MDTFormat.py
@@ -20,6 +20,7 @@ from MDANSE.Framework.Formats.IFormat import IFormat
 
 if TYPE_CHECKING:
     from MDANSE.Framework.OutputVariables.IOutputVariable import IOutputVariable
+    from MDANSE.Framework.Jobs.IJob import IJob
 from .HDFFormat import HDFFormat
 
 
@@ -44,7 +45,7 @@ class MDTFormat(IFormat):
         filename: str,
         data: Dict[str, "IOutputVariable"],
         header: str = "",
-        inputs: Dict[str, str] = None,
+        run_instance: "IJob" = None,
         extension: str = extensions[0],
     ) -> None:
         """Write a set of output variables into an HDF file with the

--- a/MDANSE/Src/MDANSE/Framework/Formats/MDTFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/MDTFormat.py
@@ -13,8 +13,13 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+from typing import TYPE_CHECKING, Dict
+
 from MDANSE.Framework.Formats.IFormat import IFormat
-from MDANSE.Framework.OutputVariables import IOutputVariable
+
+if TYPE_CHECKING:
+    from MDANSE.Framework.OutputVariables.IOutputVariable import IOutputVariable
 from .HDFFormat import HDFFormat
 
 
@@ -37,8 +42,9 @@ class MDTFormat(IFormat):
     def write(
         cls,
         filename: str,
-        data: dict[str, IOutputVariable],
+        data: Dict[str, "IOutputVariable"],
         header: str = "",
+        inputs: Dict[str, str] = None,
         extension: str = extensions[0],
     ) -> None:
         """Write a set of output variables into an HDF file with the

--- a/MDANSE/Src/MDANSE/Framework/Formats/MDTFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/MDTFormat.py
@@ -62,4 +62,4 @@ class MDTFormat(IFormat):
         extension : str
             The extension of the file.
         """
-        HDFFormat.write(filename, data, header, inputs, extension)
+        HDFFormat.write(filename, data, header, run_instance, extension)

--- a/MDANSE/Src/MDANSE/Framework/Formats/TextFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/TextFormat.py
@@ -19,6 +19,7 @@ import io
 import tarfile
 import codecs
 import time
+from typing import Dict
 
 import numpy as np
 
@@ -42,7 +43,7 @@ class TextFormat(IFormat):
     extensions = [".dat", ".txt"]
 
     @classmethod
-    def write(cls, filename, data, header=""):
+    def write(cls, filename, data, header: str = "", inputs: Dict[str, str] = None):
         """
         Write a set of output variables into a set of Text files.
 
@@ -69,6 +70,18 @@ class TextFormat(IFormat):
             tempStr.write("\n\n")
             real_buffer.seek(0)
             info = tarfile.TarInfo(name="jobinfo.txt")
+            info.size = length_stringio(real_buffer)
+            info.mtime = time.time()
+            tf.addfile(tarinfo=info, fileobj=real_buffer)
+
+        if inputs is not None:
+            real_buffer = io.BytesIO()
+            tempStr = codecs.getwriter("utf-8")(real_buffer)
+            for key, value in inputs.items():
+                tempStr.write(f"parameters[{str(key)}] = {str(value)}\n")
+            tempStr.write("\n\n")
+            real_buffer.seek(0)
+            info = tarfile.TarInfo(name="job_parameters.txt")
             info.size = length_stringio(real_buffer)
             info.mtime = time.time()
             tf.addfile(tarinfo=info, fileobj=real_buffer)

--- a/MDANSE/Src/MDANSE/Framework/InputData/HDFTrajectoryInputData.py
+++ b/MDANSE/Src/MDANSE/Framework/InputData/HDFTrajectoryInputData.py
@@ -38,6 +38,17 @@ class HDFTrajectoryInputData(InputFileData):
 
     def info(self):
         val = []
+        try:
+            time_axis = self._data._h5_file["time"][:]
+        except:
+            timeline = "No time information!\n"
+        else:
+            if len(time_axis) < 1:
+                timeline = "N/A\n"
+            elif len(time_axis) < 5:
+                timeline = f"{time_axis}\n"
+            else:
+                timeline = f"[{time_axis[0]}, {time_axis[1]}, ..., {time_axis[2]}]\n"
 
         val.append("Path:")
         val.append("%s\n" % self._name)
@@ -45,6 +56,8 @@ class HDFTrajectoryInputData(InputFileData):
         val.append("%s\n" % len(self._data))
         val.append("Configuration:")
         val.append("\tIs periodic: {}\n".format("unit_cell" in self._data.file))
+        val.append("Frame times (1st, 2nd, ..., last) in ps:")
+        val.append(timeline)
         val.append("Variables:")
         for k, v in self._data.file["/configuration"].items():
             val.append("\t- {}: {}".format(k, v.shape))

--- a/MDANSE/Src/MDANSE/Framework/InputData/HDFTrajectoryInputData.py
+++ b/MDANSE/Src/MDANSE/Framework/InputData/HDFTrajectoryInputData.py
@@ -48,7 +48,7 @@ class HDFTrajectoryInputData(InputFileData):
             elif len(time_axis) < 5:
                 timeline = f"{time_axis}\n"
             else:
-                timeline = f"[{time_axis[0]}, {time_axis[1]}, ..., {time_axis[2]}]\n"
+                timeline = f"[{time_axis[0]}, {time_axis[1]}, ..., {time_axis[-1]}]\n"
 
         val.append("Path:")
         val.append("%s\n" % self._name)

--- a/MDANSE/Src/MDANSE/Framework/InputData/HDFTrajectoryInputData.py
+++ b/MDANSE/Src/MDANSE/Framework/InputData/HDFTrajectoryInputData.py
@@ -14,10 +14,14 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+import json
 
 from MDANSE.Framework.InputData.IInputData import InputDataError
 from MDANSE.Framework.InputData.InputFileData import InputFileData
 from MDANSE.MolecularDynamics.Trajectory import Trajectory
+
+
+json_decoder = json.decoder.JSONDecoder()
 
 
 class HDFTrajectoryInputData(InputFileData):
@@ -92,7 +96,10 @@ class HDFTrajectoryInputData(InputFileData):
             except:
                 print(f"Decode failed for {name}: {obj}")
             else:
-                meta_dict[name] = string
+                try:
+                    meta_dict[name] = json_decoder.decode(string)
+                except ValueError:
+                    meta_dict[name] = string
 
         try:
             meta = self._data.file["metadata"]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AngularCorrelation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AngularCorrelation.py
@@ -210,6 +210,7 @@ class AngularCorrelation(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AngularCorrelation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AngularCorrelation.py
@@ -210,7 +210,7 @@ class AngularCorrelation(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AreaPerMolecule.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AreaPerMolecule.py
@@ -168,6 +168,6 @@ class AreaPerMolecule(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AreaPerMolecule.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AreaPerMolecule.py
@@ -168,5 +168,6 @@ class AreaPerMolecule(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CoordinationNumber.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CoordinationNumber.py
@@ -196,6 +196,7 @@ class CoordinationNumber(DistanceHistogram):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CoordinationNumber.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CoordinationNumber.py
@@ -196,7 +196,7 @@ class CoordinationNumber(DistanceHistogram):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
@@ -591,7 +591,7 @@ class CurrentCorrelationFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
@@ -591,6 +591,7 @@ class CurrentCorrelationFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
@@ -149,6 +149,7 @@ class Density(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
@@ -149,7 +149,7 @@ class Density(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -244,6 +244,7 @@ class DensityOfStates(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -244,7 +244,7 @@ class DensityOfStates(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
@@ -190,6 +190,7 @@ class DensityProfile(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
@@ -190,7 +190,7 @@ class DensityProfile(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
@@ -152,7 +152,7 @@ class DipoleAutoCorrelationFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
@@ -152,6 +152,7 @@ class DipoleAutoCorrelationFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
@@ -284,6 +284,7 @@ class DynamicCoherentStructureFactor(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
@@ -284,7 +284,7 @@ class DynamicCoherentStructureFactor(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -271,6 +271,7 @@ class DynamicIncoherentStructureFactor(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -271,7 +271,7 @@ class DynamicIncoherentStructureFactor(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
@@ -291,6 +291,7 @@ class Eccentricity(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
@@ -291,7 +291,7 @@ class Eccentricity(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -198,7 +198,7 @@ class ElasticIncoherentStructureFactor(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -198,6 +198,7 @@ class ElasticIncoherentStructureFactor(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -257,6 +257,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -257,7 +257,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GeneralAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GeneralAutoCorrelationFunction.py
@@ -172,7 +172,7 @@ class GeneralAutoCorrelationFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GeneralAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GeneralAutoCorrelationFunction.py
@@ -172,6 +172,7 @@ class GeneralAutoCorrelationFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -411,7 +411,8 @@ class %(classname)s(IJob):
         """ 
 
         # The output data are written
-        self._outputData.write(self.configuration['output_files']['root'], self.configuration['output_files']['formats'], self._info)
+        self._outputData.write(self.configuration['output_files']['root'], self.configuration['output_files']['formats'], self._info,
+            self.output_configuration())
         
         # The trajectory is closed
         self.configuration['trajectory']['instance'].close()        

--- a/MDANSE/Src/MDANSE/Framework/Jobs/McStasVirtualInstrument.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/McStasVirtualInstrument.py
@@ -309,7 +309,7 @@ class McStasVirtualInstrument(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
     def treat_str_var(self, s):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/McStasVirtualInstrument.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/McStasVirtualInstrument.py
@@ -309,6 +309,7 @@ class McStasVirtualInstrument(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
     def treat_str_var(self, s):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -205,6 +205,7 @@ class MeanSquareDisplacement(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -205,7 +205,7 @@ class MeanSquareDisplacement(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MolecularTrace.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MolecularTrace.py
@@ -184,6 +184,7 @@ class MolecularTrace(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MolecularTrace.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MolecularTrace.py
@@ -184,7 +184,7 @@ class MolecularTrace(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
@@ -453,6 +453,6 @@ class NeutronDynamicTotalStructureFactor(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
@@ -453,5 +453,6 @@ class NeutronDynamicTotalStructureFactor(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/OrderParameter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/OrderParameter.py
@@ -273,7 +273,7 @@ class OrderParameter(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/OrderParameter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/OrderParameter.py
@@ -273,6 +273,7 @@ class OrderParameter(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
@@ -172,6 +172,7 @@ class PairDistributionFunction(DistanceHistogram):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
@@ -172,7 +172,7 @@ class PairDistributionFunction(DistanceHistogram):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -182,7 +182,7 @@ class PositionAutoCorrelationFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -182,6 +182,7 @@ class PositionAutoCorrelationFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RadiusOfGyration.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RadiusOfGyration.py
@@ -134,7 +134,7 @@ class RadiusOfGyration(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RadiusOfGyration.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RadiusOfGyration.py
@@ -134,6 +134,7 @@ class RadiusOfGyration(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
@@ -170,6 +170,7 @@ class RootMeanSquareDeviation(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
@@ -170,7 +170,7 @@ class RootMeanSquareDeviation(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -135,7 +135,7 @@ class RootMeanSquareFluctuation(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -135,6 +135,7 @@ class RootMeanSquareFluctuation(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/SolventAccessibleSurface.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/SolventAccessibleSurface.py
@@ -177,7 +177,7 @@ class SolventAccessibleSurface(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/SolventAccessibleSurface.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/SolventAccessibleSurface.py
@@ -177,6 +177,7 @@ class SolventAccessibleSurface(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
@@ -201,7 +201,7 @@ class StaticStructureFactor(DistanceHistogram):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
@@ -201,6 +201,7 @@ class StaticStructureFactor(DistanceHistogram):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StructureFactorFromScatteringFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StructureFactorFromScatteringFunction.py
@@ -144,7 +144,7 @@ class StructureFactorFromScatteringFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["sample_inc"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StructureFactorFromScatteringFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StructureFactorFromScatteringFunction.py
@@ -144,6 +144,7 @@ class StructureFactorFromScatteringFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["sample_inc"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -174,7 +174,7 @@ class Temperature(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -174,6 +174,7 @@ class Temperature(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -221,7 +221,7 @@ class VelocityAutoCorrelationFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -221,6 +221,7 @@ class VelocityAutoCorrelationFunction(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Voronoi.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Voronoi.py
@@ -236,7 +236,7 @@ class Voronoi(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Voronoi.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Voronoi.py
@@ -236,6 +236,7 @@ class Voronoi(IJob):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
@@ -212,7 +212,7 @@ class XRayStaticStructureFactor(DistanceHistogram):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
-            self.output_configuration(),
+            self,
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
@@ -212,6 +212,7 @@ class XRayStaticStructureFactor(DistanceHistogram):
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],
             self._info,
+            self.output_configuration(),
         )
 
         self.configuration["trajectory"]["instance"].close()

--- a/MDANSE/Src/MDANSE/Framework/OutputVariables/IOutputVariable.py
+++ b/MDANSE/Src/MDANSE/Framework/OutputVariables/IOutputVariable.py
@@ -36,10 +36,10 @@ class OutputData(collections.OrderedDict):
             IOutputVariable.create(dataType, data, dataName, **kwargs),
         )
 
-    def write(self, basename, formats, header=None):
+    def write(self, basename, formats, header=None, inputs=None):
         for fmt in formats:
             temp_format = IFormat.create(fmt)
-            temp_format.write(basename, self, header)
+            temp_format.write(basename, self, header, inputs)
 
 
 class IOutputVariable(np.ndarray, metaclass=SubclassFactory):

--- a/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
@@ -66,7 +66,7 @@ def test_parallel_meansquare():
         h5py.File(temp_name2 + ".mda") as parallel,
     ):
         for kk in single.keys():
-            if not "inputs" in kk:
+            if not "metadata" in kk:
                 assert np.allclose(np.array(single[kk]), np.array(parallel[kk]), 1e-5, 1e-4)
     os.remove(temp_name + ".mda")
     os.remove(temp_name2 + ".mda")

--- a/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
@@ -66,7 +66,8 @@ def test_parallel_meansquare():
         h5py.File(temp_name2 + ".mda") as parallel,
     ):
         for kk in single.keys():
-            assert np.allclose(np.array(single[kk]), np.array(parallel[kk]), 1e-5, 1e-4)
+            if not "inputs" in kk:
+                assert np.allclose(np.array(single[kk]), np.array(parallel[kk]), 1e-5, 1e-4)
     os.remove(temp_name + ".mda")
     os.remove(temp_name2 + ".mda")
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Plotter/models/data_tree_model.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Plotter/models/data_tree_model.py
@@ -16,6 +16,7 @@
 
 import abc
 import os
+import json
 
 import numpy as np
 
@@ -24,6 +25,9 @@ import h5py
 from qtpy import QtCore, QtGui
 
 from MDANSE.Framework.Units import measure, UnitError
+
+
+json_decoder = json.decoder.JSONDecoder()
 
 
 class DataItemError(Exception):
@@ -280,7 +284,10 @@ class HDFDataItem(DataItem):
             except:
                 print(f"Decode failed for {name}: {obj}")
             else:
-                meta_dict[name] = string
+                try:
+                    meta_dict[name] = json_decoder.decode(string)
+                except ValueError:
+                    meta_dict[name] = string
 
         try:
             meta = self._file["metadata"]

--- a/MDANSE_GUI/Src/MDANSE_GUI/Plotter/models/data_tree_model.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Plotter/models/data_tree_model.py
@@ -349,7 +349,10 @@ class HDFDataItem(DataItem):
             elif hdf_variable.ndim == 1:
                 info["data"] = hdf_variable[:]
             else:
-                info["data"] = np.expand_dims(hdf_variable[:], axis=0)
+                try:
+                    info["data"] = np.expand_dims(hdf_variable[:], axis=0)
+                except ValueError:
+                    info["data"] = np.array(hdf_variable)
 
         return info
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Plotter/widgets/main_window.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Plotter/widgets/main_window.py
@@ -144,12 +144,13 @@ class MainWindow(QtWidgets.QMainWindow):
         """Callback called when a file is opened."""
         extensions = " ".join([f"*{k}" for k in DATA_ITEMS.keys()])
         filter_mask = f"Data files {extensions}"
-        filename, _ = QtWidgets.QFileDialog.getOpenFileName(
+        filenames, _ = QtWidgets.QFileDialog.getOpenFileNames(
             self, "Open Data File(s)", "", filter_mask
         )
-        if not filename:
+        if not filenames:
             return
-        self.add_data(filename)
+        for filename in filenames:
+            self.add_data(filename)
 
     def on_plot_in_new_figure(self, plot_type):
         """Callback when the plot in a new figure button is clicked.

--- a/MDANSE_GUI/Src/MDANSE_GUI/Session/LocalSession.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Session/LocalSession.py
@@ -53,6 +53,9 @@ class LocalSession(QObject):
         value = self._paths.get(key, ".")
         return value
 
+    def set_path(self, key: str, value: str):
+        self._paths[key] = value
+
     def get_unit(self, key: str) -> str:
         value = self._units.get(key, "1")
         return value

--- a/MDANSE_GUI/Src/MDANSE_GUI/Session/LocalSession.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Session/LocalSession.py
@@ -15,8 +15,11 @@
 #
 
 import os
+import json
 
 from qtpy.QtCore import QObject, Signal, Slot
+
+from MDANSE import PLATFORM
 
 
 class LocalSession(QObject):
@@ -59,3 +62,27 @@ class LocalSession(QObject):
     def get_unit(self, key: str) -> str:
         value = self._units.get(key, "1")
         return value
+
+    @Slot()
+    def save_json(self, fname: str = None):
+        all_items = {}
+        all_items["paths"] = self._paths
+        all_items["units"] = self._units
+        output = json.encoder.JSONEncoder().encode(all_items)
+        if fname is None:
+            fname = os.path.join(PLATFORM.application_directory(), "gui_session.json")
+        with open(fname, "w") as target:
+            target.write(output)
+
+    def load_json(self, fname: str = None):
+        if fname is None:
+            fname = os.path.join(PLATFORM.application_directory(), "gui_session.json")
+        try:
+            with open(fname, "r") as source:
+                all_items_text = source.readline()
+        except:
+            print(f"Failed to read session settings from {fname}")
+        else:
+            all_items = json.decoder.JSONDecoder().decode(all_items_text)
+            self._paths = all_items["paths"]
+            self._units = all_items["units"]

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -62,7 +62,15 @@ class TabbedWindow(QMainWindow):
     file_name_for_loading = Signal(str)
     converter_name_for_dialog = Signal(str)
 
-    def __init__(self, *args, parent=None, title="MDANSE", settings=None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        parent=None,
+        title="MDANSE",
+        settings=None,
+        app_instance=None,
+        **kwargs,
+    ):
         super().__init__(parent, *args, **kwargs)
         self.tabs = QTabWidget(self)
         self.setCentralWidget(self.tabs)
@@ -91,6 +99,10 @@ class TabbedWindow(QMainWindow):
         self.style_selector.connectStyleDatabase(self._style_database)
         self.style_selector.new_style.connect(self.setStyleSheet)
         self.style_selector.icon_swap.connect(self.invertToolbar)
+
+        if app_instance is not None:
+            app_instance.aboutToQuit.connect(self._session.save_json)
+        self._session.load_json()
 
     def createCommonModels(self):
         self._trajectory_model = GeneralModel()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/ConverterTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/ConverterTab.py
@@ -105,6 +105,7 @@ class ConverterTab(GeneralTab):
             label_text=tab_label,
             action=action,
         )
+        action.set_session(the_tab._session)
         return the_tab
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/TrajectoryTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/TrajectoryTab.py
@@ -42,24 +42,29 @@ class TrajectoryTab(GeneralTab):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._core.add_button("Load an .MDT Trajectory", self.load_trajectory)
+        self._core.add_button("Load .MDT Trajectories", self.load_trajectories)
 
     @Slot()
-    def load_trajectory(self):
-        fname = QFileDialog.getOpenFileName(
+    def load_trajectories(self):
+        fnames = QFileDialog.getOpenFileNames(
             self._core,
             "Load an MD trajectory",
             self._session.get_path("root_directory"),
             "MDANSE trajectory files (*.mdt);;HDF5 files (*.h5);;HDF5 files(*.hdf);;All files(*.*)",
         )
-        if len(fname[0]) > 0:
-            _, short_name = os.path.split(fname[0])
+        for fname in fnames[0]:
+            self.load_trajectory(fname)
+
+    @Slot()
+    def load_trajectory(self, fname: str):
+        if len(fname) > 0:
+            _, short_name = os.path.split(fname)
             try:
-                data = HDFTrajectoryInputData(fname[0])
+                data = HDFTrajectoryInputData(fname)
             except Exception as e:
                 self._core.error(repr(e))
             else:
-                self._core._model.append_object(((fname[0], data), short_name))
+                self._core._model.append_object(((fname, data), short_name))
 
     @classmethod
     def standard_instance(cls):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -76,6 +76,7 @@ class Action(QWidget):
         self._default_path = None
         self._input_trajectory = None
         self._trajectory_configurator = None
+        self._session = None
         default_path = kwargs.pop("path", None)
         input_trajectory = kwargs.pop("trajectory", None)
         self.set_trajectory(default_path, input_trajectory)
@@ -85,6 +86,9 @@ class Action(QWidget):
         self.handlers = {}
         self._widgets = []
         self._widgets_in_layout = []
+
+    def set_session(self, session):
+        self._session = session
 
     def set_trajectory(self, path: Optional[str], trajectory: Optional[str]) -> None:
         """Set the trajectory path and filename.

--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -40,7 +40,9 @@ def startGUI(some_args):
     splash = QSplashScreen(splash_img, Qt.WindowStaysOnTopHint)
     splash.show()
     t0 = time.time()
-    root = TabbedWindow(parent=None, title="MDANSE for Python 3", settings=settings)
+    root = TabbedWindow(
+        parent=None, title="MDANSE for Python 3", settings=settings, app_instance=app
+    )
     root.show()
     t1 = time.time()
     # only allow the splash screen to stay up for maximum of 2s if the


### PR DESCRIPTION
**Description of work**
Every output file now contains the name of the job that created it, the version of MDANSE and a complete list of input parameters.

closes #283 

**Fixes**
OutputData now takes the IJob class instance as the last input.
HDFFormat and TextFormat both create an additional data group called "metadata".
The input parameters are written into the "metadata".
Plotter window puts the "metadata" into the tooltip of the main data item.
Trajectory tab puts the "metadata" into the trajectory info.
Converter class now adds the unit information to the output arrays.
LocalSession has been modified to store the basic information about the file paths of converters.
TrajectoryTab now shows a preview of the trajectory's time axis.
TrajectoryTab and Plotter can load multiple files.

**To test**
All tests must pass.
Also, please run a trajectory converter, then load the trajectory and check if the input parameters of the converter are shown in the trajectory info.
Next, run an analysis and load the results into the plotter. The input parameters should be shown in the tooltip on mouse hover.
