### PR TITLE
Fix pdb conversion

### DIFF
--- a/MDANSE/Src/MDANSE/Chemistry/__init__.py
+++ b/MDANSE/Src/MDANSE/Chemistry/__init__.py
@@ -13,6 +13,9 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+import os
+import json
+
 from MDANSE.Chemistry.Databases import (
     AtomsDatabase,
     MoleculesDatabase,
@@ -27,3 +30,6 @@ MOLECULES_DATABASE = MoleculesDatabase()
 RESIDUES_DATABASE = ResiduesDatabase()
 
 NUCLEOTIDES_DATABASE = NucleotidesDatabase()
+
+with open(os.path.join(os.path.dirname(__file__), "residues_alt_names.json"), "r") as f:
+    RESIDUE_ALT_NAMES = json.load(f)

--- a/MDANSE/Src/MDANSE/Chemistry/residues_alt_names.json
+++ b/MDANSE/Src/MDANSE/Chemistry/residues_alt_names.json
@@ -1,0 +1,4 @@
+{
+  "HIS": ["HID", "HIE", "HIP"],
+  "CYS": ["CYS", "CYX"]
+}

--- a/MDANSE/Src/MDANSE/IO/PDB.py
+++ b/MDANSE/Src/MDANSE/IO/PDB.py
@@ -489,7 +489,11 @@ class PDBFile:
         name = name.upper()
         if self.export_filter is not None:
             name, number = self.export_filter.processResidue(name, number, terminus)
-        self.het_flag = not (name in RESIDUES_DATABASE or name in RESIDUE_ALT_NAMES or name in NUCLEOTIDES_DATABASE)
+        self.het_flag = not (
+            name in RESIDUES_DATABASE
+            or name in RESIDUE_ALT_NAMES
+            or name in NUCLEOTIDES_DATABASE
+        )
         self.data["residue_name"] = name
         self.data["residue_number"] = (self.data["residue_number"] + 1) % 10000
         self.data["insertion_code"] = ""
@@ -1051,8 +1055,10 @@ class PDBPeptideChain(PDBChain):
         return (
             chain_data["chain_id"] == self.chain_id
             and chain_data["segment_id"] == self.segment_id
-            and (residue_data["residue_name"] in RESIDUES_DATABASE
-            or residue_data["residue_name"] in RESIDUE_ALT_NAMES)
+            and (
+                residue_data["residue_name"] in RESIDUES_DATABASE
+                or residue_data["residue_name"] in RESIDUE_ALT_NAMES
+            )
         )
 
 

--- a/MDANSE/Src/MDANSE/IO/PDB.py
+++ b/MDANSE/Src/MDANSE/IO/PDB.py
@@ -73,12 +73,11 @@ Example::
 @undocumented: export_filters
 @undocumented: DummyChain
 """
-
 import string
 
 import numpy as np
 
-from MDANSE.Chemistry import NUCLEOTIDES_DATABASE, RESIDUES_DATABASE
+from MDANSE.Chemistry import NUCLEOTIDES_DATABASE, RESIDUES_DATABASE, RESIDUE_ALT_NAMES
 from MDANSE.IO.FortranFormat import FortranFormat, FortranLine
 from MDANSE.IO.PDBExportFilters import export_filters
 from MDANSE.IO.TextFile import TextFile
@@ -490,7 +489,7 @@ class PDBFile:
         name = name.upper()
         if self.export_filter is not None:
             name, number = self.export_filter.processResidue(name, number, terminus)
-        self.het_flag = not (name in RESIDUES_DATABASE or name in NUCLEOTIDES_DATABASE)
+        self.het_flag = not (name in RESIDUES_DATABASE or name in RESIDUE_ALT_NAMES or name in NUCLEOTIDES_DATABASE)
         self.data["residue_name"] = name
         self.data["residue_number"] = (self.data["residue_number"] + 1) % 10000
         self.data["insertion_code"] = ""
@@ -1052,7 +1051,8 @@ class PDBPeptideChain(PDBChain):
         return (
             chain_data["chain_id"] == self.chain_id
             and chain_data["segment_id"] == self.segment_id
-            and residue_data["residue_name"] in RESIDUES_DATABASE
+            and (residue_data["residue_name"] in RESIDUES_DATABASE
+            or residue_data["residue_name"] in RESIDUE_ALT_NAMES)
         )
 
 
@@ -1097,6 +1097,7 @@ class PDBDummyChain(PDBChain):
             chain_data["chain_id"] == self.chain_id
             and chain_data["segment_id"] == self.segment_id
             and residue_data["residue_name"] not in RESIDUES_DATABASE
+            and residue_data["residue_name"] not in RESIDUE_ALT_NAMES
             and residue_data["residue_name"] not in NUCLEOTIDES_DATABASE
         )
 
@@ -1279,7 +1280,7 @@ class Structure:
     def newResidue(self, residue_data):
         name = residue_data["residue_name"]
         residue_number = residue_data["residue_number"]
-        if name in RESIDUES_DATABASE:
+        if name in RESIDUES_DATABASE or name in RESIDUE_ALT_NAMES:
             residue = PDBAminoAcidResidue(name, [], residue_number)
         elif name in NUCLEOTIDES_DATABASE:
             residue = PDBNucleotideResidue(name, [], residue_number)

--- a/MDANSE/Src/MDANSE/IO/PDBReader.py
+++ b/MDANSE/Src/MDANSE/IO/PDBReader.py
@@ -37,7 +37,7 @@ from MDANSE.Chemistry import (
     MOLECULES_DATABASE,
     NUCLEOTIDES_DATABASE,
     RESIDUES_DATABASE,
-    RESIDUE_ALT_NAMES
+    RESIDUE_ALT_NAMES,
 )
 from MDANSE.MolecularDynamics.Configuration import RealConfiguration
 from MDANSE.IO.PDB import PDBMolecule, PDBNucleotideChain, PDBPeptideChain, Structure
@@ -484,7 +484,9 @@ class PDBReader:
                 # go through each name that code could be
                 atoms_found = [None] * len(pdb_atoms)
                 for comp, pdb_atom in enumerate(pdb_atoms):
-                    if len(atoms_found) != len(RESIDUES_DATABASE[new_code]["atoms"].items()):
+                    if len(atoms_found) != len(
+                        RESIDUES_DATABASE[new_code]["atoms"].items()
+                    ):
                         # different number of atoms break and try the next name
                         break
                     for at, info in RESIDUES_DATABASE[new_code]["atoms"].items():
@@ -518,7 +520,9 @@ class PDBReader:
                         break
                 else:
                     raise PDBReaderError(
-                        "The atom {}{}:{} is unknown".format(code, residue.number, pdb_atom)
+                        "The atom {}{}:{} is unknown".format(
+                            code, residue.number, pdb_atom
+                        )
                     )
 
         resname = "{}{}".format(code, residue.number)

--- a/MDANSE/Src/MDANSE/IO/PDBReader.py
+++ b/MDANSE/Src/MDANSE/IO/PDBReader.py
@@ -504,7 +504,7 @@ class PDBReader:
                 # went through all alternative names looks like we were
                 # unable to match the code to the MDANSE residues
                 raise PDBReaderError(
-                    "Unable to fine residue for {}{}".format(code, residue.number)
+                    "Unable to find residue for {}{}".format(code, residue.number)
                 )
             # found the match from the alternate name to the name in
             # mdanse lets rename the code


### PR DESCRIPTION
**Description of work**
Fix residue mapping so that it allows for a many-to-many map. Basically, in some cases, a residue could map to many different codes e.g. HIS could be HID, HIE or HIP. Updated MDANSE so that residues_alt_names.json can be updated for these cases. Basically, MDANSE will now check all codes in residues_alt_names.json to get the correct residue.

**Fixes**
Fixes #311

**To test**
Unittest should all pass. Try running the gromacs conversion with adk_oplsaa and cobrotoxin, they should convert without any issues.
