### PR TITLE
Output xaxis preview

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/AxisSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AxisSelectionConfigurator.py
@@ -85,5 +85,7 @@ class AxisSelectionConfigurator(IConfigurator):
         :return: the information about this configurator
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Axis vector:%s\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/BasisSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/BasisSelectionConfigurator.py
@@ -82,5 +82,7 @@ class BasisSelectionConfigurator(IConfigurator):
         :return: the information about this configurator
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Basis vector:%s\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/BooleanConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/BooleanConfigurator.py
@@ -72,5 +72,7 @@ class BooleanConfigurator(IConfigurator):
         :return: the information about this configurator
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Value: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FloatConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FloatConfigurator.py
@@ -125,5 +125,7 @@ class FloatConfigurator(IConfigurator):
         :return: the information about this configurator
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Value: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FramesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FramesConfigurator.py
@@ -110,7 +110,9 @@ class FramesConfigurator(RangeConfigurator):
 
     def preview_output_axis(self):
         if not self.is_configured():
-            return None
+            return None, None
+        if not self._valid:
+            return None, None
         return self["time"], "ps"
 
     def get_information(self):

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FramesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FramesConfigurator.py
@@ -108,6 +108,11 @@ class FramesConfigurator(RangeConfigurator):
 
         self["duration"] = self["time"] - self["time"][0]
 
+    def preview_output_axis(self):
+        if not self.is_configured():
+            return None
+        return self["time"], "ps"
+
     def get_information(self):
         """
         Returns some informations about this configurator.

--- a/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
@@ -172,5 +172,7 @@ class GroupingLevelConfigurator(SingleChoiceConfigurator):
         :return: the information about this configurator
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Grouping level: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFInputFileConfigurator.py
@@ -117,6 +117,8 @@ class HDFInputFileConfigurator(InputFileConfigurator):
         :return: the informations about the contents of the HDF file.
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         info = ["HDF input file: %r" % self["value"]]
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
@@ -274,6 +274,9 @@ class IConfigurator(dict, metaclass=SubclassFactory):
     def set_configurable(self, configurable):
         self._configurable = configurable
 
+    def preview_output_axis(self):
+        return None, None
+
     def check_dependencies(self, configured=None):
         """
         Check that the configurators on which this configurator depends on have already been configured.

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InputDirectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InputDirectoryConfigurator.py
@@ -53,5 +53,7 @@ class InputDirectoryConfigurator(IConfigurator):
         :return: the information about this configurator
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Input directory: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
@@ -65,6 +65,9 @@ class InstrumentResolutionConfigurator(IConfigurator):
 
         time = framesCfg["time"]
         self["n_frames"] = len(time)
+        if len(time) < 2:
+            framesCfg.error_status = "This analysis requires more time steps"
+            return
 
         self._timeStep = framesCfg["time"][1] - framesCfg["time"][0]
         self["time_step"] = self._timeStep
@@ -100,8 +103,13 @@ class InstrumentResolutionConfigurator(IConfigurator):
 
     def preview_output_axis(self):
         if not self.is_configured():
-            return None
-        return self["romega"], "rad/ps"
+            return None, None
+        if not self._valid:
+            return None, None
+        if "romega" in self:
+            return self["romega"], "rad/ps"
+        else:
+            return None, None
 
     def get_information(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InstrumentResolutionConfigurator.py
@@ -98,6 +98,11 @@ class InstrumentResolutionConfigurator(IConfigurator):
             : len(time)
         ]
 
+    def preview_output_axis(self):
+        if not self.is_configured():
+            return None
+        return self["romega"], "rad/ps"
+
     def get_information(self):
         """
         Returns some informations the instrument resolution.

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IntegerConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IntegerConfigurator.py
@@ -134,5 +134,7 @@ class IntegerConfigurator(IConfigurator):
         :return: the information about this configurator
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Value: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/McStasOptionsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/McStasOptionsConfigurator.py
@@ -107,5 +107,7 @@ class McStasOptionsConfigurator(IConfigurator):
         :return: the McStas command-line options.
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "McStas command line options: %s\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/McStasParametersConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/McStasParametersConfigurator.py
@@ -123,5 +123,7 @@ class McStasParametersConfigurator(IConfigurator):
         :return: the McStas command-line parameters.
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "McStas command line parameters:%s\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputDirectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputDirectoryConfigurator.py
@@ -72,5 +72,7 @@ class OutputDirectoryConfigurator(IConfigurator):
         :return: the information about this configurator.
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Output directory: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/PythonObjectConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/PythonObjectConfigurator.py
@@ -59,5 +59,7 @@ class PythonObjectConfigurator(IConfigurator):
         :return: the information about this configurator.
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Python object: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/QVectorsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/QVectorsConfigurator.py
@@ -103,6 +103,11 @@ class QVectorsConfigurator(IConfigurator):
         self["value"] = self["q_vectors"]
         self.error_status = "OK"
 
+    def preview_output_axis(self):
+        if not self.is_configured():
+            return None
+        return self["shells"], "1/nm"
+
     def get_information(self):
         """
         Returns string information about this configurator.

--- a/MDANSE/Src/MDANSE/Framework/Configurators/QVectorsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/QVectorsConfigurator.py
@@ -105,7 +105,9 @@ class QVectorsConfigurator(IConfigurator):
 
     def preview_output_axis(self):
         if not self.is_configured():
-            return None
+            return None, None
+        if not self._valid:
+            return None, None
         return self["shells"], "1/nm"
 
     def get_information(self):

--- a/MDANSE/Src/MDANSE/Framework/Configurators/SingleChoiceConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/SingleChoiceConfigurator.py
@@ -78,5 +78,7 @@ class SingleChoiceConfigurator(IConfigurator):
         :return: the information about this configurator.
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Selected item: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/StringConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/StringConfigurator.py
@@ -104,5 +104,7 @@ class StringConfigurator(IConfigurator):
         :return: the information about this configurator.
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Value: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryVariableConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryVariableConfigurator.py
@@ -57,5 +57,7 @@ class TrajectoryVariableConfigurator(IConfigurator):
         :return: the information about this configurator.
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Selected variable: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/VectorConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/VectorConfigurator.py
@@ -142,5 +142,7 @@ class VectorConfigurator(IConfigurator):
         :return: the information about this configurator.
         :rtype: str
         """
+        if "value" not in self:
+            return "Not configured yet\n"
 
         return "Value: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -151,6 +151,15 @@ class IJob(Configurable, metaclass=SubclassFactory):
     def run_step(self, index):
         pass
 
+    def preview_output_axis(self):
+        axes = {}
+        for configurator in self._configuration.values():
+            axis, unit = configurator.preview_output_axis()
+            if axis is None:
+                continue
+            axes[unit] = axis
+        return axes
+
     @classmethod
     def save(cls, jobFile, parameters=None):
         """

--- a/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
@@ -115,3 +115,13 @@ def test_dynamics_analysis(parameters, job_type, running_mode, output_format):
         assert path.exists(temp_name + "_text.tar")
         assert path.isfile(temp_name + "_text.tar")
         os.remove(temp_name + "_text.tar")
+
+
+def test_output_axis_preview(parameters):
+    temp_name = tempfile.mktemp()
+    parameters["running_mode"] = ("single-core", 1)
+    parameters["output_files"] = (temp_name, ("MDAFormat",))
+    job = IJob.create("DensityOfStates")
+    job.setup(parameters)
+    axes = job.preview_output_axis()
+    assert len(axes) == 2  # two configurators return valid arrays

--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -98,6 +98,25 @@ def test_dcsf(trajectory, qvector_spherical_lattice):
     os.remove(temp_name + "_text.tar")
 
 
+def test_output_axis_preview(qvector_spherical_lattice):
+    temp_name = tempfile.mktemp()
+    parameters = {}
+    parameters["atom_selection"] = None
+    parameters["atom_transmutation"] = None
+    parameters["frames"] = (0, 10, 1)
+    parameters["instrument_resolution"] = ("Ideal", {})
+    parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
+    parameters["q_vectors"] = qvector_spherical_lattice
+    parameters["running_mode"] = ("single-core",)
+    parameters["trajectory"] = short_traj
+    parameters["weights"] = "b_coherent"
+    dcsf = IJob.create("DynamicCoherentStructureFactor")
+    dcsf.setup(parameters)
+    axes = dcsf.preview_output_axis()
+    print(axes)
+    assert len(axes) == 3  # two configurators return valid arrays
+
+
 def test_disf(trajectory, qvector_spherical_lattice):
     temp_name = tempfile.mktemp()
     parameters = {}

--- a/MDANSE/Tests/UnitTests/AtomSelector/test_selector.py
+++ b/MDANSE/Tests/UnitTests/AtomSelector/test_selector.py
@@ -92,9 +92,7 @@ def test_selector_returns_correct_number_of_atom_idxs_when_waters_and_sulfurs_ar
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
-    selector.update_settings(
-        {"all": False, "element": {"S": True}, "water": True}
-    )
+    selector.update_settings({"all": False, "element": {"S": True}, "water": True})
     atm_idxs = selector.get_idxs()
     assert len(atm_idxs) == 28746 + 10
 
@@ -126,9 +124,7 @@ def test_selector_json_dump_3(protein_chemical_system):
         {"all": False, "element": {"S": True, "H": True}, "water": True}
     )
     json_dump = selector.settings_to_json()
-    assert (
-        json_dump == '{"all": false, "water": true, "element": ["S", "H"]}'
-    )
+    assert json_dump == '{"all": false, "water": true, "element": ["S", "H"]}'
 
 
 def test_selector_json_dump_4(protein_chemical_system):
@@ -153,9 +149,7 @@ def test_selector_json_dump_with_second_update(protein_chemical_system):
     selector.update_settings({"all": False})
     selector.update_settings({"element": {"S": True, "O": True}, "water": True})
     json_dump = selector.settings_to_json()
-    assert (
-        json_dump == '{"all": false, "water": true, "element": ["S", "O"]}'
-    )
+    assert json_dump == '{"all": false, "water": true, "element": ["S", "O"]}'
 
 
 def test_selector_json_dump_with_third_update(protein_chemical_system):
@@ -181,9 +175,7 @@ def test_selector_returns_correct_number_of_atom_idxs_after_setting_settings_aga
     protein_chemical_system,
 ):
     selector = Selector(protein_chemical_system)
-    selector.update_settings(
-        {"all": False, "element": {"S": True}, "water": True}
-    )
+    selector.update_settings({"all": False, "element": {"S": True}, "water": True})
     atm_idxs = selector.get_idxs()
     assert len(atm_idxs) == 28746 + 10
 
@@ -200,13 +192,9 @@ def test_selector_returns_correct_number_of_atom_idxs_after_setting_settings_aga
 
 def test_selector_json_dump_and_load_0(protein_chemical_system):
     selector = Selector(protein_chemical_system)
-    selector.update_settings(
-        {"all": False, "index": {0: True, 1: True}}
-    )
+    selector.update_settings({"all": False, "index": {0: True, 1: True}})
     json_dump = selector.settings_to_json()
-    assert (
-        json_dump == '{"all": false, "index": [0, 1]}'
-    )
+    assert json_dump == '{"all": false, "index": [0, 1]}'
     selector.load_from_json(json_dump)
     atm_idxs = selector.get_idxs()
     assert len(atm_idxs) == 2
@@ -214,14 +202,9 @@ def test_selector_json_dump_and_load_0(protein_chemical_system):
 
 def test_selector_json_dump_and_load_1(protein_chemical_system):
     selector = Selector(protein_chemical_system)
-    selector.update_settings(
-        {"all": False, "element": {"S": True}, "water": True}
-    )
+    selector.update_settings({"all": False, "element": {"S": True}, "water": True})
     json_dump = selector.settings_to_json()
-    assert (
-        json_dump
-        == '{"all": false, "water": true, "element": ["S"]}'
-    )
+    assert json_dump == '{"all": false, "water": true, "element": ["S"]}'
     selector.load_from_json(json_dump)
     atm_idxs = selector.get_idxs()
     assert len(atm_idxs) == 28746 + 10

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
@@ -30,6 +30,7 @@ from qtpy.QtWidgets import (
 class WidgetBase(QObject):
 
     valid_changed = Signal()
+    value_updated = Signal()
 
     def __init__(self, *args, **kwargs):
         parent = kwargs.get("parent", None)
@@ -128,6 +129,7 @@ class WidgetBase(QObject):
             )
         if self._configurator.valid:
             self.clear_error()
+            self.value_updated.emit()
         else:
             self.mark_error(self._configurator.error_status)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
@@ -111,7 +111,7 @@ class JobTab(GeneralTab):
         logger,
         **kwargs,
     ):
-        action = Action()
+        action = Action(use_preview=True)
         the_tab = cls(
             parent,
             name=name,

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -228,11 +228,11 @@ class Action(QWidget):
 
         self.layout.addWidget(buttonbase)
         self._widgets_in_layout.append(buttonbase)
-        self.allow_execution()
         self.show_output_prediction()
 
     @Slot()
     def show_output_prediction(self):
+        self.allow_execution()
         print("Show output prediction")
         pardict = self.set_parameters()
         self._job_instance.setup(pardict)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -21,6 +21,7 @@ from qtpy.QtWidgets import (
     QWidget,
     QHBoxLayout,
     QScrollArea,
+    QTextEdit,
 )
 from qtpy.QtCore import Signal, Slot
 from MDANSE.Framework.Jobs.IJob import IJob
@@ -73,11 +74,12 @@ class Action(QWidget):
 
     last_paths = {}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, use_preview=False, **kwargs):
         self._default_path = None
         self._input_trajectory = None
         self._trajectory_configurator = None
         self._session = None
+        self._use_preview = use_preview
         default_path = kwargs.pop("path", None)
         input_trajectory = kwargs.pop("trajectory", None)
         self.set_trajectory(default_path, input_trajectory)
@@ -119,6 +121,7 @@ class Action(QWidget):
             self.layout.removeWidget(widget)
         self._widgets = []
         self._widgets_in_layout = []
+        self._preview_box = None
 
     def update_panel(self, job_name: str) -> None:
         """Sets all the widgets for the selected job.
@@ -190,6 +193,8 @@ class Action(QWidget):
                 self._widgets_in_layout.append(widget)
                 self._widgets.append(input_widget)
                 input_widget.valid_changed.connect(self.allow_execution)
+                if self._use_preview:
+                    input_widget.value_updated.connect(self.show_output_prediction)
                 print(f"Set up the right widget for {key}")
             # self.handlers[key] = data_handler
             configured = False
@@ -202,6 +207,11 @@ class Action(QWidget):
                 iterations += 1
                 if iterations > 5:
                     break
+
+        if self._use_preview:
+            self._preview_box = QTextEdit(self)
+            self.layout.addWidget(self._preview_box)
+            self._widgets_in_layout.append(self._preview_box)
 
         buttonbase = QWidget(self)
         buttonlayout = QHBoxLayout(buttonbase)
@@ -219,6 +229,22 @@ class Action(QWidget):
         self.layout.addWidget(buttonbase)
         self._widgets_in_layout.append(buttonbase)
         self.allow_execution()
+        self.show_output_prediction()
+
+    @Slot()
+    def show_output_prediction(self):
+        print("Show output prediction")
+        pardict = self.set_parameters()
+        self._job_instance.setup(pardict)
+        axes = self._job_instance.preview_output_axis()
+        print(f"Axes = {axes.keys()}")
+        text = "<p><b>The results will cover the following range:</b></p>"
+        for unit, array in axes.items():
+            if len(array) < 6:
+                text += f"<p>{array} ({unit})</p>"
+            else:
+                text += f"<p>[{array[0]}, {array[1]}, {array[2]}, ..., {array[-1]}] ({unit})</p>"
+        self._preview_box.setHtml(text)
 
     @Slot(dict)
     def parse_updated_params(self, new_params: dict):


### PR DESCRIPTION
**Description of work**
Action widget now includes a QTextEdit preview field, which informs users about the data axis of the output. This allows the user to check how a change to the input parameters affects the output of the analysis. At the moment the main application is to confirm that the frame selection results in a sufficient energy resolution and range.

At the moment only FramesConfigurator, InstrumentResolutionConfigurator and QVectorsConfigurator create a preview of an output axis. The automatic conversion of the units will be added in another PR.

closes #412 

**Fixes**
1. Configurators now have a new method: `preview_output_axis`.
2. Action collects and displays the output axis of each configurator using the `show_output_prediction` slot.
3. Extra checks have been added to prevent the GUI from crashing when only a single frame is selected. A single frame is a valid choice for FramesConfigurator, but makes the InstrumentResolutionConfigurator fail.

**To test**
Load a trajectory into the GUI and select an analysis in the "Actions" tab.
Try changing the frames input and check if it affects the preview in the text field just above the "RUN" button.
