### PR TITLE
Startup run converter fix

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -241,6 +241,7 @@ class Action(QWidget):
 
         self.layout.addWidget(buttonbase)
         self._widgets_in_layout.append(buttonbase)
+        self.allow_execution()
         self.show_output_prediction()
 
     @Slot()


### PR DESCRIPTION
**Description of work**
Fixes the bug where users were able to run invalid conversion jobs on startup.

**Fixes**
Fixes #490

**To test**
Start up MDANSE and check that the converter RUN button is blocked for invalid settings. Test that the conversion and analysis jobs work as usual.
