### PR TITLE
Reactivate metadata printout in Plot Creator

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
@@ -111,8 +111,15 @@ class MDADataStructure:
 
         def put_into_dict(name, obj):
             try:
-                string = obj[:][0].decode()
-            except:
+                string = obj[:][0]
+            except TypeError:
+                try:
+                    string = obj[0]
+                except TypeError:
+                    return
+            try:
+                string = string.decode()
+            except KeyError:
                 print(f"Decode failed for {name}: {obj}")
                 meta_dict[name] = str(obj)
             else:
@@ -149,7 +156,7 @@ class PlotDataModel(QStandardItemModel):
         try:
             new_datafile = MDADataStructure(filename)
         except Exception as e:
-            print(f"Invalid: {str(e)}", role=Qt.ItemDataRole.DisplayRole)
+            print(f"Invalid: {str(e)}")
         else:
             self._nodes[self._next_number] = new_datafile
             new_item = DataFileItem()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -48,10 +48,8 @@ class PlotDataView(QTreeView):
         return super().mousePressEvent(e)
 
     def mouseMoveEvent(self, event: QMouseEvent) -> None:
-        # print("Mouse Move Event!", event.button(), QtCore.Qt.MouseButton.LeftButton)
         if event.buttons() == Qt.MouseButton.LeftButton:
             # if event.button():
-            print("dragging")
             new_position = event.position()
             distance = (self.click_position - new_position).manhattanLength()
             if distance > QApplication.startDragDistance():
@@ -99,6 +97,10 @@ class PlotDataView(QTreeView):
         except AttributeError:
             packet = text, mda_data_structure.file
         self.dataset_selected.emit(packet)
+        if hasattr(mda_data_structure, "_metadata"):
+            self.item_details.emit(mda_data_structure._metadata)
+        else:
+            self.item_details.emit("No additional information included.")
 
     @Slot(QModelIndex)
     def item_picked(self, index: QModelIndex):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -86,6 +86,7 @@ class PlotDataView(QTreeView):
         model = self.model()
         index = self.currentIndex()
         model.removeRow(index.row())
+        self.item_details.emit("")
 
     def on_select_dataset(self, index):
         model = self.model()
@@ -100,7 +101,13 @@ class PlotDataView(QTreeView):
         if hasattr(mda_data_structure, "_metadata"):
             self.item_details.emit(mda_data_structure._metadata)
         else:
-            self.item_details.emit("No additional information included.")
+            try:
+                text += "\n"
+                for attr in mda_data_structure.attrs:
+                    text += f"{attr}: {mda_data_structure.attrs[attr]}\n"
+                self.item_details.emit(text)
+            except:
+                self.item_details.emit("No additional information included.")
 
     @Slot(QModelIndex)
     def item_picked(self, index: QModelIndex):


### PR DESCRIPTION
**Description of work**
An MDANSE analysis output file normally includes the information about the input parameters that were used to create it. This PR makes this information visible in the GUI.

**Fixes**
1. Corrected parsing problems in PlotDataModel.py
2. Added the `item_details.emit(...)` to PlotDataView.on_select_dataset.

**To test**
Load several MDA files in the Plot Creator tab. Click on different files and datasets to confirm that the bottom-left box updates the text.
