### PR TITLE
Add missing build dependencies to readthedoc files

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,6 @@
     configuration: Doc/conf.py
 
  # Dependencies required to build your docs
- # python:
- #    install:
- #    - requirements: docs/requirements.txt
+ python:
+    install:
+    - requirements: Doc/requirements.txt

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -92,7 +92,7 @@ numfig = True
 current_year = datetime.date.today().year
 # General information about the project.
 project = u'MDANSE'
-copyright = u'2015-' + str(current_year) + u', MDANSE is developed and supported by the Institut Laue-Langevin and the ISIS Neutron and Muon Source, ![UKRI Logo](_static/UKRI_Logo.png)'
+copyright = u'2015-' + str(current_year) + u', MDANSE is developed and supported by the Institut Laue-Langevin and the ISIS Neutron and Muon Source.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -126,6 +126,14 @@ html_theme_options = {'sidebarwidth':250}#, 'nosidebar':True}
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'MDANSE_doc'
+
+html_context = {
+    "display_github": True, # Integrate GitHub
+    "github_user": "ISISNeutronMuon", # Username
+    "github_repo": "MDANSE", # Repo name
+    "github_version": "protos", # Version
+    "conf_py_path": "/Doc/", # Path in the checkout to the docs root
+}
 
 latex_documents = [
     (master_doc, 'theory_help.tex', 'Theory background of MDANSE',

--- a/Doc/index.rst
+++ b/Doc/index.rst
@@ -33,7 +33,7 @@ J Chem Inf Model. 57(1):1-5 (2017).
        <div class="grid-item">
            <h3>💡 Explanations</h3>
            <p>Learn the basics and core concepts of MDANSE.</p>
-           <a href="pages/explanations.html">Learn More</a>
+           <a href="pages/introduction.html">Learn More</a>
        </div>
        <div class="grid-item">
            <h3>⚛️ How-To Guides</h3>
@@ -43,7 +43,7 @@ J Chem Inf Model. 57(1):1-5 (2017).
        <div class="grid-item">
            <h3>🧪 Tutorials</h3>
            <p>Detailed tutorials to help you get started with MDANSE.</p>
-           <a href="pages/T_Batch.html">Learn More</a>
+           <a href="pages/T_Water_IR.html">Learn More</a>
        </div>
        <div class="grid-item">
            <h3>📚 Technical References</h3>
@@ -105,10 +105,3 @@ J Chem Inf Model. 57(1):1-5 (2017).
    pages/R_units
    pages/R_further
    pages/references
-
-Indices and Tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/Doc/pages/R_contact.rst
+++ b/Doc/pages/R_contact.rst
@@ -29,9 +29,4 @@ GitHub Repository
 You can report issues and make suggestions on our GitHub repository. Please visit
 the following link to access the repository:
 
-<div style="background-color: black; padding: 10px; display: inline-block; border-radius: 5px;">
-   <a href="https://github.com/ISISNeutronMuon/MDANSE" style="color: white; text-decoration: none;">
-      <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Logo.png" alt="GitHub Logo" style="vertical-align: middle; height: 20px; margin-right: 5px;">
-      MDANSE GitHub Repository
-   </a>
-</div>
+`MDANSE GitHub Page <https://github.com/ISISNeutronMuon/MDANSE>`_

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme


### PR DESCRIPTION
**Description of work**
As the requirements on Read The Docs have been gradually changing, we have reached the stage where our documentation build fails. This PR adds the missing configuration which should fix the problem.

**Fixes**
Doc/requirements.txt has been added.
A few broken links on the main page have been corrected.

**To test**
I tested the build manually via my ReadTheDocs account. There is not much testing to do otherwise.
