### PR TITLE
update IR jobs to use correlation frames

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
@@ -125,9 +125,7 @@ class DipoleAutoCorrelationFunction(IJob):
             for atm in molecule.atom_list:
                 idx = atm.index
                 q = self.configuration["atom_charges"]["charges"][idx]
-                dipoles[i] = q * (
-                    contiguous_configuration["coordinates"][idx, :] - com
-                )
+                dipoles[i] = q * (contiguous_configuration["coordinates"][idx, :] - com)
 
         n_configs = self.configuration["frames"]["n_configs"]
         mol_dacf = correlate(dipoles, dipoles[:n_configs], mode="valid") / (

--- a/MDANSE/Tests/UnitTests/Analysis/test_infrared.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_infrared.py
@@ -19,7 +19,7 @@ short_traj = os.path.join(
 def test_dacf_analysis():
     temp_name = tempfile.mktemp()
     parameters = {}
-    parameters["frames"] = (0, 100, 1)
+    parameters["frames"] = (0, 100, 1, 51)
     parameters["output_files"] = (temp_name, ("MDAFormat",))
     parameters["running_mode"] = ("single-core", 1)
     parameters["trajectory"] = short_traj
@@ -35,7 +35,7 @@ def test_dacf_analysis():
 def test_ir_analysis():
     temp_name = tempfile.mktemp()
     parameters = {}
-    parameters["frames"] = (0, 100, 1)
+    parameters["frames"] = (0, 100, 1, 51)
     parameters["instrument_resolution"] = ("Gaussian", {"sigma": 1.0, "mu": 0.0})
     parameters["output_files"] = (temp_name, ("MDAFormat",))
     parameters["running_mode"] = ("single-core", 1)


### PR DESCRIPTION
**Description of work**
Applied the correlation update IR jobs following #435. Here are some tests I did using a water trajectory.

dipole autocorrelation
Before 
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/3257d6f7-fb12-433e-a424-fc8931694c97)

After
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/04667c76-138c-43fd-8940-8cf897574768)

Infrared
- derivative dipole autocorrelation
Before 
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/8ab13899-d841-4f56-adaa-871ef3bb1d1c)
After
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/4ba43825-1c67-4251-bed6-081ef1ba075f)

- IR
Before
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/da3f70ba-e3ab-4983-8f10-291d975e36f9)
After
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/79fd8996-363a-4b7a-ba50-d3a324533fe1)

**To test**
Run all IR jobs and check that they are completed successfully.
