### PR TITLE
widget window fix

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -118,8 +118,14 @@ class Action(QWidget):
     def clear_panel(self) -> None:
         """Clear the widgets so that it leaves an empty layout"""
         for widget in self._widgets_in_layout:
-            widget.setParent(None)
             self.layout.removeWidget(widget)
+            # fixes #448
+            # even with the call to deleteLater sometimes the widget
+            # windows can pop up and then disappear we need to hide
+            # them first to make sure this doesn't happen
+            widget.hide()
+            widget.setParent(None)
+            widget.deleteLater()
         self._widgets = []
         self._widgets_in_layout = []
         self._preview_box = None


### PR DESCRIPTION
**Description of work**
Fixes the widget window bug. When the job selection is changed the widgets in that layout need to be deleted before the widgets of the new jobs are created and then added to the layout. This change makes sure that they get deleted.

**Fixes**
Closes #448 

**To test**
Load up a long trajectory and go to the jobs tab. Quickly switch between different jobs the bug seen in #448 should not occur. Run a job and load the results, everything should work correctly.
