### PR TITLE
Minimal multiprocessing improvement

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
@@ -32,7 +32,7 @@ class RunningModeConfigurator(IConfigurator):
     specify the number of slots used for running the analysis.
     """
 
-    availablesModes = ["single-core", "threadpool", "multicore"]
+    availablesModes = ["single-core", "processpool", "multicore"]
 
     _default = ("single-core", 1)
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
@@ -32,7 +32,7 @@ class RunningModeConfigurator(IConfigurator):
     specify the number of slots used for running the analysis.
     """
 
-    availablesModes = ["single-core", "processpool", "multicore"]
+    availablesModes = ["single-core", "multicore"]
 
     _default = ("single-core", 1)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -238,23 +238,6 @@ class IJob(Configurable, metaclass=SubclassFactory):
                 self._status.update()
             self.combine(idx, result)
 
-    def _run_processpool(self):
-        def helper(self, index):
-            if self._status is not None:
-                if hasattr(self._status, "_pause_event"):
-                    self._status._pause_event.wait()
-            idx, result = self.run_step(index)
-            if self._status is not None:
-                self._status.update()
-            self.combine(idx, result)
-
-        pool = PoolExecutor(max_workers=self.configuration["running_mode"]["slots"])
-
-        futures = [
-            pool.submit(helper, self, index) for index in range(self.numberOfSteps)
-        ]
-        results = [future.result() for future in futures]
-
     def process_tasks_queue(self, tasks, outputs):
         while True:
             try:
@@ -319,7 +302,6 @@ class IJob(Configurable, metaclass=SubclassFactory):
 
     _runner = {
         "single-core": _run_singlecore,
-        "processpool": _run_processpool,
         "multicore": _run_multicore,
         "remote": _run_remote,
     }

--- a/MDANSE/Src/MDANSE/Framework/Jobs/JobStatus.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/JobStatus.py
@@ -89,3 +89,6 @@ class JobStatus(Status):
             self._state["progress"] = 0
 
         self.save_status()
+
+    def fixed_status(self, current_progress: int):
+        pass

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -184,8 +184,6 @@ class MeanSquareDisplacement(IJob):
 
         self._outputData["msd_%s" % element] += result
 
-        IJob.combine(self)
-
     def finalize(self):
         """
         Finalizes the calculations (e.g. averaging the total term, output files creations ...).

--- a/MDANSE/Src/MDANSE/Framework/Status.py
+++ b/MDANSE/Src/MDANSE/Framework/Status.py
@@ -55,6 +55,10 @@ class Status(object, metaclass=abc.ABCMeta):
     def update_status(self):
         pass
 
+    @abc.abstractmethod
+    def fixed_status(self, current_progress: int):
+        pass
+
     @property
     def currentStep(self):
         return self._currentStep

--- a/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
@@ -68,7 +68,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", -4)
+    parameters["running_mode"] = ("multicore", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE/Tests/UnitTests/Analysis/test_mcstas.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_mcstas.py
@@ -28,7 +28,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", -4)
+    parameters["running_mode"] = ("multicore", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE/Tests/UnitTests/Analysis/test_molecule_names.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_molecule_names.py
@@ -28,7 +28,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", -4)
+    parameters["running_mode"] = ("multicore", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE/Tests/UnitTests/Analysis/test_structure.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_structure.py
@@ -35,7 +35,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", -4)
+    parameters["running_mode"] = ("multicore", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE/Tests/UnitTests/Analysis/test_trajectory.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_trajectory.py
@@ -28,7 +28,7 @@ def parameters():
     # parameters['atom_transmutation'] = None
     # parameters['frames'] = (0, 1000, 1)
     parameters["trajectory"] = short_traj
-    parameters["running_mode"] = ("threadpool", -4)
+    parameters["running_mode"] = ("multicore", -4)
     parameters["q_vectors"] = (
         "SphericalLatticeQVectors",
         {

--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -23,6 +23,8 @@ from qtpy.QtGui import QPixmap, QIcon
 
 from MDANSE_GUI.TabbedWindow import TabbedWindow
 
+os.environ["OMP_NUM_THREADS"] = "1"
+
 
 def startGUI(some_args):
     app = QApplication(some_args)


### PR DESCRIPTION
**Description of work**
At the moment, multicore jobs work, but do not report progress correctly.
This PR changes the way progress is reported for multicore jobs.

closes #447 
closes #361

Note: this PR should let you pause and resume multicore jobs, but **terminating multicore jobs has not been enabled by this PR.**

**Fixes**
Set OMP_NUM_THREADS to 1 in the GUI launcher, suppressing numpy multithreading.
Removed threadpool from the list of running modes.
Added a method to Status for directly updating the progress of multicore jobs.
Removed the super().combine call from MeanSquareDisplacement.

**To test**
Run a job using multiple cores. Check if the progress is updated correctly.
Specifically, try running MeanSquareDisplacement anaylsis in single- and multicore modes. Progress should update correctly for both.
