### PR TITLE
Disable jobs with no atoms selected

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomSelectionConfigurator.py
@@ -79,7 +79,11 @@ class AtomSelectionConfigurator(IConfigurator):
             [ATOMS_DATABASE.get_atom_property(n, "atomic_weight")]
             for n in self["names"]
         ]
-        self.error_status = "OK"
+        if self["selection_length"] == 0:
+            self.error_status = "The atom selection is empty."
+            return
+        else:
+            self.error_status = "OK"
 
     def get_natoms(self) -> dict[str, int]:
         """

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -147,7 +147,10 @@ class JobEntry(QObject):
     @Slot(int)
     def on_update(self, completed_steps: int):
         # print(f"completed {completed_steps} out of {self.total_steps} steps")
-        self.percent_complete = round(99 * completed_steps / self.total_steps, 1)
+        if self.total_steps > 0:
+            self.percent_complete = round(99 * completed_steps / self.total_steps, 1)
+        else:
+            self.percent_complete = 0
         self.update_fields()
         self._prog_item.emitDataChanged()
 


### PR DESCRIPTION
**Description of work**
Fixes the problem of the GUI crashing when starting a job with total_steps=0.

closes #461 

**Fixes**
1. Added a check in JobHolder before dividing by 'total_steps'.
2. AtomSelectionConfigurator becomes invalid if the selection is empty.

**To test**
Load a trajectory, pick an analysis and deselect all the atoms. The widget should become invalid, and the "run" button inactive.
