### PR TITLE
Change EISF weight default

### DIFF
--- a/Doc/pages/scattering.rst
+++ b/Doc/pages/scattering.rst
@@ -606,7 +606,7 @@ one can write:
 .. math::
    :label: pfx101
 
-   {\mathit{EISF}{(q) = b_{\text{inc}}^{2{\int d^{3}}}}r\exp\left\lbrack {\mathit{iq}\cdot r} \right\rbrack G_{s}\left( {r,{t = \infty}} \right).}
+   {\mathit{EISF}(q) = b_{\text{inc}}^{2}{\int d^{3}}r\exp\left\lbrack {\mathit{iq}\cdot r} \right\rbrack G_{s}\left( {r,{t = \infty}} \right).}
 
 The *EISF* gives the sampling distribution of the points in space in the
 limit of infinite time. In a real experiment this means times longer

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -83,7 +83,7 @@ class ElasticIncoherentStructureFactor(IJob):
     settings["weights"] = (
         "WeightsConfigurator",
         {
-            "default": "b_incoherent",
+            "default": "b_incoherent2",
             "dependencies": {"atom_selection": "atom_selection"},
         },
     )


### PR DESCRIPTION
**Description of work**
Currently the default weight for EISF is b_incoherent. According to https://mdanse.readthedocs.io/en/protos/pages/scattering.html#elastic-incoherent-structure-factor

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/e6a38430-f8ce-45e4-b4d1-7d55f21c29d7)

and 

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/ceeceac8-1698-4913-8b0b-d17396329f26)

therefore the default weight should be b_incoherent2.

**To test**
Check that the default weight for EISF is b_incoherent2.
