### PR TITLE
Multiprocessing jobs

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -272,8 +272,6 @@ class IJob(Configurable, metaclass=SubclassFactory):
                         if not self._status._end_event.is_set():
                             return False
                 output = self.run_step(index)
-                if self._status is not None:
-                    self._status.update()
                 outputs.put(output)
 
         return True
@@ -304,6 +302,8 @@ class IJob(Configurable, metaclass=SubclassFactory):
         while inputQueue.qsize() > 0:
             if self._keep_running:
                 time.sleep(0.1)
+                if self._status is not None:
+                    self._status.fixed_status(outputQueue.qsize())
             else:
                 for p in self._processes:
                     p.terminate()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/JobStatus.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/JobStatus.py
@@ -80,6 +80,9 @@ class JobStatus(Status):
     def stop_status(self):
         pass
 
+    def fixed_status(self, current_progress: int):
+        pass
+
     def update_status(self):
         self._state["elapsed"] = self.elapsedTime
         self._state["current_step"] = self.currentStep

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -190,8 +190,6 @@ class MeanSquareDisplacement(IJob):
 
         self._outputData["msd_%s" % element] += result
 
-        IJob.combine(self)
-
     def finalize(self):
         """
         Finalizes the calculations (e.g. averaging the total term, output files creations ...).

--- a/MDANSE/Src/MDANSE/Framework/Status.py
+++ b/MDANSE/Src/MDANSE/Framework/Status.py
@@ -55,6 +55,10 @@ class Status(object, metaclass=abc.ABCMeta):
     def update_status(self):
         pass
 
+    @abc.abstractmethod
+    def fixed_status(self, current_progress: int):
+        pass
+
     @property
     def currentStep(self):
         return self._currentStep

--- a/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/JobState.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/JobState.py
@@ -75,6 +75,7 @@ class Running(JobState):
 
     def terminate(self):
         """Instructs the process to stop"""
+        self._parent._end_event.clear()
         self._parent._current_state = self._parent._Aborted
 
     def kill(self):
@@ -227,6 +228,7 @@ class Paused(JobState):
 
     def terminate(self):
         """Instructs the process to stop"""
+        self._parent._end_event.clear()
         self._parent._current_state = self._parent._Aborted
 
     def kill(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/JobStatusProcess.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/JobStatusProcess.py
@@ -94,3 +94,9 @@ class JobStatusProcess(Status):
         temp = int(self._progress_meter) * self._updateStep
         self._pipe.send(("STEP", temp))
         self._mutex.release()
+
+    def fixed_status(self, current_progress: int):
+        self._mutex.acquire()
+        temp = int(current_progress) * self._updateStep
+        self._pipe.send(("STEP", temp))
+        self._mutex.release()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/Subprocess.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/Subprocess.py
@@ -32,16 +32,28 @@ class Subprocess(Process):
         sending_pipe = kwargs.get("pipe")
         receiving_queue = kwargs.get("queue")
         pause_event = kwargs.get("pause_event")
-        self.construct_job(job_name, sending_pipe, receiving_queue, pause_event)
+        end_event = kwargs.get("end_event")
+        self.construct_job(
+            job_name, sending_pipe, receiving_queue, pause_event, end_event
+        )
 
     def construct_job(
-        self, job: str, pipe: Connection, queue: "Queue", pause_event: "Event"
+        self,
+        job: str,
+        pipe: Connection,
+        queue: "Queue",
+        pause_event: "Event",
+        end_event: "Event",
     ):
         job_instance = IJob.create(job)
         job_instance.build_configuration()
-        status = JobStatusProcess(pipe, queue, pause_event)
+        status = JobStatusProcess(pipe, queue, pause_event, end_event)
         job_instance._status = status
         self._job_instance = job_instance
 
     def run(self):
         self._job_instance.run(self._job_parameters)
+
+    def terminate(self) -> None:
+        self._job_instance.terminate()
+        return super().terminate()

--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -23,6 +23,8 @@ from qtpy.QtGui import QPixmap, QIcon
 
 from MDANSE_GUI.TabbedWindow import TabbedWindow
 
+os.environ["OMP_NUM_THREADS"] = "1"
+
 
 def startGUI(some_args):
     app = QApplication(some_args)


### PR DESCRIPTION
**Description of work**
At the moment, multicore jobs work, but do not report progress correctly, and cannot be aborted from the GUI.
This PR adds a mechanism for aborting multicore jobs, and changes the way progress is reported for multicore jobs.

closes #447 
closes #361 

**Fixes**
1. Added an extra Event (end_event) to the JobStatus. This is checked by a running job, and can be used to abort a job
2. Added a new method to Status, which allows a Job to report progress directly from the main thread and not from subprocesses. The progress is now the size of the output queue.
3. Set OMP_NUM_THREADS to 1 in the GUI launcher, suppressing numpy multithreading.

**To test**
Run a job using multiple cores. Check if the progress is updated correctly.
Run a long job using multiple cores. Abort it before it finishes, and confirm that every child process terminates eventually, without being killed manually by the user. (For slower jobs this may take some time, but should happen eventually).
