### PR TITLE
Make 1st order intepolation match the docs

### DIFF
--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -25,9 +25,7 @@ class SignalError(Error):
 
 INTERPOLATION_ORDER = {}
 
-INTERPOLATION_ORDER[1] = np.array(
-    [[-3.0, 4.0, -1.0], [-1.0, 0.0, 1.0], [1.0, -4.0, 3.0]], dtype=np.float64
-)
+INTERPOLATION_ORDER[1] = np.array([[-1.0, 1.0], [1.0, -1.0]], dtype=np.float64)
 
 
 INTERPOLATION_ORDER[2] = np.array(
@@ -153,13 +151,10 @@ def differentiate(a, dt=1.0, order=1):
     fact = 1.0 / dt
 
     if order == 1:
-        ts[0] = np.add.reduce(coefs[0, :] * a[:3])
-        ts[-1] = np.add.reduce(coefs[2, :] * a[-3:])
+        ts[-1] = np.add.reduce(coefs[1, :] * a[-2:])
 
         gj = a[1:] - a[:-1]
-        ts[1:-1] = gj[1:] + gj[:-1]
-
-        fact /= 2.0
+        ts[:-1] = gj
 
     # Case of the order 2
     elif order == 2:

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InterpolationOrderWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InterpolationOrderWidget.py
@@ -44,11 +44,10 @@ class InterpolationOrderWidget(WidgetBase):
         ]["instance"]
         if not trajectory.has_variable("velocities"):
             self._field.setMinimum(1)
-            self._field.setValue(1)
+            self._field.setValue(3)
         label = QLabel("Interpolation order", self._base)
         self.numerator = QLabel("st order")
-
-        self._field.valueChanged.connect(self.adjust_numerator)
+        self.adjust_numerator(3)
 
         self._layout.addWidget(label)
         self._layout.addWidget(self._field)
@@ -62,6 +61,7 @@ class InterpolationOrderWidget(WidgetBase):
             tooltip_text = "The order of the polynomial function used for interpolating velocity values from atom positions. If zero, velocity values present in the trajectory will be used."
         self._field.setToolTip(tooltip_text)
         self.numerator.setToolTip(tooltip_text)
+        self._field.valueChanged.connect(self.adjust_numerator)
 
     def configure_using_default(self):
         """This is too simple to have a default value"""


### PR DESCRIPTION
**Description of work**
Simplifies the formula for the 1st-order derivative used for interpolating velocities.

closes #369

Example result:

![zoomed_four](https://github.com/ISISNeutronMuon/MDANSE/assets/108934199/544753cd-6854-47b8-89c7-7154ae3a681c)


**Fixes**
1. The formula for the 1st order derivative is now really v_{i} = (r_{i+1} - r_{i})/dt
2. Default interpolation order in the GUI is now the 3rd order.

**To test**
All tests must pass.
Calculate the temperature of a trajectory using different interpolation orders.
