### PR TITLE
Disable spinbox in the RunningModeWidget on startup

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/RunningModeWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/RunningModeWidget.py
@@ -35,6 +35,7 @@ class RunningModeWidget(WidgetBase):
         self._field = QSpinBox(self._base)
         self._field.setValue(1)
         self._field.setMinimum(1)
+        self._field.setEnabled(False)
         self._layout.addWidget(self.mode_box)
         self._layout.addWidget(self._field)
         self.mode_box.currentIndexChanged.connect(self.mode_changed)


### PR DESCRIPTION
**Description of work**
In the GUI, a 'single-core' running mode should only accept number of cores=1.

closes #483 

**Fixes**
Disabled the spin box of the RunningModeWidget on startup.

**To test**
In the GUI, load a trajectory and select an analysis type. You should not be able to change the number of cores from 1 when using the single-core mode.
