### PR TITLE
simplify json selection setting

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomSelectionConfigurator.py
@@ -56,7 +56,7 @@ class AtomSelectionConfigurator(IConfigurator):
 
         self["value"] = value
 
-        selector.update_from_json(value)
+        selector.load_from_json(value)
         indexes = selector.get_idxs()
 
         self["flatten_indexes"] = sorted(list(indexes))

--- a/MDANSE/Tests/UnitTests/AtomSelector/test_selector.py
+++ b/MDANSE/Tests/UnitTests/AtomSelector/test_selector.py
@@ -103,14 +103,14 @@ def test_selector_json_dump_0(protein_chemical_system):
     selector = Selector(protein_chemical_system)
     selector.update_settings({"all": False, "element": {"S": True}})
     json_dump = selector.settings_to_json()
-    assert json_dump == '{"all": false, "element": {"S": true}}'
+    assert json_dump == '{"all": false, "element": ["S"]}'
 
 
 def test_selector_json_dump_1(protein_chemical_system):
     selector = Selector(protein_chemical_system)
     selector.update_settings({"all": False, "element": {"S": True}, "water": True})
     json_dump = selector.settings_to_json()
-    assert json_dump == '{"all": false, "water": true, "element": {"S": true}}'
+    assert json_dump == '{"all": false, "water": true, "element": ["S"]}'
 
 
 def test_selector_json_dump_2(protein_chemical_system):
@@ -127,7 +127,7 @@ def test_selector_json_dump_3(protein_chemical_system):
     )
     json_dump = selector.settings_to_json()
     assert (
-        json_dump == '{"all": false, "water": true, "element": {"S": true, "H": true}}'
+        json_dump == '{"all": false, "water": true, "element": ["S", "H"]}'
     )
 
 
@@ -144,7 +144,7 @@ def test_selector_json_dump_4(protein_chemical_system):
     json_dump = selector.settings_to_json()
     assert (
         json_dump
-        == '{"all": false, "water": true, "element": {"S": true, "H": true}, "index": {"0": true, "1": true}}'
+        == '{"all": false, "water": true, "element": ["S", "H"], "index": [0, 1]}'
     )
 
 
@@ -154,7 +154,7 @@ def test_selector_json_dump_with_second_update(protein_chemical_system):
     selector.update_settings({"element": {"S": True, "O": True}, "water": True})
     json_dump = selector.settings_to_json()
     assert (
-        json_dump == '{"all": false, "water": true, "element": {"S": true, "O": true}}'
+        json_dump == '{"all": false, "water": true, "element": ["S", "O"]}'
     )
 
 
@@ -164,7 +164,7 @@ def test_selector_json_dump_with_third_update(protein_chemical_system):
     selector.update_settings({"element": {"S": True, "O": True}, "water": True})
     selector.update_settings({"element": {"S": False}})
     json_dump = selector.settings_to_json()
-    assert json_dump == '{"all": false, "water": true, "element": {"O": true}}'
+    assert json_dump == '{"all": false, "water": true, "element": ["O"]}'
 
 
 def test_selector_json_dump_with_fourth_update(protein_chemical_system):
@@ -174,7 +174,7 @@ def test_selector_json_dump_with_fourth_update(protein_chemical_system):
     selector.update_settings({"element": {"S": False}})
     selector.update_settings({"water": False})
     json_dump = selector.settings_to_json()
-    assert json_dump == '{"all": false, "element": {"O": true}}'
+    assert json_dump == '{"all": false, "element": ["O"]}'
 
 
 def test_selector_returns_correct_number_of_atom_idxs_after_setting_settings_again_with_reset_first(
@@ -201,13 +201,13 @@ def test_selector_returns_correct_number_of_atom_idxs_after_setting_settings_aga
 def test_selector_json_dump_and_load_0(protein_chemical_system):
     selector = Selector(protein_chemical_system)
     selector.update_settings(
-        {"all": False, "index": {0: True, "1": True}}
+        {"all": False, "index": {0: True, 1: True}}
     )
     json_dump = selector.settings_to_json()
     assert (
-        json_dump == '{"all": false, "index": {"0": true, "1": true}}'
+        json_dump == '{"all": false, "index": [0, 1]}'
     )
-    selector.update_from_json(json_dump, reset_first=True)
+    selector.load_from_json(json_dump)
     atm_idxs = selector.get_idxs()
     assert len(atm_idxs) == 2
 
@@ -220,9 +220,9 @@ def test_selector_json_dump_and_load_1(protein_chemical_system):
     json_dump = selector.settings_to_json()
     assert (
         json_dump
-        == '{"all": false, "water": true, "element": {"S": true}}'
+        == '{"all": false, "water": true, "element": ["S"]}'
     )
-    selector.update_from_json(json_dump, reset_first=True)
+    selector.load_from_json(json_dump)
     atm_idxs = selector.get_idxs()
     assert len(atm_idxs) == 28746 + 10
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -339,7 +339,7 @@ class SelectionHelper(QDialog):
             elif isinstance(v, dict):
                 combo_layout = QHBoxLayout()
                 combo = CheckableComboBox()
-                items = [i for i in v.keys() if match_exists[k][i]]
+                items = [str(i) for i in v.keys() if match_exists[k][i]]
                 # we blocksignals here as there can be some
                 # performance issues with a large number of items
                 combo.model().blockSignals(True)
@@ -368,7 +368,12 @@ class SelectionHelper(QDialog):
             self.full_settings[check_box.objectName()] = check_box.isChecked()
         for combo_box in self.combo_boxes:
             for item in combo_box.getItems():
-                self.full_settings[combo_box.objectName()][item.text()] = (
+                txt = item.text()
+                try:
+                    key = int(txt)
+                except ValueError:
+                    key = txt
+                self.full_settings[combo_box.objectName()][key] = (
                     item.checkState() == Qt.Checked
                 )
 
@@ -405,7 +410,12 @@ class SelectionHelper(QDialog):
         for combo_box in self.combo_boxes:
             combo_box.model().blockSignals(True)
             for item in combo_box.getItems():
-                if self.full_settings[combo_box.objectName()][item.text()]:
+                txt = item.text()
+                try:
+                    key = int(txt)
+                except ValueError:
+                    key = txt
+                if self.full_settings[combo_box.objectName()][key]:
                     item.setCheckState(Qt.Checked)
                 else:
                     item.setCheckState(Qt.Unchecked)


### PR DESCRIPTION
**Description of work**
Updated the json selection setting so that it is simplified slightly.

Before 
`{"all": false, "element": {"H1": true}, "index": {"144": true, "387": true, "639": true}}`

After:
`{"all": false, "element": ["H1"], "index": [126, 252, 630, 663]}`

**To test**
Run a job with atom selection and check that it behaves correctly.
