### PR TITLE
Scattering correlation update 1

### DIFF
--- a/MDANSE/Extensions/.gitignore
+++ b/MDANSE/Extensions/.gitignore
@@ -1,4 +1,6 @@
 /*.c
 /*.cpp
+/*.html
 /xtc/xtc.c
 /xtc/trr.c
+/xtc/*.html

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -228,7 +228,9 @@ class DynamicIncoherentStructureFactor(IJob):
             qVectors = self.configuration["q_vectors"]["value"][q]["q_vectors"]
 
             rho = np.exp(1j * np.dot(series, qVectors))
-            res = correlate(rho, rho[:n_configs], mode="valid").T[0] / n_configs
+            res = correlate(rho, rho[:n_configs], mode="valid").T[0] / (
+                n_configs * qVectors.shape[1]
+            )
 
             disf_per_q_shell[q] += res.real
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -17,11 +17,11 @@
 import collections
 
 import numpy as np
-
+from scipy.signal import correlate
 
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import weight
-from MDANSE.Mathematics.Signal import correlation, get_spectrum
+from MDANSE.Mathematics.Signal import get_spectrum
 from MDANSE.MolecularDynamics.TrajectoryUtils import sorted_atoms
 
 
@@ -43,7 +43,7 @@ class DynamicIncoherentStructureFactor(IJob):
     settings = collections.OrderedDict()
     settings["trajectory"] = ("HDFTrajectoryConfigurator", {})
     settings["frames"] = (
-        "FramesConfigurator",
+        "CorrelationFramesConfigurator",
         {"dependencies": {"trajectory": "trajectory"}},
     )
     settings["instrument_resolution"] = (
@@ -107,7 +107,7 @@ class DynamicIncoherentStructureFactor(IJob):
 
         self._nQShells = self.configuration["q_vectors"]["n_shells"]
 
-        self._nFrames = self.configuration["frames"]["number"]
+        self._nFrames = self.configuration["frames"]["n_frames"]
 
         self._instrResolution = self.configuration["instrument_resolution"]
 
@@ -223,13 +223,14 @@ class DynamicIncoherentStructureFactor(IJob):
         for q in self.configuration["q_vectors"]["shells"]:
             disf_per_q_shell[q] = np.zeros((self._nFrames,), dtype=np.float64)
 
+        n_configs = self.configuration["frames"]["n_configs"]
         for q in self.configuration["q_vectors"]["shells"]:
             qVectors = self.configuration["q_vectors"]["value"][q]["q_vectors"]
 
             rho = np.exp(1j * np.dot(series, qVectors))
-            res = correlation(rho, axis=0, average=1)
+            res = correlate(rho, rho[:n_configs], mode="valid").T[0] / n_configs
 
-            disf_per_q_shell[q] += res
+            disf_per_q_shell[q] += res.real
 
         return index, disf_per_q_shell
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -42,7 +42,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
     settings = collections.OrderedDict()
     settings["trajectory"] = ("HDFTrajectoryConfigurator", {})
     settings["frames"] = (
-        "FramesConfigurator",
+        "CorrelationFramesConfigurator",
         {"dependencies": {"trajectory": "trajectory"}},
     )
     settings["q_shells"] = (
@@ -102,7 +102,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
 
         self._nQShells = self.configuration["q_shells"]["number"]
 
-        self._nFrames = self.configuration["frames"]["number"]
+        self._nFrames = self.configuration["frames"]["n_frames"]
 
         self._instrResolution = self.configuration["instrument_resolution"]
 
@@ -210,7 +210,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
 
         atomicSF = np.zeros((self._nQShells, self._nFrames), dtype=np.float64)
 
-        msd = mean_square_displacement(series)
+        msd = mean_square_displacement(series, self.configuration["frames"]["n_configs"])
 
         for i, q2 in enumerate(self._kSquare):
             gaussian = np.exp(-msd * q2 / 6.0)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -210,7 +210,9 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
 
         atomicSF = np.zeros((self._nQShells, self._nFrames), dtype=np.float64)
 
-        msd = mean_square_displacement(series, self.configuration["frames"]["n_configs"])
+        msd = mean_square_displacement(
+            series, self.configuration["frames"]["n_configs"]
+        )
 
         for i, q2 in enumerate(self._kSquare):
             gaussian = np.exp(-msd * q2 / 6.0)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -165,7 +165,9 @@ class MeanSquareDisplacement(IJob):
 
         series = self.configuration["projection"]["projector"](series)
 
-        msd = mean_square_displacement(series, self.configuration["frames"]["n_configs"])
+        msd = mean_square_displacement(
+            series, self.configuration["frames"]["n_configs"]
+        )
 
         return index, msd
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -16,9 +16,7 @@
 
 import collections
 
-import numpy as np
-from scipy.signal import correlate
-
+from MDANSE.MolecularDynamics.Analysis import mean_square_displacement
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import weight
 from MDANSE.MolecularDynamics.TrajectoryUtils import sorted_atoms
@@ -167,13 +165,7 @@ class MeanSquareDisplacement(IJob):
 
         series = self.configuration["projection"]["projector"](series)
 
-        n_configs = self.configuration["frames"]["n_configs"]
-
-        r2 = series * series
-        window = np.ones((n_configs, 3))
-        r2t = correlate(r2, window, mode="valid").T[0] / n_configs
-        rtr0 = correlate(series, series[:n_configs], mode="valid").T[0] / n_configs
-        msd = r2t[0] + r2t - 2 * rtr0
+        msd = mean_square_displacement(series, self.configuration["frames"]["n_configs"])
 
         return index, msd
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_qvectors.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_qvectors.py
@@ -30,7 +30,7 @@ def test_disf(trajectory):
     parameters = {}
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
-    parameters["frames"] = (0, 10, 1)
+    parameters["frames"] = (0, 10, 1, 5)
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["output_files"] = (temp_name, ("MDAFormat",))
     parameters["running_mode"] = ("single-core",)

--- a/MDANSE/Tests/UnitTests/Analysis/test_resolutions.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_resolutions.py
@@ -31,7 +31,7 @@ def test_disf(trajectory):
     parameters = {}
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
-    parameters["frames"] = (0, 10, 1)
+    parameters["frames"] = (0, 10, 1, 5)
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",

--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -60,7 +60,7 @@ def disf():
     parameters = {}
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
-    parameters["frames"] = (0, 10, 1)
+    parameters["frames"] = (0, 10, 1, 10)
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["output_files"] = (temp_name, ("MDAFormat",))
     parameters["q_vectors"] = (
@@ -122,7 +122,7 @@ def test_disf(trajectory, qvector_spherical_lattice):
     parameters = {}
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
-    parameters["frames"] = (0, 10, 1)
+    parameters["frames"] = (0, 10, 1, 5)
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice
@@ -165,7 +165,7 @@ def test_gdisf(trajectory):
     parameters = {}
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
-    parameters["frames"] = (0, 10, 1)
+    parameters["frames"] = (0, 10, 1, 5)
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     parameters["q_shells"] = (2.0, 12.2, 2.0)

--- a/MDANSE/Tests/UnitTests/test_analysis.py
+++ b/MDANSE/Tests/UnitTests/test_analysis.py
@@ -37,7 +37,7 @@ class TestAnalysis(unittest.TestCase):
 
     def test_mean_square_displacement(self):
         coords = np.array([[1, 1, 1], [2, 1, 1], [3, 1, 1]])
-        msd = mean_square_displacement(coords)
+        msd = mean_square_displacement(coords, 1)
         self.assertTrue(np.allclose([0.0, 1.0, 4.0], msd), f"\nactual = {msd}")
 
     def test_mean_square_fluctuation_no_root(self):


### PR DESCRIPTION
**Description of work**
Updated dynamic incoherent structure factor and Gaussian dynamic incoherent structure factor jobs to use the correlation method following #435. 

cp2k water trajectory comparison.

DISF (sphericalqvectors) 
Before
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/99f92254-9347-45b5-9955-4d84b24641c1)
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/b58a59e5-842f-404f-9cdc-01daf7e6b4f3)


After
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/60b7cde9-02a4-4202-9774-0d6690d40f87)
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/5389d498-b0c8-4484-ad2e-740d33543535)



GDISF (MSD is linear for long times so GDISF should go something like exp(-x))
Before
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/dd65f5a7-02e1-4148-89f2-62c64c49b73e)
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/a066514b-b914-4f91-931b-502650e170d0)


After 
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/387e308d-df88-48ef-82e6-99036ebcfae9)
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/ee318d42-2d33-4a50-8b0e-8f5d8c881704)

**To test**
Run dynamic incoherent structure factor and Gaussian incoherent structure factor jobs and check they are working as expected.
