### PR TITLE
Correct the package tags for PyPI and installation instructions

### DIFF
--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
         'Development Status :: 3 - Alpha',
 
         'Intended Audience :: Science/Research',
-        'Topic :: Software Development :: Build Tools',
+        'Topic :: Scientific/Engineering :: Chemistry',
+        'Topic :: Scientific/Engineering :: Physics',
 
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -20,7 +20,9 @@ classifiers = [
         'Development Status :: 3 - Alpha',
 
         'Intended Audience :: Science/Research',
-        'Topic :: Software Development :: Build Tools',
+        'Topic :: Scientific/Engineering :: Chemistry',
+        'Topic :: Scientific/Engineering :: Physics',
+        'Topic :: Scientific/Engineering :: Visualization',
 
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.9',

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "qtpy",
     "vtk",
     "PyQt6",
+    "pyqt6-tools",
     "PyYAML",
 ]
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ source mdanse_env/bin/activate
 ```
 in a bash console, or
 ```
-mdanse_end/Scripts/activate.bat
+mdanse_end\Scripts\activate.bat
 ```
 if you are using cmd.exe on Windows.
 
@@ -43,6 +43,18 @@ and start the graphical interface by typing
 ```
 mdanse_gui
 ```
+
+## Installation: development version
+
+At the moment MDANSE and MDANSE_GUI are undergoing frequent changes. If you would
+like to try out the latest development version, you can install directly from GitHub
+using pip:
+```
+python3 -m pip install "git+https://github.com/ISISNeutronMuon/MDANSE@protos#egg=MDANSE&subdirectory=MDANSE"
+python3 -m pip install "git+https://github.com/ISISNeutronMuon/MDANSE@protos#egg=MDANSE_GUI&subdirectory=MDANSE_GUI"
+```
+
+## Quick start: the workflow
 
 The typical workflow of MDANSE:
 


### PR DESCRIPTION
**Description of work**
The 'topic' tags in pyproject.toml were not correct at the time of the alpha release. Also, minor corrections were needed in the installation instructions.

**Fixes**
1. Changed topic tags in pyproject.toml to include Physics and Chemistry,
2. Corrected the slash characters in Windows installation instructions,
3. Added the installation instructions for pip install from GitHub,
4. Added `pyqt6-tools` to GUI dependencies. This may not be necessary, but it is possible that some installations on Windows machines will not work without it. Also, **this fixes the PyQt6 version to a slightly older one**.

**To test**
Please install MDANSE_GUI in a clean virtual environment and see if it starts correctly after installing.
