### PR TITLE
Improve GUI layout

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
@@ -14,9 +14,9 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from qtpy.QtWidgets import QLineEdit, QComboBox, QLabel, QTableView
+from qtpy.QtWidgets import QSizePolicy, QComboBox, QLabel, QTableView
 from qtpy.QtCore import Slot, Signal, Qt
-from qtpy.QtGui import QIntValidator, QStandardItemModel, QStandardItem, QBrush
+from qtpy.QtGui import QStandardItemModel, QStandardItem, QBrush
 
 from MDANSE.Framework.QVectors.IQVectors import IQVectors
 
@@ -120,6 +120,9 @@ class QVectorsWidget(WidgetBase):
             "The q vectors will be generated using the method chosen here."
         )
         self._model.input_is_valid.connect(self.validate_model_parameters)
+        policy = self._view.sizePolicy()
+        policy.setVerticalPolicy(QSizePolicy.Policy.Minimum)
+        self._view.setSizePolicy(policy)
 
     @Slot(bool)
     def validate_model_parameters(self, all_are_correct: bool):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
@@ -123,6 +123,7 @@ class QVectorsWidget(WidgetBase):
         policy = self._view.sizePolicy()
         policy.setVerticalPolicy(QSizePolicy.Policy.Minimum)
         self._view.setSizePolicy(policy)
+        self._view.horizontalHeader().hide()
 
     @Slot(bool)
     def validate_model_parameters(self, all_are_correct: bool):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
@@ -94,6 +94,7 @@ class QVectorsWidget(WidgetBase):
     def __init__(self, *args, **kwargs):
         kwargs["layout_type"] = "QVBoxLayout"
         super().__init__(*args, **kwargs)
+        self._relative_size = 3
         trajectory_configurator = kwargs.get("trajectory_configurator", None)
         chemical_system = None
         if trajectory_configurator is not None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
@@ -36,6 +36,7 @@ class WidgetBase(QObject):
         parent = kwargs.get("parent", None)
         super().__init__(*args, parent=parent)
         self._value = None
+        self._relative_size = 1
         self._label_text = kwargs.get("label", "")
         self._tooltip = kwargs.pop("tooltip", "")
         self._base_type = kwargs.get("base_type", "QGroupBox")

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/ConverterTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/ConverterTab.py
@@ -29,8 +29,9 @@ from MDANSE_GUI.Tabs.Views.ActionsTree import ActionsTree
 
 
 tab_label = """Convert your trajectory to the MDANSE MDT format.
-If you cannot find the converter for your MD engine, the
-ASE converter can be tried as a backup option.
+If you cannot find a dedciated converter
+for your MD engine, the ASE converter
+can be tried as a backup option.
 """
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
@@ -26,9 +26,11 @@ from MDANSE_GUI.Tabs.Models.JobTree import JobTree
 from MDANSE_GUI.Tabs.Views.ActionsTree import ActionsTree
 
 
-job_tab_label = """This is the list of jobs you can run using MDANSE.
+job_tab_label = """This is the list of jobs
+you can run using MDANSE.
 Pick a job to see additional information.
-Use the button to start a job.
+Use the button to start a job,
+or to save the inputs as a script.
 """
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Layouts/DoublePanel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Layouts/DoublePanel.py
@@ -73,6 +73,9 @@ class DoublePanel(QWidget):
         scroll_area_right.setWidgetResizable(True)
         rightlayout = QVBoxLayout(rightside)
         rightside.setLayout(rightlayout)
+        rpolicy = rightside.sizePolicy()
+        rpolicy.setHorizontalStretch(2)
+        rightside.setSizePolicy(rpolicy)
 
         self._splitter.addWidget(scroll_area_left)
         self._splitter.addWidget(scroll_area_right)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Layouts/DoublePanel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Layouts/DoublePanel.py
@@ -73,9 +73,6 @@ class DoublePanel(QWidget):
         scroll_area_right.setWidgetResizable(True)
         rightlayout = QVBoxLayout(rightside)
         rightside.setLayout(rightlayout)
-        rpolicy = rightside.sizePolicy()
-        rpolicy.setHorizontalStretch(2)
-        rightside.setSizePolicy(rpolicy)
 
         self._splitter.addWidget(scroll_area_left)
         self._splitter.addWidget(scroll_area_right)
@@ -105,6 +102,9 @@ class DoublePanel(QWidget):
             self._rightlayout.addWidget(visualiser_side)
             if self._view is not None:
                 self._view.connect_to_visualiser(visualiser_side)
+
+        self._splitter.setStretchFactor(0, 1)
+        self._splitter.setStretchFactor(1, 2)
 
     def connect_logging(self):
         self.error.connect(self._tab_reference.error)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/TrajectoryTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/TrajectoryTab.py
@@ -32,9 +32,12 @@ from MDANSE_GUI.MolecularViewer.MolecularViewer import MolecularViewer
 
 
 label_text = """Here you can load the .mdt files.
-They are MD trajectories in HDF5 format created by one of the MDANSE converters.
-You can select trajectories. They will be visualised in the 3D view window.
-The animation of the MD trajectory will allow you to verify if the contents 
+They are MD trajectories in HDF5 format
+created by one of the MDANSE converters.
+Any trajectory you select will be visualised
+in the 3D view window on the right side.
+The animation of the MD trajectory will
+allow you to verify if the contents 
 of the trajectory are what you expected.
 """
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -165,7 +165,7 @@ class Action(QWidget):
             widget_class = widget_lookup[dtype]
             input_widget = widget_class(parent=self, **ddict)
             widget = input_widget._base
-            self.layout.addWidget(widget)
+            self.layout.addWidget(widget, stretch=widget._relative_size)
             self._widgets_in_layout.append(widget)
             self._widgets.append(input_widget)
             self._trajectory_configurator = input_widget._configurator
@@ -187,7 +187,7 @@ class Action(QWidget):
                 )
                 placeholder = BackupWidget(parent=self, **ddict)
                 widget = placeholder._base
-                self.layout.addWidget(widget)
+                self.layout.addWidget(widget, stretch=widget._relative_size)
                 self._widgets_in_layout.append(widget)
                 self._widgets.append(placeholder)
                 print(f"Could not find the right widget for {key}")
@@ -196,7 +196,7 @@ class Action(QWidget):
                 # expected = {key: ddict[key] for key in widget_class.__init__.__code__.co_varnames}
                 input_widget = widget_class(parent=self, **ddict)
                 widget = input_widget._base
-                self.layout.addWidget(widget)
+                self.layout.addWidget(widget, stretch=widget._relative_size)
                 self._widgets_in_layout.append(widget)
                 self._widgets.append(input_widget)
                 input_widget.valid_changed.connect(self.allow_execution)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -165,7 +165,7 @@ class Action(QWidget):
             widget_class = widget_lookup[dtype]
             input_widget = widget_class(parent=self, **ddict)
             widget = input_widget._base
-            self.layout.addWidget(widget, stretch=widget._relative_size)
+            self.layout.addWidget(widget, stretch=input_widget._relative_size)
             self._widgets_in_layout.append(widget)
             self._widgets.append(input_widget)
             self._trajectory_configurator = input_widget._configurator
@@ -187,7 +187,7 @@ class Action(QWidget):
                 )
                 placeholder = BackupWidget(parent=self, **ddict)
                 widget = placeholder._base
-                self.layout.addWidget(widget, stretch=widget._relative_size)
+                self.layout.addWidget(widget, stretch=placeholder._relative_size)
                 self._widgets_in_layout.append(widget)
                 self._widgets.append(placeholder)
                 print(f"Could not find the right widget for {key}")
@@ -196,7 +196,7 @@ class Action(QWidget):
                 # expected = {key: ddict[key] for key in widget_class.__init__.__code__.co_varnames}
                 input_widget = widget_class(parent=self, **ddict)
                 widget = input_widget._base
-                self.layout.addWidget(widget, stretch=widget._relative_size)
+                self.layout.addWidget(widget, stretch=input_widget._relative_size)
                 self._widgets_in_layout.append(widget)
                 self._widgets.append(input_widget)
                 input_widget.valid_changed.connect(self.allow_execution)


### PR DESCRIPTION
**Description of work**
Cosmetic changes which should give the users a better starting point when they launch a new GUI.

**Fixes**
1. In each tab, the right panel is now larger than the left panel. The main advantage is that the 3D view of the trajectory is now larger.
2. The parameter table in the QVectorsWidget is now given more space, so that all the rows can be seen simultaneously.

**To test**
Start the GUI and load a trajectory.
Pick a scattering analysis (e.g. DISF) and check the size of the QVectorsWidget.
