### PR TITLE
Add tags to output datasets in MDA files

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/AngularCorrelation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AngularCorrelation.py
@@ -121,6 +121,7 @@ class AngularCorrelation(IJob):
             (self.configuration["frames"]["number"],),
             axis="time",
             units="au",
+            main_result=True,
         )
 
         if self.configuration["per_axis"]["value"]:
@@ -137,6 +138,8 @@ class AngularCorrelation(IJob):
                 ),
                 axis="axis_index|time",
                 units="au",
+                main_result=True,
+                partial_result=True,
             )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AreaPerMolecule.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AreaPerMolecule.py
@@ -120,6 +120,7 @@ class AreaPerMolecule(IJob):
             (self.configuration["frames"]["number"],),
             axis="time",
             units="1/nm2",
+            main_result=True,
         )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
@@ -207,6 +207,8 @@ class CurrentCorrelationFunction(IJob):
                 (nQShells, self._nOmegas),
                 axis="q|omega",
                 units="au",
+                main_result=True,
+                partial_result=True,
             )
             self._outputData.add(
                 "J(q,f)_trans_%s%s" % pair,
@@ -214,6 +216,8 @@ class CurrentCorrelationFunction(IJob):
                 (nQShells, self._nOmegas),
                 axis="q|omega",
                 units="au",
+                main_result=True,
+                partial_result=True,
             )
 
         self._outputData.add(
@@ -229,6 +233,7 @@ class CurrentCorrelationFunction(IJob):
             (nQShells, self._nOmegas),
             axis="q|omega",
             units="au",
+            main_result=True,
         )
         self._outputData.add(
             "j(q,t)_trans_total",
@@ -243,6 +248,7 @@ class CurrentCorrelationFunction(IJob):
             (nQShells, self._nOmegas),
             axis="q|omega",
             units="au",
+            main_result=True,
         )
 
         traj = self.configuration["trajectory"]["instance"]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
@@ -83,6 +83,7 @@ class Density(IJob):
             (self._n_frames,),
             axis="time",
             units="g/cm3",
+            main_result=True,
         )
 
         self._outputData.add(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -135,6 +135,8 @@ class DensityOfStates(IJob):
                 (instrResolution["n_romegas"],),
                 axis="romega",
                 units="au",
+                main_result=True,
+                partial_result=True,
             )
         self._outputData.add(
             "vacf_total",
@@ -149,6 +151,7 @@ class DensityOfStates(IJob):
             (instrResolution["n_romegas"],),
             axis="romega",
             units="au",
+            main_result=True,
         )
 
         self._atoms = sorted_atoms(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
@@ -113,6 +113,8 @@ class DensityProfile(IJob):
                 (self._n_bins,),
                 axis="r",
                 units="au",
+                main_result=True,
+                partial_result=True,
             )
 
         self._extent = 0.0

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
@@ -88,6 +88,7 @@ class DipoleAutoCorrelationFunction(IJob):
             "LineOutputVariable",
             (self.configuration["frames"]["number"],),
             axis="time",
+            main_result=True,
         )
 
     def run_step(self, index) -> tuple[int, np.ndarray]:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
@@ -173,6 +173,8 @@ class DynamicCoherentStructureFactor(IJob):
                 (nQShells, self._nOmegas),
                 axis="q|omega",
                 units="nm2/ps",
+                main_result=True,
+                partial_result=True,
             )
 
         self._outputData.add(
@@ -188,6 +190,7 @@ class DynamicCoherentStructureFactor(IJob):
             (nQShells, self._nOmegas),
             axis="q|omega",
             units="nm2/ps",
+            main_result=True,
         )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -165,6 +165,8 @@ class DynamicIncoherentStructureFactor(IJob):
                 (self._nQShells, self._nOmegas),
                 axis="q|omega",
                 units="nm2/ps",
+                main_result=True,
+                partial_result=True,
             )
 
         self._outputData.add(
@@ -180,6 +182,7 @@ class DynamicIncoherentStructureFactor(IJob):
             (self._nQShells, self._nOmegas),
             axis="q|omega",
             units="nm2/ps",
+            main_result=True,
         )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
@@ -135,7 +135,13 @@ class Eccentricity(IJob):
                 units="nm",
             )
 
-        self._outputData.add("eccentricity", "LineOutputVariable", npoints, axis="time")
+        self._outputData.add(
+            "eccentricity",
+            "LineOutputVariable",
+            npoints,
+            axis="time",
+            main_result=True,
+        )
 
         self._outputData.add(
             "ratio_of_largest_to_smallest", "LineOutputVariable", npoints, axis="time"

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -118,10 +118,17 @@ class ElasticIncoherentStructureFactor(IJob):
                 (self._nQShells,),
                 axis="q",
                 units="au",
+                main_result=True,
+                partial_result=True,
             )
 
         self._outputData.add(
-            "eisf_total", "LineOutputVariable", (self._nQShells,), axis="q", units="au"
+            "eisf_total",
+            "LineOutputVariable",
+            (self._nQShells,),
+            axis="q",
+            units="au",
+            main_result=True,
         )
 
         self._atoms = sorted_atoms(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -160,6 +160,8 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
                 (self._nQShells, self._nOmegas),
                 axis="q|omega",
                 units="nm2/ps",
+                main_result=True,
+                partial_result=True,
             )
 
         self._outputData.add(
@@ -175,6 +177,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
             (self._nQShells, self._nOmegas),
             axis="q|omega",
             units="nm2/ps",
+            main_result=True,
         )
 
         self._atoms = sorted_atoms(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GeneralAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GeneralAutoCorrelationFunction.py
@@ -94,6 +94,8 @@ class GeneralAutoCorrelationFunction(IJob):
                 (self.configuration["frames"]["number"],),
                 axis="time",
                 units="au",
+                main_result=True,
+                partial_result=True,
             )
 
         self._outputData.add(
@@ -102,6 +104,7 @@ class GeneralAutoCorrelationFunction(IJob):
             (self.configuration["frames"]["number"],),
             axis="time",
             units="au",
+            main_result=True,
         )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
@@ -116,6 +116,7 @@ class Infrared(IJob):
             "LineOutputVariable",
             (instrResolution["n_romegas"],),
             axis="omega",
+            main_result=True,
         )
 
     def run_step(self, index) -> tuple[int, np.ndarray]:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/McStasVirtualInstrument.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/McStasVirtualInstrument.py
@@ -453,6 +453,8 @@ class McStasVirtualInstrument(IJob):
                 I,
                 axis="%s|%s" % (xlabel, ylabel),
                 units="au",
+                main_result=True,
+                partial_result=True,
             )
 
         return FileStruct

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -125,6 +125,8 @@ class MeanSquareDisplacement(IJob):
                 (self.configuration["frames"]["number"],),
                 axis="time",
                 units="nm2",
+                main_result=True,
+                partial_result=True,
             )
 
         self._atoms = sorted_atoms(
@@ -198,7 +200,12 @@ class MeanSquareDisplacement(IJob):
         msdTotal = weight(weights, self._outputData, nAtomsPerElement, 1, "msd_%s")
 
         self._outputData.add(
-            "msd_total", "LineOutputVariable", msdTotal, axis="time", units="nm2"
+            "msd_total",
+            "LineOutputVariable",
+            msdTotal,
+            axis="time",
+            units="nm2",
+            main_result=True,
         )
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MolecularTrace.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MolecularTrace.py
@@ -127,6 +127,7 @@ class MolecularTrace(IJob):
             "molecular_trace",
             "VolumeOutputVariable",
             tuple(np.ceil(np.array([dimx, dimy, dimz]) / self.resolution).astype(int)),
+            main_result=True,
         )
 
         self._indexes = [

--- a/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
@@ -334,6 +334,8 @@ class NeutronDynamicTotalStructureFactor(IJob):
             (nQValues, nOmegas),
             axis="q|omega",
             units="nm2/ps",
+            main_result=True,
+            partial_result=True,
         )
         self._outputData.add(
             "s(q,f)_inc_total",
@@ -341,6 +343,8 @@ class NeutronDynamicTotalStructureFactor(IJob):
             (nQValues, nOmegas),
             axis="q|omega",
             units="nm2/ps",
+            main_result=True,
+            partial_result=True,
         )
         self._outputData.add(
             "s(q,f)_total",
@@ -348,6 +352,7 @@ class NeutronDynamicTotalStructureFactor(IJob):
             (nQValues, nOmegas),
             axis="q|omega",
             units="nm2/ps",
+            main_result=True,
         )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/OrderParameter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/OrderParameter.py
@@ -143,10 +143,20 @@ class OrderParameter(IJob):
             self._doRotation = True
 
         self._outputData.add(
-            "p1", "LineOutputVariable", (self._nFrames,), axis="time", units="au"
+            "p1",
+            "LineOutputVariable",
+            (self._nFrames,),
+            axis="time",
+            units="au",
+            main_result=True,
         )
         self._outputData.add(
-            "p2", "LineOutputVariable", (self._nFrames,), axis="time", units="au"
+            "p2",
+            "LineOutputVariable",
+            (self._nFrames,),
+            axis="time",
+            units="au",
+            main_result=True,
         )
         self._outputData.add(
             "s2", "LineOutputVariable", (self._nAxis,), axis="time", units="au"
@@ -159,6 +169,8 @@ class OrderParameter(IJob):
                 (self._nAxis, self._nFrames),
                 axis="axis_index|time",
                 units="au",
+                main_result=True,
+                partial_result=True,
             )
             self._outputData.add(
                 "p2_per_axis",
@@ -166,6 +178,8 @@ class OrderParameter(IJob):
                 (self._nAxis, self._nFrames),
                 axis="axis_index|time",
                 units="au",
+                main_result=True,
+                partial_result=True,
             )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -102,6 +102,8 @@ class PositionAutoCorrelationFunction(IJob):
                 (self.configuration["frames"]["number"],),
                 axis="time",
                 units="nm2",
+                main_result=True,
+                partial_result=True,
             )
 
         self._atoms = sorted_atoms(
@@ -175,7 +177,12 @@ class PositionAutoCorrelationFunction(IJob):
         pacfTotal = weight(weights, self._outputData, nAtomsPerElement, 1, "pacf_%s")
 
         self._outputData.add(
-            "pacf_total", "LineOutputVariable", pacfTotal, axis="time", units="nm2"
+            "pacf_total",
+            "LineOutputVariable",
+            pacfTotal,
+            axis="time",
+            units="nm2",
+            main_result=True,
         )
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RadiusOfGyration.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RadiusOfGyration.py
@@ -76,6 +76,7 @@ class RadiusOfGyration(IJob):
             (self.configuration["frames"]["number"],),
             axis="time",
             units="nm",
+            main_result=True,
         )
 
         self._indexes = [

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
@@ -98,6 +98,8 @@ class RootMeanSquareDeviation(IJob):
                 (self.configuration["frames"]["number"],),
                 axis="time",
                 units="nm",
+                main_result=True,
+                partial_result=True,
             )
         self._outputData.add(
             "rmsd_all",
@@ -105,6 +107,7 @@ class RootMeanSquareDeviation(IJob):
             (self.configuration["frames"]["number"],),
             axis="time",
             units="nm",
+            main_result=True,
         )
 
         self._atoms = sorted_atoms(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -84,6 +84,7 @@ class RootMeanSquareFluctuation(IJob):
             (self.configuration["atom_selection"]["selection_length"],),
             axis="indexes",
             units="nm",
+            main_result=True,
         )
 
         self._atoms = sorted_atoms(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/SolventAccessibleSurface.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/SolventAccessibleSurface.py
@@ -90,6 +90,7 @@ class SolventAccessibleSurface(IJob):
             (self.configuration["frames"]["number"],),
             axis="time",
             units="nm2",
+            main_result=True,
         )
 
         # Generate the sphere points that will be used to evaluate the sas per atom.

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StructureFactorFromScatteringFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StructureFactorFromScatteringFunction.py
@@ -106,6 +106,8 @@ class StructureFactorFromScatteringFunction(IJob):
                     (nQVectors, nOmegas),
                     axis="q|omega",
                     units="au",
+                    main_result=True,
+                    partial_result=True,
                 )
                 self._outputData["s(q,f)_%s" % suffix][:] = get_spectrum(
                     v[:],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -95,6 +95,7 @@ class Temperature(IJob):
             (self._nFrames,),
             axis="time",
             units="K",
+            main_result=True,
         )
 
         self._atoms = sorted_atoms(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -120,6 +120,8 @@ class VelocityAutoCorrelationFunction(IJob):
                 (self.configuration["frames"]["number"],),
                 axis="time",
                 units="nm2/ps2",
+                main_result=True,
+                partial_result=True,
             )
 
         self._outputData.add(
@@ -128,6 +130,7 @@ class VelocityAutoCorrelationFunction(IJob):
             (self.configuration["frames"]["number"],),
             axis="time",
             units="nm2/ps2",
+            main_result=True,
         )
 
         self._atoms = sorted_atoms(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Voronoi.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Voronoi.py
@@ -222,7 +222,11 @@ class Voronoi(IJob):
             self.neighbourhood[k] = v
 
         self._outputData.add(
-            "mean_volume", "LineOutputVariable", self.mean_volume, units="nm3"
+            "mean_volume",
+            "LineOutputVariable",
+            self.mean_volume,
+            units="nm3",
+            main_result=True,
         )
 
         self._outputData.add(

--- a/MDANSE/Src/MDANSE/Framework/OutputVariables/IOutputVariable.py
+++ b/MDANSE/Src/MDANSE/Framework/OutputVariables/IOutputVariable.py
@@ -50,7 +50,15 @@ class IOutputVariable(np.ndarray, metaclass=SubclassFactory):
     Those extra attributes will be contain information necessary for the the MDANSE plotter.
     """
 
-    def __new__(cls, value, varname, axis="index", units="unitless"):
+    def __new__(
+        cls,
+        value,
+        varname,
+        axis="index",
+        units="unitless",
+        main_result=False,
+        partial_result=False,
+    ):
         """
         Instanciate a new MDANSE output variable.
 
@@ -88,6 +96,14 @@ class IOutputVariable(np.ndarray, metaclass=SubclassFactory):
         obj.units = units
 
         obj.axis = axis
+
+        data_tags = []
+        if main_result:
+            data_tags.append("main")
+        if partial_result:
+            data_tags.append("partial")
+
+        obj.tags = ",".join(data_tags)
 
         return obj
 


### PR DESCRIPTION
**Description of work**
This PR adds an extra attribute called 'tags' to IOutputVariable. As a result, the HDF5 datasets in the MDA output file will have a 'tags' attribute as well. This does not change the output as such, but is a starting point allowing to store useful hints for the data plotter.

The DOS calculation will now label 'dos_total' as 'main', and 'dos_{element name}' as 'main,partial'. The goal is to let the plotter create a quick plot out of an entire output file, where the main result is plotted first (solid line) and the partial results are added (using dashed lines, etc.)

**Fixes**
1. The 'tags' attribute has been added to IOutputVariable,
2. For each job, keyword arguments 'main_result = True' and 'partial_result = True' have been manually added for the outputs considered the main/partial results of a given analysis type.

**To test**
All tests should pass. The tags are not used at the moment.
