### PR TITLE
Scattering correlation update 2

### DIFF
--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -38,7 +38,7 @@ def dcsf():
     parameters = {}
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
-    parameters["frames"] = (0, 10, 1)
+    parameters["frames"] = (0, 10, 1, 5)
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["output_files"] = (temp_name, ("MDAFormat",))
     parameters["q_vectors"] = (
@@ -60,7 +60,7 @@ def disf():
     parameters = {}
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
-    parameters["frames"] = (0, 10, 1, 10)
+    parameters["frames"] = (0, 10, 1, 5)
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["output_files"] = (temp_name, ("MDAFormat",))
     parameters["q_vectors"] = (
@@ -81,7 +81,7 @@ def test_dcsf(trajectory, qvector_spherical_lattice):
     parameters = {}
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
-    parameters["frames"] = (0, 10, 1)
+    parameters["frames"] = (0, 10, 1, 5)
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice
@@ -103,7 +103,7 @@ def test_output_axis_preview(qvector_spherical_lattice):
     parameters = {}
     parameters["atom_selection"] = None
     parameters["atom_transmutation"] = None
-    parameters["frames"] = (0, 10, 1)
+    parameters["frames"] = (0, 10, 1, 5)
     parameters["instrument_resolution"] = ("Ideal", {})
     parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"))
     parameters["q_vectors"] = qvector_spherical_lattice


### PR DESCRIPTION
**Description of work**
Updated DCSF to use correlation frames following #435.

DCSF with DLPOLY water trajectory and SphericalQVectors
Before
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/3ab7003b-77e6-45af-a8cf-634d4545c619)


After
![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/861b5233-2d5b-4204-9267-08e1174d10e7)



**Fixes**
Fixes #464
Fixes #459

**To test**
Run DCSF and DISF with the default number of correlation frames. Using the output files run NDTSF. All jobs should complete without any issues. 
