### PR TITLE
Add cumulative time-averaged results to thermodynamic jobs

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
@@ -16,9 +16,10 @@
 
 import collections
 
+import numpy as np
 
 from MDANSE.Chemistry import ATOMS_DATABASE
-from MDANSE.Framework.Jobs.IJob import IJob, JobError
+from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Units import measure
 from MDANSE.MolecularDynamics.Trajectory import sorted_atoms
 
@@ -85,9 +86,24 @@ class Density(IJob):
             units="g/cm3",
             main_result=True,
         )
+        self._outputData.add(
+            "avg_mass_density",
+            "LineOutputVariable",
+            (self._n_frames,),
+            axis="time",
+            units="g/cm3",
+            main_result=True,
+        )
 
         self._outputData.add(
             "atomic_density",
+            "LineOutputVariable",
+            (self._n_frames,),
+            axis="time",
+            units="1/cm3",
+        )
+        self._outputData.add(
+            "avg_atomic_density",
             "LineOutputVariable",
             (self._n_frames,),
             axis="time",
@@ -146,6 +162,10 @@ class Density(IJob):
         """
         Finalize the job.
         """
+
+        norm = np.arange(1, self._outputData["atomic_density"].shape[0] + 1)
+        self._outputData["avg_atomic_density"][:] = np.cumsum(self._outputData["atomic_density"]) / norm
+        self._outputData["avg_mass_density"][:] = np.cumsum(self._outputData["mass_density"]) / norm
 
         self._outputData.write(
             self.configuration["output_files"]["root"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
@@ -164,8 +164,12 @@ class Density(IJob):
         """
 
         norm = np.arange(1, self._outputData["atomic_density"].shape[0] + 1)
-        self._outputData["avg_atomic_density"][:] = np.cumsum(self._outputData["atomic_density"]) / norm
-        self._outputData["avg_mass_density"][:] = np.cumsum(self._outputData["mass_density"]) / norm
+        self._outputData["avg_atomic_density"][:] = (
+            np.cumsum(self._outputData["atomic_density"]) / norm
+        )
+        self._outputData["avg_mass_density"][:] = (
+            np.cumsum(self._outputData["mass_density"]) / norm
+        )
 
         self._outputData.write(
             self.configuration["output_files"]["root"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -90,12 +90,26 @@ class Temperature(IJob):
             units="kJ_per_mole",
         )
         self._outputData.add(
+            "avg_kinetic_energy",
+            "LineOutputVariable",
+            (self._nFrames,),
+            axis="time",
+            units="kJ_per_mole",
+        )
+        self._outputData.add(
             "temperature",
             "LineOutputVariable",
             (self._nFrames,),
             axis="time",
             units="K",
             main_result=True,
+        )
+        self._outputData.add(
+            "avg_temperature",
+            "LineOutputVariable",
+            (self._nFrames,),
+            axis="time",
+            units="K",
         )
 
         self._atoms = sorted_atoms(
@@ -167,8 +181,14 @@ class Temperature(IJob):
         nAtoms = len(self._atoms)
         self._outputData["kinetic_energy"] /= nAtoms - 1
 
+        norm = np.arange(1, self._outputData["kinetic_energy"].shape[0] + 1)
+        self._outputData["avg_kinetic_energy"][:] = np.cumsum(self._outputData["kinetic_energy"]) / norm
+
         self._outputData["temperature"][:] = (
             2.0 * self._outputData["kinetic_energy"] / (3.0 * KB)
+        )
+        self._outputData["avg_temperature"][:] = (
+            2.0 * self._outputData["avg_kinetic_energy"] / (3.0 * KB)
         )
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -182,7 +182,9 @@ class Temperature(IJob):
         self._outputData["kinetic_energy"] /= nAtoms - 1
 
         norm = np.arange(1, self._outputData["kinetic_energy"].shape[0] + 1)
-        self._outputData["avg_kinetic_energy"][:] = np.cumsum(self._outputData["kinetic_energy"]) / norm
+        self._outputData["avg_kinetic_energy"][:] = (
+            np.cumsum(self._outputData["kinetic_energy"]) / norm
+        )
 
         self._outputData["temperature"][:] = (
             2.0 * self._outputData["kinetic_energy"] / (3.0 * KB)


### PR DESCRIPTION
**Description of work**
When we calculate the temperature and density they are the instantaneous temperatures and densities. To get the actual temperatures and densities we should time-average those properties, I have added a cumulative time-average results to the temperature and density jobs.

I think this should help with reading the temperature and density results since they fluctuate quite a lot. We can see in the below trajectory hasn't equilibrated until at least 2.5 ps.

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/bcbd72ed-8462-45fc-af1e-70cf770131c7)

![image](https://github.com/ISISNeutronMuon/MDANSE/assets/14276033/5a7b2e66-f964-4764-90a0-4c897b9ddb37)


**To test**
Run density (use NPT MD trajectory) and temperature jobs. Open results, cumulative average thermodynamic results be available.
