### PR TITLE
Numpy2 cleanup

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/MoleculeFinder.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MoleculeFinder.py
@@ -126,15 +126,10 @@ class MoleculeFinder(IJob):
         coords = conf.coordinates
 
         variables = {}
-        if (
-            "velocities"
-            in self.configuration["trajectory"]["instance"]
-            ._h5_file["configuration"]
-            .keys()
-        ):
+        if self.configuration["trajectory"]["instance"].has_variable("velocities"):
             variables = {
                 "velocities": self.configuration["trajectory"]["instance"]
-                ._h5_file["/configuration/velocities"][frameIndex, :, :]
+                .variable("velocities")[frameIndex, :, :]
                 .astype(np.float64)
             }
 

--- a/MDANSE/Src/MDANSE/Framework/OutputVariables/IOutputVariable.py
+++ b/MDANSE/Src/MDANSE/Framework/OutputVariables/IOutputVariable.py
@@ -117,9 +117,6 @@ class IOutputVariable(np.ndarray, metaclass=SubclassFactory):
 
         self.units = getattr(obj, "units", "unitless")
 
-    def __array_wrap__(self, out_arr, context=None):
-        return np.ndarray.__array_wrap__(self, out_arr, context)
-
     def info(self):
         info = []
 

--- a/MDANSE/Src/MDANSE/MolecularDynamics/MockTrajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/MockTrajectory.py
@@ -72,7 +72,7 @@ class MockTrajectory:
         self._box_size = box_size * measure(1.0, "ang").toval("nm")
         self._real_length = 0
         self._num_atoms_in_box = len(atoms_in_box)
-        self._full_box_size = np.row_stack(
+        self._full_box_size = np.vstack(
             [
                 box_repetitions[0] * self._box_size[0, :],
                 box_repetitions[1] * self._box_size[1, :],
@@ -114,7 +114,7 @@ class MockTrajectory:
                 for nc in range(C):
                     shift = na * vA + nb * vB + nc * vC
                     copies.append(coords_nm + shift.reshape((1, 3)))
-        self._start_coordinates = np.row_stack(copies)
+        self._start_coordinates = np.vstack(copies)
 
     def modulate_structure(
         self,
@@ -149,7 +149,7 @@ class MockTrajectory:
             if the period of the new modulation is incommensurate with the number of frames
         """
         if len(polarisation) * self._multiplier == len(self._start_coordinates):
-            polarisation = np.row_stack(self._multiplier * [polarisation])
+            polarisation = np.vstack(self._multiplier * [polarisation])
         if len(polarisation) != len(self._start_coordinates):
             return False
         n_steps = period
@@ -168,7 +168,7 @@ class MockTrajectory:
             if current_steps < period:
                 step = math.gcd([current_steps, period])
                 while len(self._coordinates) < period:
-                    self._coordinates = np.row_stack(
+                    self._coordinates = np.vstack(
                         [self._coordinates, self._coordinates[-step:]]
                     )
         nm_amp = amplitude * measure(1.0, "ang").toval("nm")


### PR DESCRIPTION
**Description of work**
Since the release of Numpy 2.0.0, the MDANSE unit tests have been producing large numbers of DeprecationWarnings. This PR corrects this. There are still errors output by rdkit, but they don't seem to cause immediate problems, and we expect them to be solved by rdkit developers eventually.

closes #479 

**Fixes**
1. Removed the __array_wrap__ from IOutputVariable.
2. Replaced numpy.row_stack with numpy.vstack.
3. Corrected the code in MoleculeFinder which tried to access the trajectory HDF5 file directly, and not by using the methods of the Trajectory wrapper class.

**To test**
All tests should pass without producing warnings.
Try running MoleculeFinder on a trajectory without molecule labels, to see if the InChI strings are assigned as molecule labels by rdkit.
