### PR TITLE
Remove hardcoded background colour in the GUI dialogs

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
@@ -136,9 +136,6 @@ class InstrumentResolutionWidget(WidgetBase):
                     value = float(self._fields[index].text())
                 except ValueError:
                     value = self._defaults[index]
-                    self._fields[index].setStyleSheet(
-                        "background-color:rgb(180,20,180); font-weight: bold"
-                    )
                 else:
                     self._fields[index].setStyleSheet("")
                 params[key] = value

--- a/MDANSE_GUI/Src/MDANSE_GUI/PeriodicTableViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/PeriodicTableViewer.py
@@ -256,7 +256,7 @@ class ElementButton(QToolButton):
         varbox_stylesheet = (
             "QToolButton {background-color:rgb("
             + text_rgb
-            + "); font-size: 20pt ; font-weight: bold}"
+            + "); font-size: 20pt ; font-weight: bold; font: ; color: rgb(20,0,0)}"
         )
         self.setStyleSheet(varbox_stylesheet)
 
@@ -328,7 +328,7 @@ class InfoDisplay(QFrame):
 
         self.fields = fields
 
-        stylesheet = "background-color:rgb(180,220,180); font-weight: bold"
+        stylesheet = "font-weight: bold"
         self.setStyleSheet(stylesheet)
 
     @Slot(object)
@@ -376,10 +376,6 @@ class PeriodicTableViewer(QDialog):
         self.glayout.addWidget(self.data_display, 1, 5, 3, 8)
 
         self.placeElements()
-
-        self.setStyleSheet(
-            "QLabel {background-color:rgb(250,250,250); qproperty-alignment: AlignCenter}"
-        )
 
     def placeElements(self):
         for key, value in _LAYOUT.items():

--- a/MDANSE_GUI/Src/MDANSE_GUI/Plotter/models/data_tree_model.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Plotter/models/data_tree_model.py
@@ -478,11 +478,7 @@ class DataTreeModel(QtCore.QAbstractItemModel):
             else:
                 data_root_item = self.get_data_root_item(node)
                 variable_info = data_root_item.get_dataset_info(node.path, False)
-                return (
-                    QtGui.QColor("black")
-                    if variable_info["plottable"]
-                    else QtGui.QColor("red")
-                )
+                return None if variable_info["plottable"] else QtGui.QColor("red")
 
         elif role == QtCore.Qt.ItemDataRole.ToolTipRole:
             node = index.internalPointer()

--- a/MDANSE_GUI/Src/MDANSE_GUI/RegistryViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/RegistryViewer.py
@@ -253,9 +253,6 @@ class RegistryViewer(QDialog):
         self.doc_panel = QTextEdit(self)
         self.glayout.addWidget(self.doc_panel, 3, 2, 1, 1)
 
-        self.setStyleSheet(
-            "QLabel {background-color:rgb(250,250,250); qproperty-alignment: AlignCenter}"
-        )
         self.filter_field.textChanged.connect(self.filterEntries)
 
         self.viewer.clicked.connect(self.updateDocstring)

--- a/MDANSE_GUI/Src/MDANSE_GUI/SubclassViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/SubclassViewer.py
@@ -83,9 +83,6 @@ class RegistryViewer(QDialog):
         self.doc_panel = QTextEdit(self)
         self.glayout.addWidget(self.doc_panel, 3, 2, 1, 1)
 
-        self.setStyleSheet(
-            "QLabel {background-color:rgb(250,250,250); qproperty-alignment: AlignCenter}"
-        )
         self.filter_field.textChanged.connect(self.filterEntries)
 
         self.viewer.clicked.connect(self.updateDocstring)


### PR DESCRIPTION
**Description of work**
Hardcoded font/background colour made it impossible to see the text in some GUI components, notably the chemical element viewer and the data list in the plotter. The solution is to remove the custom formatting wherever possible and have the GUI rely on the system style settings.

**Fixes**
Colour setting code has been removed wherever necessary.

**To test**
Please start the GUI and open the following GUI elements:
1. Periodic table viewer.
2. Atom information in the periodic table viewer for any specific atom.
3. Data plotter with any data file loaded.
Try changing the style sheets. All the background and font colours should change accordingly.
