### PR TITLE
Pair distribution function with supercell setting

### DIFF
--- a/MDANSE/Extensions/.gitignore
+++ b/MDANSE/Extensions/.gitignore
@@ -1,4 +1,6 @@
 /*.c
 /*.cpp
+/*.html
 /xtc/xtc.c
 /xtc/trr.c
+/xtc/*.html

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DistanceHistogram.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DistanceHistogram.py
@@ -54,9 +54,9 @@ class DistanceHistogram(IJob):
             "mini": 0.0,
         },
     )
-    settings["pbc"] = (
+    settings["supercell"] = (
         "BooleanConfigurator",
-        {"label": "apply periodic boundary conditions", "default": False},
+        {"label": "create supercell", "default": False},
     )
     settings["atom_selection"] = (
         "AtomSelectionConfigurator",
@@ -173,7 +173,7 @@ class DistanceHistogram(IJob):
         mol_idxs = self.indexToMolecule
         sym_idxs = self.indexToSymbol
 
-        if self.configuration["pbc"]["value"]:
+        if self.configuration["supercell"]["value"]:
             rs, direct, inverse, mol_idxs, sym_idxs = create_supercell(
                 rs,
                 direct,

--- a/MDANSE/Src/MDANSE/MolecularDynamics/UnitCell.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/UnitCell.py
@@ -166,8 +166,6 @@ def get_expansions(direct, cutoff) -> tuple[int, int, int]:
     tuple[int, int, int]
         A tuple of supercell expansions.
     """
-    cutoff += np.linalg.norm(np.sum(direct, axis=0))
-
     vec_a, vec_b, vec_c = direct
     a = np.linalg.norm(vec_a)
     b = np.linalg.norm(vec_b)
@@ -182,16 +180,18 @@ def get_expansions(direct, cutoff) -> tuple[int, int, int]:
     vec_k = vecs[k]
 
     # expand with the longest vector
-    max_i = math.ceil(abs(cutoff / lens[i]))
+    max_i = math.ceil((cutoff + 0.5 * lens[i]) / lens[i])
 
     # expand with the second-longest vector
     oproj = vec_j - vec_i * (vec_j @ vec_i) / (vec_i @ vec_i)
-    max_j = math.ceil(abs(cutoff / np.linalg.norm(oproj)))
+    mag_o = np.linalg.norm(oproj)
+    max_j = math.ceil((cutoff + 0.5 * mag_o) / np.linalg.norm(oproj))
 
     # expand with the smallest vector
     cross_ij = np.cross(vec_i, vec_j)
     proj = cross_ij * (vec_k @ cross_ij) / (cross_ij @ cross_ij)
-    max_k = math.ceil(abs(cutoff / np.linalg.norm(proj)))
+    mag_p = np.linalg.norm(proj)
+    max_k = math.ceil((cutoff + 0.5 * mag_p) / np.linalg.norm(proj))
 
     maxs = sorted(zip([max_i, max_j, max_k], [i, j, k]), key=lambda x: x[1])
     return maxs[0][0], maxs[1][0], maxs[2][0]

--- a/MDANSE/Tests/UnitTests/test_unit_cell.py
+++ b/MDANSE/Tests/UnitTests/test_unit_cell.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
+from MDANSE.MolecularDynamics.UnitCell import get_expansions
 
 
 class TestUnitCell(unittest.TestCase):
@@ -89,3 +90,53 @@ class TestUnitCell(unittest.TestCase):
 
     def test_volume(self):
         self.assertAlmostEqual(1, self.cell.volume)
+
+
+def test_get_expansions_0():
+    direct_matrix = np.array([
+        [1, 0, 0],
+        [0, 2, 0],
+        [0, 0, 2],
+    ]
+    )
+    assert (10, 5, 5) == get_expansions(direct_matrix, 10 - 3)
+
+
+def test_get_expansions_1():
+    direct_matrix = np.array([
+        [2, 0, 0],
+        [0, 10, 0],
+        [0, 0, 11],
+    ]
+    )
+    assert (15, 3, 3) == get_expansions(direct_matrix, 30 - 15)
+
+
+def test_get_expansions_2():
+    direct_matrix = np.array([
+        [2, 0, 0],
+        [0, 0, 11],
+        [0, 10, 0],
+    ]
+    )
+    assert (15, 3, 3) == get_expansions(direct_matrix, 30 - 15)
+
+
+def test_get_expansions_3():
+    direct_matrix = np.array([
+        [0, 0, 11],
+        [2, 0, 0],
+        [0, 10, 0],
+    ]
+    )
+    assert (3, 15, 3) == get_expansions(direct_matrix, 30 - 15)
+
+
+def test_get_expansions_4():
+    direct_matrix = np.array([
+        [0, 0, 11],
+        [0, 10, 0],
+        [2, 0, 0],
+    ]
+    )
+    assert (3, 3, 15) == get_expansions(direct_matrix, 30 - 15)

--- a/MDANSE/Tests/UnitTests/test_unit_cell.py
+++ b/MDANSE/Tests/UnitTests/test_unit_cell.py
@@ -99,7 +99,7 @@ def test_get_expansions_0():
         [0, 0, 2],
     ]
     )
-    assert (11, 6, 6) == get_expansions(direct_matrix, 10)
+    assert (20, 10, 10) == get_expansions(direct_matrix, 10)
 
 
 def test_get_expansions_1():
@@ -109,7 +109,7 @@ def test_get_expansions_1():
         [0, 0, 11],
     ]
     )
-    assert (16, 4, 4) == get_expansions(direct_matrix, 30)
+    assert (30, 6, 6) == get_expansions(direct_matrix, 30)
 
 
 def test_get_expansions_2():
@@ -119,7 +119,7 @@ def test_get_expansions_2():
         [0, 10, 0],
     ]
     )
-    assert (16, 4, 4) == get_expansions(direct_matrix, 30)
+    assert (30, 6, 6) == get_expansions(direct_matrix, 30)
 
 
 def test_get_expansions_3():
@@ -129,7 +129,7 @@ def test_get_expansions_3():
         [0, 10, 0],
     ]
     )
-    assert (4, 16, 4) == get_expansions(direct_matrix, 30)
+    assert (6, 30, 6) == get_expansions(direct_matrix, 30)
 
 
 def test_get_expansions_4():
@@ -139,4 +139,4 @@ def test_get_expansions_4():
         [2, 0, 0],
     ]
     )
-    assert (4, 4, 16) == get_expansions(direct_matrix, 30)
+    assert (6, 6, 30) == get_expansions(direct_matrix, 30)

--- a/MDANSE/Tests/UnitTests/test_unit_cell.py
+++ b/MDANSE/Tests/UnitTests/test_unit_cell.py
@@ -99,7 +99,7 @@ def test_get_expansions_0():
         [0, 0, 2],
     ]
     )
-    assert (10, 5, 5) == get_expansions(direct_matrix, 10 - 3)
+    assert (11, 6, 6) == get_expansions(direct_matrix, 10)
 
 
 def test_get_expansions_1():
@@ -109,7 +109,7 @@ def test_get_expansions_1():
         [0, 0, 11],
     ]
     )
-    assert (15, 3, 3) == get_expansions(direct_matrix, 30 - 15)
+    assert (16, 4, 4) == get_expansions(direct_matrix, 30)
 
 
 def test_get_expansions_2():
@@ -119,7 +119,7 @@ def test_get_expansions_2():
         [0, 10, 0],
     ]
     )
-    assert (15, 3, 3) == get_expansions(direct_matrix, 30 - 15)
+    assert (16, 4, 4) == get_expansions(direct_matrix, 30)
 
 
 def test_get_expansions_3():
@@ -129,7 +129,7 @@ def test_get_expansions_3():
         [0, 10, 0],
     ]
     )
-    assert (3, 15, 3) == get_expansions(direct_matrix, 30 - 15)
+    assert (4, 16, 4) == get_expansions(direct_matrix, 30)
 
 
 def test_get_expansions_4():
@@ -139,4 +139,4 @@ def test_get_expansions_4():
         [2, 0, 0],
     ]
     )
-    assert (3, 3, 15) == get_expansions(direct_matrix, 30 - 15)
+    assert (4, 4, 16) == get_expansions(direct_matrix, 30)


### PR DESCRIPTION
**Description of work**
Updated the pair distribution function job so that it creates a supercell for large r values. The previous version of the pair distribution function used PBC however it only added the closest distance for a given pair of atoms. I've left the default of this setting to false since it can make the calculation expensive for large values of r. With this update, you now have the option to let MDANSE generate a supercell so that it adds the distances between a given pair of atoms including its periodic images out to the cutoff radius.

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/1892acda-649b-4789-9d2d-e24df94f0b48)

Here are some comparisons. I used a trajectory that has a cubic unit cell of ~1.8 nm. The sharp peaks are due to the atoms and the periodic images of itself. In the example below we have a peak at ~1.8 and ~sqrt(2) * 1.8.

**PDF**
Without supercell
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/59d0e8a1-38b4-4973-bd2f-124854a495f9)

With supercell
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/78a4baef-5f41-4cf3-b670-ebd35ec85793)

**RDF**
Without supercell
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/c71645df-df70-4be7-8b04-7736630ca3db)

With supercell
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/31368e88-b3f3-47db-961d-83fb22913ecd)

**TCF**
Without supercell
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/600b64d8-247c-41c3-9c7e-c149bbbcf32d)

With supercell
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/8ee8840f-229c-49a7-bd33-5045044a2979)


**Fixes**
Fixes #431

**To test**
You will need to rebuild MDANSE when testing since some cython code was updated.

Try running the pair distribution function job with and without the supercell setting. Both should finish successfully without issues. Without supercell, results should be the same as the previous version. 

With supercell, results should be the same except for longer ranges. Check that the correct long-range behaviors are seen e.g.  PDF goes to 1 at long distances.

NOTE: with very large r values (r > 3) it will take quite some time since there will be a lot of distance calculations. 


