### PR TITLE
Distance cutoff widget update

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
@@ -16,7 +16,9 @@ class DistHistCutoffConfigurator(RangeConfigurator):
             A tuple of the range parameters.
         """
         if value[1] > floor(self.get_largest_cutoff() * 100) / 100:
-            self.error_status = "The cutoff distance goes into the simulation box periodic images."
+            self.error_status = (
+                "The cutoff distance goes into the simulation box periodic images."
+            )
             return
 
         super().configure(value)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
@@ -1,0 +1,45 @@
+from math import floor
+
+import numpy as np
+
+from .RangeConfigurator import RangeConfigurator
+
+
+class DistHistCutoffConfigurator(RangeConfigurator):
+
+    def configure(self, value):
+        """Configure the distance histogram cutoff configurator.
+
+        Parameters
+        ----------
+        value : tuple
+            A tuple of the range parameters.
+        """
+        if value[1] > floor(self.get_largest_cutoff() * 100) / 100:
+            self.error_status = "The cutoff distance goes into the simulation box periodic images."
+            return
+
+        super().configure(value)
+
+    def get_largest_cutoff(self) -> float:
+        """Get the largest cutoff value for the given trajectories
+        unit cells.
+
+        Returns
+        -------
+        float
+            The maximum cutoff for the distance histogram job.
+        """
+        traj_config = self._configurable[self._dependencies["trajectory"]]["instance"]
+        min_d = np.min(traj_config._trajectory._h5_file["unit_cell"], axis=0)
+        vec_a, vec_b, vec_c = min_d
+        a = np.linalg.norm(vec_a)
+        b = np.linalg.norm(vec_b)
+        c = np.linalg.norm(vec_c)
+
+        i, j, k = reversed(np.argsort([a, b, c]))
+        vecs = [vec_a, vec_b, vec_c]
+
+        cross_ij = np.cross(vecs[i], vecs[j])
+        proj = cross_ij * (vecs[k] @ cross_ij) / (cross_ij @ cross_ij)
+        return np.linalg.norm(proj) / 2

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DistanceHistogram.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DistanceHistogram.py
@@ -46,12 +46,13 @@ class DistanceHistogram(IJob):
         {"dependencies": {"trajectory": "trajectory"}},
     )
     settings["r_values"] = (
-        "RangeConfigurator",
+        "DistHistCutoffConfigurator",
         {
             "label": "r values (nm)",
             "valueType": float,
             "includeLast": True,
             "mini": 0.0,
+            "dependencies": {"trajectory": "trajectory"}
         },
     )
     settings["atom_selection"] = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DistanceHistogram.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DistanceHistogram.py
@@ -52,7 +52,7 @@ class DistanceHistogram(IJob):
             "valueType": float,
             "includeLast": True,
             "mini": 0.0,
-            "dependencies": {"trajectory": "trajectory"}
+            "dependencies": {"trajectory": "trajectory"},
         },
     )
     settings["atom_selection"] = (

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/DistHistCutoffWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/DistHistCutoffWidget.py
@@ -1,0 +1,29 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from math import floor
+from .RangeWidget import RangeWidget
+
+
+class DistHistCutoffWidget(RangeWidget):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def setup_fields(self, *args, **kwargs):
+        start = 0.0
+        end = floor(self._configurator.get_largest_cutoff() * 100) / 100
+        step = 0.01
+        super().setup_fields(*args, default=(start, end, step), **kwargs)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/RangeWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/RangeWidget.py
@@ -29,12 +29,7 @@ class RangeWidget(WidgetBase):
 
     def setup_fields(self, *args, **kwargs):
         start, end, step = kwargs.get("default", self._configurator._default)
-
         num_type = kwargs.get("valueType", int)
-        if num_type is int and isinstance(step, float):
-            step = 1
-        elif num_type is float and isinstance(step, int):
-            step = 0.1
 
         labels = [
             QLabel("From", self._base),

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/RangeWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/RangeWidget.py
@@ -22,25 +22,31 @@ from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
 
 
 class RangeWidget(WidgetBase):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, layout_type="QGridLayout", **kwargs)
-        source_object = kwargs.get("source_object", None)
+        self.setup_fields(*args, **kwargs)
+
+    def setup_fields(self, *args, **kwargs):
+        start, end, step = kwargs.get("default", self._configurator._default)
+
         num_type = kwargs.get("valueType", int)
-        if num_type is int:
-            step_val = 1
-        else:
-            step_val = 0.1
+        if num_type is int and isinstance(step, float):
+            step = 1
+        elif num_type is float and isinstance(step, int):
+            step = 0.1
+
         labels = [
             QLabel("From", self._base),
             QLabel("to", self._base),
             QLabel("in steps of", self._base),
         ]
         fields = [
-            QLineEdit(str(num_type(0)), self._base),
-            QLineEdit(str(num_type(5)), self._base),
-            QLineEdit(str(num_type(step_val)), self._base),
+            QLineEdit(str(num_type(start)), self._base),
+            QLineEdit(str(num_type(end)), self._base),
+            QLineEdit(str(num_type(step)), self._base),
         ]
-        placeholders = [str(num_type(0)), str(num_type(5)), str(num_type(step_val))]
+        placeholders = [str(num_type(start)), str(num_type(end)), str(num_type(step))]
         if num_type is int:
             validators = [QIntValidator(parent_field) for parent_field in fields]
         else:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -36,6 +36,7 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "CorrelationFramesConfigurator": CorrelationFramesWidget,
     "FramesConfigurator": FramesWidget,
     "RangeConfigurator": RangeWidget,
+    "DistHistCutoffConfigurator": DistHistCutoffWidget,
     "VectorConfigurator": VectorWidget,
     "HDFInputFileConfigurator": InputFileWidget,
     "HDFTrajectoryConfigurator": HDFTrajectoryWidget,


### PR DESCRIPTION
**Description of work**
Created distance cutoff widget for the PDF job. The max r value is now set to the radius of the largest sphere that can be placed in the smallest unit cell of the whole trajectory. A more sensible 0.1 A step size is used. Removed hardcoded values from the rangewidget.

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/88c93a0b-1848-4845-b92c-c32003f91917)


**Fixes**
Closes #462
Closes #431

**To test**
Run PDF and check that the results are good with the default settings. The results should be the same as the previous version except the max r value is set to a reasonable value.
