### PR TITLE
Extend unit tests

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
@@ -93,7 +93,9 @@ class InstrumentResolutionConfigurator(IConfigurator):
         resolution.set_kernel(self["omega"], self["time_step"])
         self["omega_window"] = resolution.omegaWindow
         self["time_window"] = resolution.timeWindow.real
-        self["time_window_positive"] = np.fft.ifftshift(self["time_window"])[:len(time)]
+        self["time_window_positive"] = np.fft.ifftshift(self["time_window"])[
+            : len(time)
+        ]
 
     def get_information(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
@@ -93,12 +93,7 @@ class InstrumentResolutionConfigurator(IConfigurator):
         resolution.set_kernel(self["omega"], self["time_step"])
         self["omega_window"] = resolution.omegaWindow
         self["time_window"] = resolution.timeWindow.real
-
-        rresolution = IInstrumentResolution.create(kernel)
-        rresolution.setup(parameters)
-        rresolution.set_kernel(self["romega"], self["time_step"], fft="rfft")
-        self["romega_window"] = rresolution.omegaWindow
-        self["rtime_window"] = rresolution.timeWindow.real
+        self["time_window_positive"] = np.fft.ifftshift(self["time_window"])[:len(time)]
 
     def get_information(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
@@ -28,7 +28,7 @@ class RunningModeConfigurator(IConfigurator):
     """
     This configurator allows to choose the mode used to run the calculation.
 
-    MDANSE currently support single-core or multicore (SMP) running modes. In the laster case, you have to
+    MDANSE currently support single-core or multicore (SMP) running modes. In the latter case, you have to
     specify the number of slots used for running the analysis.
     """
 
@@ -59,16 +59,19 @@ class RunningModeConfigurator(IConfigurator):
 
         else:
             slots = int(value[1])
+            maxSlots = multiprocessing.cpu_count()
 
-            if mode == "multicore":
-                maxSlots = multiprocessing.cpu_count()
+            if slots == 0:
+                self.error_status = "invalid number of allocated slots."
+                return
+            elif slots < 0:
+                slots = abs(slots)
+                if slots > maxSlots:
+                    slots = maxSlots
+            else:
                 if slots > maxSlots:
                     self.error_status = "invalid number of allocated slots."
                     return
-
-            if slots <= 0:
-                self.error_status = "invalid number of allocated slots."
-                return
 
         self["mode"] = mode
 

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Gaussian.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Gaussian.py
@@ -31,11 +31,11 @@ class Gaussian(IInstrumentResolution):
     settings["mu"] = ("FloatConfigurator", {"default": 0.0})
     settings["sigma"] = ("FloatConfigurator", {"default": 1.0})
 
-    def set_kernel(self, omegas, dt, fft="fft"):
+    def set_kernel(self, omegas, dt):
         mu = self._configuration["mu"]["value"]
         sigma = self._configuration["sigma"]["value"]
 
         self._omegaWindow = (np.sqrt(2.0 * np.pi) / sigma) * np.exp(
             -0.5 * ((omegas - mu) / sigma) ** 2
         )
-        self._timeWindow = self.apply_fft(self._omegaWindow, dt, fft)
+        self._timeWindow = self.apply_fft(self._omegaWindow, dt)

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/IInstrumentResolution.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/IInstrumentResolution.py
@@ -41,9 +41,7 @@ class IInstrumentResolution(Configurable, metaclass=SubclassFactory):
         pass
 
     def apply_fft(self, omegaWindow, dt):
-        timeWindow = np.fft.fftshift(
-            np.fft.ifft(np.fft.ifftshift(omegaWindow)) / dt
-        )
+        timeWindow = np.fft.fftshift(np.fft.ifft(np.fft.ifftshift(omegaWindow)) / dt)
         return timeWindow
 
     @property

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/IInstrumentResolution.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/IInstrumentResolution.py
@@ -37,18 +37,13 @@ class IInstrumentResolution(Configurable, metaclass=SubclassFactory):
         self._timeWindow = None
 
     @abc.abstractmethod
-    def set_kernel(self, omegas, dt, fft="fft"):
+    def set_kernel(self, omegas, dt):
         pass
 
-    def apply_fft(self, omegaWindow, dt, fft="fft"):
-        if fft == "fft":
-            timeWindow = np.fft.fftshift(
-                np.fft.ifft(np.fft.ifftshift(omegaWindow)) / dt
-            )
-        elif fft == "rfft":
-            timeWindow = np.fft.irfft(np.fft.ifftshift(omegaWindow)) / dt
-        else:
-            raise ValueError("fft variable should be fft or rfft.")
+    def apply_fft(self, omegaWindow, dt):
+        timeWindow = np.fft.fftshift(
+            np.fft.ifft(np.fft.ifftshift(omegaWindow)) / dt
+        )
         return timeWindow
 
     @property

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Ideal.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Ideal.py
@@ -29,7 +29,7 @@ class Ideal(IInstrumentResolution):
 
     settings = collections.OrderedDict()
 
-    def set_kernel(self, omegas, dt, fft="fft"):
+    def set_kernel(self, omegas, dt):
         nOmegas = len(omegas)
         self._omegaWindow = np.zeros(nOmegas, dtype=np.float64)
         self._omegaWindow[int(nOmegas / 2)] = 1.0

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Lorentzian.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Lorentzian.py
@@ -33,9 +33,9 @@ class Lorentzian(IInstrumentResolution):
     settings["mu"] = ("FloatConfigurator", {"default": 0.0})
     settings["sigma"] = ("FloatConfigurator", {"default": 1.0})
 
-    def set_kernel(self, omegas, dt, fft="fft"):
+    def set_kernel(self, omegas, dt):
         mu = self._configuration["mu"]["value"]
         sigma = self._configuration["sigma"]["value"]
 
         self._omegaWindow = (2.0 * sigma) / ((omegas - mu) ** 2 + sigma**2)
-        self._timeWindow = self.apply_fft(self._omegaWindow, dt, fft)
+        self._timeWindow = self.apply_fft(self._omegaWindow, dt)

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/PseudoVoigt.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/PseudoVoigt.py
@@ -34,7 +34,7 @@ class PseudoVoigt(IInstrumentResolution):
     settings["mu_gaussian"] = ("FloatConfigurator", {"default": 0.0})
     settings["sigma_gaussian"] = ("FloatConfigurator", {"default": 1.0})
 
-    def set_kernel(self, omegas, dt, fft="fft"):
+    def set_kernel(self, omegas, dt):
         eta = self._configuration["eta"]["value"]
         muL = self._configuration["mu_lorentzian"]["value"]
         sigmaL = self._configuration["sigma_lorentzian"]["value"]
@@ -48,4 +48,4 @@ class PseudoVoigt(IInstrumentResolution):
         lorentzian = (2.0 * sigmaL) / ((omegas - muL) ** 2 + sigmaL**2)
 
         self._omegaWindow = eta * lorentzian + (1.0 - eta) * gaussian
-        self._timeWindow = self.apply_fft(self._omegaWindow, dt, fft)
+        self._timeWindow = self.apply_fft(self._omegaWindow, dt)

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Square.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Square.py
@@ -31,7 +31,7 @@ class Square(IInstrumentResolution):
     settings["mu"] = ("FloatConfigurator", {"default": 0.0})
     settings["sigma"] = ("FloatConfigurator", {"default": 1.0})
 
-    def set_kernel(self, omegas, dt, fft="fft"):
+    def set_kernel(self, omegas, dt):
         mu = self._configuration["mu"]["value"]
         sigma = self._configuration["sigma"]["value"]
 
@@ -41,4 +41,4 @@ class Square(IInstrumentResolution):
             * np.where((np.abs(omegas - mu) - sigma) > 0, 0.0, 1.0 / (2.0 * sigma))
         )
 
-        self._timeWindow = self.apply_fft(self._omegaWindow, dt, fft)
+        self._timeWindow = self.apply_fft(self._omegaWindow, dt)

--- a/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Triangular.py
+++ b/MDANSE/Src/MDANSE/Framework/InstrumentResolutions/Triangular.py
@@ -31,7 +31,7 @@ class Triangular(IInstrumentResolution):
     settings["mu"] = ("FloatConfigurator", {"default": 0.0})
     settings["sigma"] = ("FloatConfigurator", {"default": 1.0})
 
-    def set_kernel(self, omegas, dt, fft="fft"):
+    def set_kernel(self, omegas, dt):
         mu = self._configuration["mu"]["value"]
         sigma = self._configuration["sigma"]["value"]
 
@@ -39,4 +39,4 @@ class Triangular(IInstrumentResolution):
 
         self._omegaWindow = 2.0 * np.pi * np.where(val >= 0, 0.0, -val / sigma**2)
 
-        self._timeWindow = self.apply_fft(self._omegaWindow, dt, fft)
+        self._timeWindow = self.apply_fft(self._omegaWindow, dt)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -102,18 +102,21 @@ class DensityOfStates(IJob):
         self._outputData.add(
             "time_window",
             "LineOutputVariable",
-            instrResolution["rtime_window"],
+            instrResolution["time_window_positive"],
             axis="time",
             units="au",
         )
 
         self._outputData.add(
-            "omega", "LineOutputVariable", instrResolution["romega"], units="rad/ps"
+            "omega", "LineOutputVariable", instrResolution["omega"], units="rad/ps"
+        )
+        self._outputData.add(
+            "romega", "LineOutputVariable", instrResolution["romega"], units="rad/ps"
         )
         self._outputData.add(
             "omega_window",
             "LineOutputVariable",
-            instrResolution["romega_window"],
+            instrResolution["omega_window"],
             axis="omega",
             units="au",
         )
@@ -130,7 +133,7 @@ class DensityOfStates(IJob):
                 "dos_%s" % element,
                 "LineOutputVariable",
                 (instrResolution["n_romegas"],),
-                axis="omega",
+                axis="romega",
                 units="au",
             )
         self._outputData.add(
@@ -144,7 +147,7 @@ class DensityOfStates(IJob):
             "dos_total",
             "LineOutputVariable",
             (instrResolution["n_romegas"],),
-            axis="omega",
+            axis="romega",
             units="au",
         )
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StructureFactorFromScatteringFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StructureFactorFromScatteringFunction.py
@@ -72,7 +72,7 @@ class StructureFactorFromScatteringFunction(IJob):
         self._outputData.add(
             "time_window",
             "LineOutputVariable",
-            inputFile["time_window"][:],
+            resolution["time_window_positive"],
             axis="time",
             units="au",
         )

--- a/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
@@ -95,7 +95,7 @@ for jt in [
     # "OrderParameter",
     "PositionAutoCorrelationFunction",
 ]:
-    for rm in [("single-core", 1), ("threadpool", 4), ("multicore", 4)]:
+    for rm in [("single-core", 1), ("multicore", 4)]:
         for of in ["MDAFormat", "TextFormat"]:
             total_list.append((jt, rm, of))
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
@@ -61,7 +61,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", 4)
+    parameters["running_mode"] = ("threadpool", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
@@ -95,7 +95,7 @@ for jt in [
     # "OrderParameter",
     "PositionAutoCorrelationFunction",
 ]:
-    for rm in [("single-core", 1), ("multicore", 4)]:
+    for rm in [("single-core", 1), ("multicore", -4)]:
         for of in ["MDAFormat", "TextFormat"]:
             total_list.append((jt, rm, of))
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_infrared.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_infrared.py
@@ -28,7 +28,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", 4)
+    parameters["running_mode"] = ("threadpool", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE/Tests/UnitTests/Analysis/test_mcstas.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_mcstas.py
@@ -28,7 +28,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", 4)
+    parameters["running_mode"] = ("threadpool", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
@@ -57,7 +57,7 @@ def test_parallel_meansquare():
     parameters = {}
     parameters["frames"] = (0, 10, 1)
     parameters["output_files"] = (temp_name2, ("MDAFormat",))
-    parameters["running_mode"] = ("multicore", 4)
+    parameters["running_mode"] = ("multicore", -4)
     parameters["trajectory"] = short_traj
     msd_par = IJob.create("MeanSquareDisplacement")
     msd_par.run(parameters, status=True)

--- a/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
@@ -57,7 +57,7 @@ def test_parallel_meansquare():
     parameters = {}
     parameters["frames"] = (0, 10, 1)
     parameters["output_files"] = (temp_name2, ("MDAFormat",))
-    parameters["running_mode"] = ("threadpool", 4)
+    parameters["running_mode"] = ("multicore", 4)
     parameters["trajectory"] = short_traj
     msd_par = IJob.create("MeanSquareDisplacement")
     msd_par.run(parameters, status=True)

--- a/MDANSE/Tests/UnitTests/Analysis/test_molecule_names.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_molecule_names.py
@@ -28,7 +28,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", 4)
+    parameters["running_mode"] = ("threadpool", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -83,7 +83,7 @@ def test_dcsf(trajectory, qvector_spherical_lattice):
     parameters["atom_transmutation"] = None
     parameters["frames"] = (0, 10, 1)
     parameters["instrument_resolution"] = ("Ideal", {})
-    parameters["output_files"] = (temp_name, ("MDAFormat",))
+    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
@@ -93,6 +93,9 @@ def test_dcsf(trajectory, qvector_spherical_lattice):
     assert path.exists(temp_name + ".mda")
     assert path.isfile(temp_name + ".mda")
     os.remove(temp_name + ".mda")
+    assert path.exists(temp_name + "_text.tar")
+    assert path.isfile(temp_name + "_text.tar")
+    os.remove(temp_name + "_text.tar")
 
 
 def test_disf(trajectory, qvector_spherical_lattice):
@@ -102,7 +105,7 @@ def test_disf(trajectory, qvector_spherical_lattice):
     parameters["atom_transmutation"] = None
     parameters["frames"] = (0, 10, 1)
     parameters["instrument_resolution"] = ("Ideal", {})
-    parameters["output_files"] = (temp_name, ("MDAFormat",))
+    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
@@ -112,6 +115,9 @@ def test_disf(trajectory, qvector_spherical_lattice):
     assert path.exists(temp_name + ".mda")
     assert path.isfile(temp_name + ".mda")
     os.remove(temp_name + ".mda")
+    assert path.exists(temp_name + "_text.tar")
+    assert path.isfile(temp_name + "_text.tar")
+    os.remove(temp_name + "_text.tar")
 
 
 def test_eisf(trajectory, qvector_spherical_lattice):
@@ -120,7 +126,7 @@ def test_eisf(trajectory, qvector_spherical_lattice):
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
     parameters["frames"] = (0, 10, 1)
-    parameters["output_files"] = (temp_name, ("MDAFormat",))
+    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
@@ -130,6 +136,9 @@ def test_eisf(trajectory, qvector_spherical_lattice):
     assert path.exists(temp_name + ".mda")
     assert path.isfile(temp_name + ".mda")
     os.remove(temp_name + ".mda")
+    assert path.exists(temp_name + "_text.tar")
+    assert path.isfile(temp_name + "_text.tar")
+    os.remove(temp_name + "_text.tar")
 
 
 def test_gdisf(trajectory):
@@ -139,7 +148,7 @@ def test_gdisf(trajectory):
     parameters["atom_transmutation"] = None
     parameters["frames"] = (0, 10, 1)
     parameters["instrument_resolution"] = ("Ideal", {})
-    parameters["output_files"] = (temp_name, ("MDAFormat",))
+    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
     parameters["q_shells"] = (2.0, 12.2, 2.0)
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
@@ -149,6 +158,9 @@ def test_gdisf(trajectory):
     assert path.exists(temp_name + ".mda")
     assert path.isfile(temp_name + ".mda")
     os.remove(temp_name + ".mda")
+    assert path.exists(temp_name + "_text.tar")
+    assert path.isfile(temp_name + "_text.tar")
+    os.remove(temp_name + "_text.tar")
 
 
 def test_ndtsf(disf, dcsf, qvector_spherical_lattice):
@@ -160,12 +172,15 @@ def test_ndtsf(disf, dcsf, qvector_spherical_lattice):
     parameters["dcsf_input_file"] = dcsf
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
-    parameters["output_files"] = (temp_name, ("MDAFormat",))
+    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
     ndtsf = IJob.create("NeutronDynamicTotalStructureFactor")
     ndtsf.run(parameters, status=True)
     assert path.exists(temp_name + ".mda")
     assert path.isfile(temp_name + ".mda")
     os.remove(temp_name + ".mda")
+    assert path.exists(temp_name + "_text.tar")
+    assert path.isfile(temp_name + "_text.tar")
+    os.remove(temp_name + "_text.tar")
 
 
 def test_ssfsf(disf):
@@ -175,12 +190,16 @@ def test_ssfsf(disf):
     parameters["sample_inc"] = disf
     parameters["running_mode"] = ("single-core",)
     parameters["instrument_resolution"] = ("Ideal", {})
-    parameters["output_files"] = (temp_name, ("MDAFormat",))
+    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
     ndtsf = IJob.create("StructureFactorFromScatteringFunction")
     ndtsf.run(parameters, status=True)
     assert path.exists(temp_name + ".mda")
     assert path.isfile(temp_name + ".mda")
     os.remove(temp_name + ".mda")
+    assert path.exists(temp_name + "_text.tar")
+    assert path.isfile(temp_name + "_text.tar")
+    os.remove(temp_name + "_text.tar")
+    assert False
 
 
 @pytest.mark.xfail(reason="see docstring")
@@ -195,7 +214,7 @@ def test_ccf(qvector_spherical_lattice):
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["interpolation_order"] = 3
     parameters["interpolation_mode"] = "automatic"
-    parameters["output_files"] = (temp_name, ("MDAFormat",))
+    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
@@ -205,3 +224,6 @@ def test_ccf(qvector_spherical_lattice):
     assert path.exists(temp_name + ".mda")
     assert path.isfile(temp_name + ".mda")
     os.remove(temp_name + ".mda")
+    assert path.exists(temp_name + "_text.tar")
+    assert path.isfile(temp_name + "_text.tar")
+    os.remove(temp_name + "_text.tar")

--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -83,7 +83,7 @@ def test_dcsf(trajectory, qvector_spherical_lattice):
     parameters["atom_transmutation"] = None
     parameters["frames"] = (0, 10, 1)
     parameters["instrument_resolution"] = ("Ideal", {})
-    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
+    parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
@@ -105,7 +105,7 @@ def test_disf(trajectory, qvector_spherical_lattice):
     parameters["atom_transmutation"] = None
     parameters["frames"] = (0, 10, 1)
     parameters["instrument_resolution"] = ("Ideal", {})
-    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
+    parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
@@ -126,7 +126,7 @@ def test_eisf(trajectory, qvector_spherical_lattice):
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
     parameters["frames"] = (0, 10, 1)
-    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
+    parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
@@ -148,7 +148,7 @@ def test_gdisf(trajectory):
     parameters["atom_transmutation"] = None
     parameters["frames"] = (0, 10, 1)
     parameters["instrument_resolution"] = ("Ideal", {})
-    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
+    parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     parameters["q_shells"] = (2.0, 12.2, 2.0)
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
@@ -172,7 +172,7 @@ def test_ndtsf(disf, dcsf, qvector_spherical_lattice):
     parameters["dcsf_input_file"] = dcsf
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
-    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
+    parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     ndtsf = IJob.create("NeutronDynamicTotalStructureFactor")
     ndtsf.run(parameters, status=True)
     assert path.exists(temp_name + ".mda")
@@ -190,7 +190,7 @@ def test_ssfsf(disf):
     parameters["sample_inc"] = disf
     parameters["running_mode"] = ("single-core",)
     parameters["instrument_resolution"] = ("Ideal", {})
-    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
+    parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     ndtsf = IJob.create("StructureFactorFromScatteringFunction")
     ndtsf.run(parameters, status=True)
     assert path.exists(temp_name + ".mda")
@@ -214,7 +214,7 @@ def test_ccf(qvector_spherical_lattice):
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["interpolation_order"] = 3
     parameters["interpolation_mode"] = "automatic"
-    parameters["output_files"] = (temp_name, ("MDAFormat","TextFormat"))
+    parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj

--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -184,7 +184,6 @@ def test_ndtsf(disf, dcsf, qvector_spherical_lattice):
 
 
 def test_ssfsf(disf):
-    """Also fails at the moment. Must be fixed soon"""
     temp_name = tempfile.mktemp()
     parameters = {}
     parameters["sample_inc"] = disf
@@ -199,7 +198,6 @@ def test_ssfsf(disf):
     assert path.exists(temp_name + "_text.tar")
     assert path.isfile(temp_name + "_text.tar")
     os.remove(temp_name + "_text.tar")
-    assert False
 
 
 @pytest.mark.xfail(reason="see docstring")

--- a/MDANSE/Tests/UnitTests/Analysis/test_structure.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_structure.py
@@ -63,7 +63,7 @@ for jt in [
     "Voronoi",
     "Eccentricity",
 ]:
-    for rm in [("single-core", 1), ("threadpool", 4), ("multicore", 4)]:
+    for rm in [("single-core", 1), ("multicore", 4)]:
         for of in ["MDAFormat", "TextFormat"]:
             total_list.append((jt, rm, of))
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_structure.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_structure.py
@@ -51,24 +51,35 @@ def parameters():
     return parameters
 
 
-@pytest.mark.parametrize(
-    "job_type",
-    [
-        "RadiusOfGyration",
-        "SolventAccessibleSurface",
-        "RootMeanSquareDeviation",
-        "RootMeanSquareFluctuation",
-        "DensityProfile",
-        "MolecularTrace",
-        "Voronoi",
-        "Eccentricity",
-    ],
-)
-def test_structure_analysis(parameters, job_type):
+total_list = []
+
+for jt in [
+    "RadiusOfGyration",
+    "SolventAccessibleSurface",
+    "RootMeanSquareDeviation",
+    "RootMeanSquareFluctuation",
+    "DensityProfile",
+    "MolecularTrace",
+    "Voronoi",
+    "Eccentricity",
+]:
+    for rm in [("single-core", 1), ("threadpool", 4), ("multicore", 4)]:
+        for of in ["MDAFormat", "TextFormat"]:
+            total_list.append((jt, rm, of))
+
+
+@pytest.mark.parametrize("job_type,running_mode,output_format", total_list)
+def test_structure_analysis(parameters, job_type, running_mode, output_format):
     temp_name = tempfile.mktemp()
-    parameters["output_files"] = (temp_name, ("MDAFormat",))
+    parameters["running_mode"] = running_mode
+    parameters["output_files"] = (temp_name, (output_format,))
     job = IJob.create(job_type)
     job.run(parameters, status=True)
-    assert path.exists(temp_name + ".mda")
-    assert path.isfile(temp_name + ".mda")
-    os.remove(temp_name + ".mda")
+    if output_format == "MDAFormat":
+        assert path.exists(temp_name + ".mda")
+        assert path.isfile(temp_name + ".mda")
+        os.remove(temp_name + ".mda")
+    elif output_format == "TextFormat":
+        assert path.exists(temp_name + "_text.tar")
+        assert path.isfile(temp_name + "_text.tar")
+        os.remove(temp_name + "_text.tar")

--- a/MDANSE/Tests/UnitTests/Analysis/test_structure.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_structure.py
@@ -28,7 +28,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", 4)
+    parameters["running_mode"] = ("threadpool", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE/Tests/UnitTests/Analysis/test_structure.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_structure.py
@@ -63,7 +63,7 @@ for jt in [
     "Voronoi",
     "Eccentricity",
 ]:
-    for rm in [("single-core", 1), ("multicore", 4)]:
+    for rm in [("single-core", 1), ("multicore", -4)]:
         for of in ["MDAFormat", "TextFormat"]:
             total_list.append((jt, rm, of))
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_thermodynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_thermodynamics.py
@@ -60,15 +60,21 @@ def test_temperature_nonzero(trajectory, interp_order):
     assert np.all(temperature > 0.0)
 
 
-def test_density(trajectory):
+@pytest.mark.parametrize("output_format", ["MDAFormat", "TextFormat"])
+def test_density(trajectory, output_format):
     temp_name = tempfile.mktemp()
     parameters = {}
     parameters["frames"] = (0, 10, 1)
-    parameters["output_files"] = (temp_name, ("MDAFormat",))
+    parameters["output_files"] = (temp_name, (output_format,))
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj
     den = IJob.create("Density")
     den.run(parameters, status=True)
-    assert path.exists(temp_name + ".mda")
-    assert path.isfile(temp_name + ".mda")
-    os.remove(temp_name + ".mda")
+    if output_format == "MDAFormat":
+        assert path.exists(temp_name + ".mda")
+        assert path.isfile(temp_name + ".mda")
+        os.remove(temp_name + ".mda")
+    elif output_format == "TextFormat":
+        assert path.exists(temp_name + "_text.tar")
+        assert path.isfile(temp_name + "_text.tar")
+        os.remove(temp_name + "_text.tar")

--- a/MDANSE/Tests/UnitTests/Analysis/test_trajectory.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_trajectory.py
@@ -28,7 +28,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", 4)
+    parameters["running_mode"] = ("threadpool", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE/Tests/UnitTests/AtomTransmutation/test_transmutation.py
+++ b/MDANSE/Tests/UnitTests/AtomTransmutation/test_transmutation.py
@@ -4,7 +4,6 @@ from MDANSE.IO.PDBReader import PDBReader
 from MDANSE.Framework.AtomTransmutation.transmutation import AtomTransmuter
 
 
-
 pbd_2vb1 = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "..", "Data", "2vb1.pdb"
 )
@@ -17,19 +16,27 @@ def protein_chemical_system():
     return protein_chemical_system
 
 
-def test_atom_transmutation_returns_empty_dictionary_when_no_transmutations_are_made(protein_chemical_system):
+def test_atom_transmutation_returns_empty_dictionary_when_no_transmutations_are_made(
+    protein_chemical_system,
+):
     atm_transmuter = AtomTransmuter(protein_chemical_system)
     mapping = atm_transmuter.get_setting()
     assert mapping == {}
 
 
-def test_atom_transmutation_return_dict_with_transmutations_with_incorrect_element_raises_exception(protein_chemical_system):
+def test_atom_transmutation_return_dict_with_transmutations_with_incorrect_element_raises_exception(
+    protein_chemical_system,
+):
     atm_transmuter = AtomTransmuter(protein_chemical_system)
     with pytest.raises(ValueError):
-        atm_transmuter.apply_transmutation({"all": False, "element": {"S": True}}, "CCC")
+        atm_transmuter.apply_transmutation(
+            {"all": False, "element": {"S": True}}, "CCC"
+        )
 
 
-def test_atom_transmutation_return_dict_with_transmutations_with_s_element_transmutation(protein_chemical_system):
+def test_atom_transmutation_return_dict_with_transmutations_with_s_element_transmutation(
+    protein_chemical_system,
+):
     atm_transmuter = AtomTransmuter(protein_chemical_system)
     atm_transmuter.apply_transmutation({"all": False, "element": {"S": True}}, "C")
     mapping = atm_transmuter.get_setting()
@@ -43,11 +50,13 @@ def test_atom_transmutation_return_dict_with_transmutations_with_s_element_trans
         1404: "C",
         1557: "C",
         1731: "C",
-        1913: "C"
+        1913: "C",
     }
 
 
-def test_atom_transmutation_return_dict_with_transmutations_with_s_element_transmutation_and_index_98_transmutation_0(protein_chemical_system):
+def test_atom_transmutation_return_dict_with_transmutations_with_s_element_transmutation_and_index_98_transmutation_0(
+    protein_chemical_system,
+):
     atm_transmuter = AtomTransmuter(protein_chemical_system)
     atm_transmuter.apply_transmutation({"all": False, "element": {"S": True}}, "C")
     atm_transmuter.apply_transmutation({"all": False, "index": {98: True}}, "N")
@@ -62,11 +71,13 @@ def test_atom_transmutation_return_dict_with_transmutations_with_s_element_trans
         1404: "C",
         1557: "C",
         1731: "C",
-        1913: "C"
+        1913: "C",
     }
 
 
-def test_atom_transmutation_return_dict_with_transmutations_with_s_element_transmutation_and_index_98_transmutation_1(protein_chemical_system):
+def test_atom_transmutation_return_dict_with_transmutations_with_s_element_transmutation_and_index_98_transmutation_1(
+    protein_chemical_system,
+):
     atm_transmuter = AtomTransmuter(protein_chemical_system)
     atm_transmuter.apply_transmutation({"all": False, "element": {"S": True}}, "C")
     atm_transmuter.apply_transmutation({"all": False, "index": {98: True}}, "S")
@@ -80,14 +91,18 @@ def test_atom_transmutation_return_dict_with_transmutations_with_s_element_trans
         1404: "C",
         1557: "C",
         1731: "C",
-        1913: "C"
+        1913: "C",
     }
 
 
-def test_atom_transmutation_return_dict_with_transmutations_with_s_element_transmutation_and_index_98_transmutation_2(protein_chemical_system):
+def test_atom_transmutation_return_dict_with_transmutations_with_s_element_transmutation_and_index_98_transmutation_2(
+    protein_chemical_system,
+):
     atm_transmuter = AtomTransmuter(protein_chemical_system)
     atm_transmuter.apply_transmutation({"all": False, "element": {"S": True}}, "C")
-    atm_transmuter.apply_transmutation({"all": False, "index": {98: True, 99: True}}, "S")
+    atm_transmuter.apply_transmutation(
+        {"all": False, "index": {98: True, 99: True}}, "S"
+    )
     mapping = atm_transmuter.get_setting()
     assert mapping == {
         99: "S",
@@ -99,15 +114,16 @@ def test_atom_transmutation_return_dict_with_transmutations_with_s_element_trans
         1404: "C",
         1557: "C",
         1731: "C",
-        1913: "C"
+        1913: "C",
     }
 
 
 def test_atom_transmutation_return_empty_dict_after_reset(protein_chemical_system):
     atm_transmuter = AtomTransmuter(protein_chemical_system)
     atm_transmuter.apply_transmutation({"all": False, "element": {"S": True}}, "C")
-    atm_transmuter.apply_transmutation({"all": False, "index": {98: True, 99: True}}, "S")
+    atm_transmuter.apply_transmutation(
+        {"all": False, "index": {98: True, 99: True}}, "S"
+    )
     atm_transmuter.reset_setting()
     mapping = atm_transmuter.get_setting()
     assert mapping == {}
-

--- a/MDANSE/Tests/UnitTests/test_HDF5Trajectory.py
+++ b/MDANSE/Tests/UnitTests/test_HDF5Trajectory.py
@@ -130,7 +130,8 @@ def test_identity(chemical_system):
     for i in range(nAtoms):
         temp.add_chemical_entity(Atom(symbol="H"))
     # assert(temp == chemical_system)
-    assert(chemical_system == chemical_system)
+    assert chemical_system == chemical_system
+
 
 def test_copy(chemical_system):
     original = chemical_system
@@ -139,11 +140,10 @@ def test_copy(chemical_system):
     print(original.number_of_atoms)
     print(copied.atom_list)
     print(copied.number_of_atoms)
-    assert(repr(original) == repr(copied))
+    assert repr(original) == repr(copied)
 
-def test_compression(sample_trajectory,
-                    gzipped_trajectory,
-                    lzffed_trajectory):
+
+def test_compression(sample_trajectory, gzipped_trajectory, lzffed_trajectory):
     size_uncompressed = os.stat(sample_trajectory).st_size
     size_gzipped = os.stat(gzipped_trajectory).st_size
     size_lzffed = os.stat(lzffed_trajectory).st_size


### PR DESCRIPTION
**Description of work**
Our current unit tests verify for all the analysis tasks if an .mda file can be created, which indicates that the task completed without an error. However, it turned out that the outputs for DensityOfStates were internally inconsistent (although only for the 'time_window' array), triggering an error when using TextFormat output.

**Fixes**
1. Test of TextFormat output has been added to most analysis types,
2. Test of 'multicore' running mode has been added to unit tests.

**To test**
All tests should pass.
