### PR TITLE
Average structure analysis

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputStructureConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputStructureConfigurator.py
@@ -1,0 +1,127 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import os
+import tempfile
+
+from ase.io.formats import ioformats
+
+from MDANSE import PLATFORM
+from MDANSE.Framework.Configurators.IConfigurator import (
+    IConfigurator,
+    ConfiguratorError,
+)
+from MDANSE.Framework.Formats.IFormat import IFormat
+
+
+class OutputStructureConfigurator(IConfigurator):
+    """
+    This configurator allows to define the output directory, the basename, and the format(s) of the output file(s)
+    resulting from an analysis.
+
+    Once configured, this configurator will provide a list of files built by joining the given output directory, the
+    basename and the extensions corresponding to the input file formats.
+
+    For analysis, MDANSE currently supports only the HDF and Text formats. To define a new output file format
+    for an analysis, you must inherit from MDANSE.Framework.Formats.IFormat.IFormat interface.
+    """
+
+    _default = ("OUTPUT_FILENAME", "vasp")
+    _label = "Output filename and format (filename, format)"
+
+    def __init__(self, name, formats=None, **kwargs):
+        """
+        Initializes the configurator.
+
+        :param name: the name of the configurator as it will appear in the configuration.
+        :type name: str
+        :param formats: the list of output file formats supported.
+        :type formats: list of str
+        """
+
+        IConfigurator.__init__(self, name, **kwargs)
+
+        self._formats = [fmt for fmt in ioformats if ioformats[fmt].can_write]
+
+    def configure(self, value):
+        """
+        Configure a set of output files for an analysis.
+
+        :param value: the output files specifications. Must be a 3-tuple whose 1st element \
+        is the output directory, 2nd element the basename and 3rd element a list of file formats.
+        :type value: 3-tuple
+        """
+        self._original_input = value
+
+        root, format = value
+
+        if not root:
+            self.error_status = "empty root name for the output file."
+            return
+
+        dirname = os.path.dirname(root)
+
+        try:
+            PLATFORM.create_directory(dirname)
+        except:
+            self.error_status = f"the directory {dirname} is not writable"
+            return
+
+        if not format in self.formats:
+            self.error_status = f"Output format is not supported"
+            return
+
+        self["root"] = root
+        self["format"] = format
+        self["file"] = root
+
+        self["value"] = self["file"]
+        self.error_status = "OK"
+
+    @property
+    def formats(self):
+        """
+        Returns the list of output file formats supported.
+
+        :return: the list of file formats supported.
+        :rtype: list of str
+        """
+        return self._formats
+
+    def get_information(self):
+        """
+        Returns string information about this configurator.
+
+        :return: the information about this configurator.
+        :rtype: str
+        """
+        if not "file" in self:
+            return "Output File have not been defined"
+
+        info = f"Output file: {self['file']}\n"
+
+        return info
+
+    @property
+    def default(self) -> tuple[str, str]:
+        """
+
+        Returns
+        -------
+        tuple[str, str]
+            A tuple of the default filename and format.
+        """
+        return self._default[0], self._default[1]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
@@ -1,0 +1,152 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import collections
+
+import numpy as np
+from ase.io import write as ase_write
+from ase.atoms import Atoms, Atom
+
+from MDANSE.Framework.Units import measure
+from MDANSE.MolecularDynamics.TrajectoryUtils import sorted_atoms
+from MDANSE.Framework.Jobs.IJob import IJob
+
+
+class AverageStructure(IJob):
+    """
+    Outputs a single structure file containing the atom positions
+    averaged over time. Only makes sense for crystalline systems
+    where atoms remain within a finite distance around their
+    equilibrium positions.
+    """
+
+    label = "Average Structure"
+
+    category = (
+        "Analysis",
+        "Structure",
+    )
+
+    ancestor = ["hdf_trajectory", "molecular_viewer"]
+
+    settings = collections.OrderedDict()
+    settings["trajectory"] = ("HDFTrajectoryConfigurator", {})
+    settings["frames"] = (
+        "FramesConfigurator",
+        {"dependencies": {"trajectory": "trajectory"}, "default": (0, 1, 1)},
+    )
+    settings["atom_selection"] = (
+        "AtomSelectionConfigurator",
+        {"dependencies": {"trajectory": "trajectory"}},
+    )
+    settings["output_units"] = (
+        "SingleChoiceConfigurator",
+        {
+            "label": "Distance units of the output",
+            "choices": ["Angstrom", "Bohr", "nm", "pm"],
+            "default": "Angstrom",
+        },
+    )
+    settings["output_file"] = (
+        "OutputStructureConfigurator",
+        {"format": "vasp"},
+    )
+
+    def initialize(self):
+        """
+        Initialize the input parameters and analysis self variables
+        """
+
+        self.numberOfSteps = self.configuration["atom_selection"]["selection_length"]
+
+        self._atoms = sorted_atoms(
+            self.configuration["trajectory"]["instance"].chemical_system.atom_list
+        )
+
+        target_unit = self.configuration["output_units"]["value"]
+        if target_unit == "Angstrom":
+            target_unit = "ang"
+
+        self._conversion_factor = measure(1.0, "nm").toval(target_unit)
+
+        self._ase_atoms = Atoms()
+
+    def run_step(self, index):
+        """
+        Runs a single step of the job.
+
+        Args:
+            index (int): the index of the step
+
+        Returns:
+            tuple: the result of the step
+        """
+
+        # get selected atom indexes sublist
+        indexes = self.configuration["atom_selection"]["indexes"][index]
+        if len(indexes) == 1:
+            series = self.configuration["trajectory"][
+                "instance"
+            ].read_atomic_trajectory(
+                indexes[0],
+                first=self.configuration["frames"]["first"],
+                last=self.configuration["frames"]["last"] + 1,
+                step=self.configuration["frames"]["step"],
+            )
+
+        else:
+            selected_atoms = [self._atoms[idx] for idx in indexes]
+            series = self.configuration["trajectory"]["instance"].read_com_trajectory(
+                selected_atoms,
+                first=self.configuration["frames"]["first"],
+                last=self.configuration["frames"]["last"] + 1,
+                step=self.configuration["frames"]["step"],
+            )
+
+        return index, np.mean(series, axis=0) * self._conversion_factor
+
+    def combine(self, index, x):
+        # The symbol of the atom.
+        element = self.configuration["atom_selection"]["names"][index]
+
+        the_atom = Atom(element, x)
+
+        self._ase_atoms.append(the_atom)
+
+    def finalize(self):
+        """
+        Finalizes the calculations (e.g. averaging the total term, output files creations ...).
+        """
+
+        trajectory = self.configuration["trajectory"]["instance"]
+
+        frame_range = range(
+            self.configuration["frames"]["first"],
+            self.configuration["frames"]["last"] + 1,
+            self.configuration["frames"]["step"],
+        )
+
+        unit_cells = [trajectory.unit_cell(frame)._unit_cell for frame in frame_range]
+
+        average_unit_cell = np.mean(unit_cells, axis=0) * self._conversion_factor
+
+        self._ase_atoms.set_cell(average_unit_cell)
+
+        ase_write(
+            self.configuration["output_file"]["file"],
+            self._ase_atoms,
+            self.configuration["output_file"]["format"],
+        )

--- a/MDANSE/Tests/UnitTests/Analysis/test_average_structure.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_average_structure.py
@@ -38,6 +38,7 @@ def test_temperature(trajectory, output_unit, output_format):
     parameters = {}
     parameters["frames"] = (0, 10, 1)
     parameters["output_units"] = output_unit
+    parameters["fold"] = True
     parameters["output_file"] = (temp_name, output_format)
     parameters["running_mode"] = ("single-core",)
     parameters["trajectory"] = short_traj

--- a/MDANSE/Tests/UnitTests/Analysis/test_average_structure.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_average_structure.py
@@ -1,0 +1,50 @@
+import sys
+import tempfile
+import os
+from os import path
+import pytest
+from icecream import ic
+import numpy as np
+import h5py
+from MDANSE.Framework.InputData.HDFTrajectoryInputData import HDFTrajectoryInputData
+from MDANSE.Framework.Jobs.IJob import IJob
+
+
+sys.setrecursionlimit(100000)
+ic.disable()
+short_traj = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "..",
+    "Data",
+    "short_trajectory_after_changes.mdt",
+)
+
+
+@pytest.fixture(scope="module")
+def trajectory():
+    trajectory = HDFTrajectoryInputData(short_traj)
+    yield trajectory
+
+units = ['Angstrom', 'Bohr', 'nm', 'pm']
+formats = ['vasp', 'xyz', 'turbomole', 'abinit-in']
+inputs = []
+for u in units:
+    for f in formats:
+        inputs.append((u,f))
+
+@pytest.mark.parametrize('output_unit,output_format', inputs)
+def test_temperature(trajectory, output_unit, output_format):
+    temp_name = tempfile.mktemp()
+    parameters = {}
+    parameters["frames"] = (0, 10, 1)
+    parameters["output_units"] = output_unit
+    parameters["output_file"] = (temp_name, output_format)
+    parameters["running_mode"] = ("single-core",)
+    parameters["trajectory"] = short_traj
+    temp = IJob.create("AverageStructure")
+    temp.run(parameters, status=True)
+    assert path.exists(temp_name)
+    assert path.isfile(temp_name)
+    os.remove(temp_name)
+
+

--- a/MDANSE/Tests/UnitTests/test_ijob.py
+++ b/MDANSE/Tests/UnitTests/test_ijob.py
@@ -7,6 +7,7 @@ from MDANSE.Framework.Jobs.IJob import IJob
 ALL_JOBS = [
     "AngularCorrelation",
     "AreaPerMolecule",
+    "AverageStructure",
     "CenterOfMassesTrajectory",
     "DistanceHistogram",
     "CroppedTrajectory",

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputStructureWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputStructureWidget.py
@@ -1,0 +1,125 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import glob
+import itertools
+import os
+import os.path
+
+from qtpy.QtWidgets import QComboBox, QLineEdit, QPushButton, QFileDialog
+from qtpy.QtCore import Qt, Slot
+
+from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
+
+
+class OutputStructureWidget(WidgetBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        default_value = self._configurator.default
+        try:
+            parent = kwargs.get("parent", None)
+            self.default_path = parent.default_path
+        except KeyError:
+            self.default_path = "."
+            print("KeyError in OutputTrajectoryWidget - can't get default path.")
+        except AttributeError:
+            self.default_path = "."
+            print("AttributeError in OutputTrajectoryWidget - can't get default path.")
+        self.file_association = ".*"
+        self._value = default_value
+        self._field = QLineEdit(default_value[0], self._base)
+        self._field.setPlaceholderText(default_value[0])
+        self.format_box = QComboBox(self._base)
+        self.format_box.addItems(self._configurator._formats)
+        self.format_box.setCurrentText(default_value[1])
+        browse_button = QPushButton("Browse", self._base)
+        browse_button.clicked.connect(self.file_dialog)
+        self._layout.addWidget(self._field)
+        self._layout.addWidget(self.format_box)
+        self._layout.addWidget(browse_button)
+        self._default_value = default_value
+        self._field.textChanged.connect(self.updateValue)
+        self.default_labels()
+        self.update_labels()
+        self.updateValue()
+        if self._tooltip:
+            tooltip_text = self._tooltip
+        else:
+            tooltip_text = (
+                "The average structure of the trajectory"
+                "will be saved under this name,"
+                "using the selected format"
+            )
+        self._field.setToolTip(tooltip_text)
+
+    def default_labels(self):
+        """Each Widget should have a default tooltip and label,
+        which will be set in this method, unless specific
+        values are provided in the settings of the job that
+        is being configured."""
+        if self._label_text == "":
+            self._label_text = "OutputStructureWidget"
+        if self._tooltip == "":
+            self._tooltip = (
+                "The average structure of the trajectory"
+                "will be saved under this name,"
+                "using the selected format"
+            )
+
+    @Slot()
+    def file_dialog(self):
+        """A Slot defined to allow the GUI to be updated based on
+        the new path received from a FileDialog.
+        This will start a FileDialog, take the resulting path,
+        and emit a signal to update the value show by the GUI.
+        """
+        new_value = QFileDialog.getSaveFileName(
+            self._base,  # the parent of the dialog
+            "Load a file",  # the label of the window
+            self.default_path,  # the initial search path
+            self.file_association,  # text string specifying the file name filter.
+        )
+        if len(new_value[0]) > 0:
+            self._field.setText(new_value[0])
+            self.updateValue()
+
+    @staticmethod
+    def _get_unique_filename(directory, basename):
+        filesInDirectory = [
+            os.path.join(directory, e)
+            for e in itertools.chain(
+                glob.iglob(os.path.join(directory, "*")),
+                glob.iglob(os.path.join(directory, ".*")),
+            )
+            if os.path.isfile(os.path.join(directory, e))
+        ]
+        basenames = [os.path.splitext(f)[0] for f in filesInDirectory]
+
+        initialPath = path = os.path.join(directory, basename)
+        comp = 1
+        while True:
+            if path in basenames:
+                path = "%s(%d)" % (initialPath, comp)
+                comp += 1
+                continue
+            return path
+
+    def get_widget_value(self):
+        filename = self._field.text()
+        if len(filename) < 1:
+            filename = self._default_value[0]
+        format = self.format_box.currentText()
+        return (filename, format)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -59,6 +59,7 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "QVectorsConfigurator": QVectorsWidget,
     "InputDirectoryConfigurator": InputDirectoryWidget,
     "OutputDirectoryConfigurator": OutputDirectoryWidget,
+    "OutputStructureConfigurator": OutputStructureWidget,
     "OutputTrajectoryConfigurator": OutputTrajectoryWidget,
     "ProjectionConfigurator": ProjectionWidget,
     "AtomSelectionConfigurator": AtomSelectionWidget,


### PR DESCRIPTION
**Description of work**
A new analysis type has been added in this PR. It is a tool mentioned in #446 allowing the user to output the time-averaged crystal structure of the simulated system. The intention is to use it with an external tool like phonopy or spglib to determine the symmetry of the system and find the single unit cell of the supercell that was being simulated.

**Fixes**
1. New analysis added: AverageStructure.
2. OutputStructureConfigurator added, specifically for choosing an output format supported by ASE.
3. A matching OutputStructureWidget has been added to the GUI.
4. Unit tests for AverageStructure runs check that it executes without crashing for several combinations of parameters.

**To test**
Tests must pass. You can run the AverageStructure analysis on a crystal(like) system; the LAMMPS CuSbS trajectory can be used if you exclude the Cu atoms.
