### PR TITLE
Save as script cancel fix

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -293,7 +293,7 @@ class Action(QWidget):
         result, ftype = QFileDialog.getSaveFileName(
             self, "Save job as a Python script", currentpath, "Python script (*.py)"
         )
-        if result is None:
+        if result == "":
             return None
         path, _ = os.path.split(result)
         try:


### PR DESCRIPTION
**Description of work**
Fixes the save as script crash when the cancel button is clicked.

**Fixes**
Fixes #491

**To test**
In the converter or analysis jobs, click the save as script button and hit cancel the GUI should not crash. Save as script should continue to work as normal.
