### PR TITLE
Job termination fixes

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -137,6 +137,10 @@ class IJob(Configurable, metaclass=SubclassFactory):
 
         self._log_filename = None
 
+        self.inputQueue = Queue()
+        self.outputQueue = Queue()
+        self.log_queue = Queue()
+
     def __getstate__(self):
         d = self.__dict__.copy()
         del d["_processes"]
@@ -279,9 +283,9 @@ class IJob(Configurable, metaclass=SubclassFactory):
         if hasattr(self._status, "_queue_0"):
             self._status._queue_0.put("started")
 
-        inputQueue = Queue()
-        outputQueue = Queue()
-        log_queue = Queue()
+        inputQueue = self.inputQueue
+        outputQueue = self.outputQueue
+        log_queue = self.log_queue
 
         log_queues = [log_queue]
         handlers = []  # handlers that are not QueueHandlers

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -336,7 +336,9 @@ class IJob(Configurable, metaclass=SubclassFactory):
         listener : QueueListener
             The log listener that we need to stop.
         """
-        if not (hasattr(self._status, "_queue_0") and hasattr(self._status, "_queue_1")):
+        if not (
+            hasattr(self._status, "_queue_0") and hasattr(self._status, "_queue_1")
+        ):
             return
         if self._status._queue_1.qsize() > 0:
             if self._status._queue_1.get() == "terminate":

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -309,11 +309,11 @@ class IJob(Configurable, metaclass=SubclassFactory):
             p.daemon = False
             p.start()
 
-        while inputQueue.qsize() > 0:
+        while not inputQueue.empty():
             self._run_multicore_check_terminate(listener)
             time.sleep(0.1)
-            if self._status is not None:
-                self._status.fixed_status(outputQueue.qsize())
+            # if self._status is not None:
+            #     self._status.fixed_status(outputQueue.qsize())
 
         for i in range(self.numberOfSteps):
             index, result = outputQueue.get()
@@ -340,7 +340,7 @@ class IJob(Configurable, metaclass=SubclassFactory):
             hasattr(self._status, "_queue_0") and hasattr(self._status, "_queue_1")
         ):
             return
-        if self._status._queue_1.qsize() > 0:
+        if not self._status._queue_1.empty():
             if self._status._queue_1.get() == "terminate":
                 for p in self._processes:
                     p.terminate()

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/RunningModeWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/RunningModeWidget.py
@@ -35,6 +35,7 @@ class RunningModeWidget(WidgetBase):
         self._field = QSpinBox(self._base)
         self._field.setValue(1)
         self._field.setMinimum(1)
+        self._field.setMaximum(multiprocessing.cpu_count())
         self._field.setEnabled(False)
         self._layout.addWidget(self.mode_box)
         self._layout.addWidget(self._field)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/JobStatusProcess.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/JobStatusProcess.py
@@ -66,13 +66,15 @@ class JobStatusProcess(Status):
     def __init__(
         self,
         pipe: "Connection",
-        queue: Queue,
+        queue_0: Queue,
+        queue_1: Queue,
         pause_event: "Event",
         **kwargs,
     ):
         super().__init__()
         self._pipe = pipe
-        self._queue = queue
+        self._queue_0 = queue_0
+        self._queue_1 = queue_1
         self._state = {}  # for compatibility with JobStatus
         self._progress_meter = 0
         self._pause_event = pause_event

--- a/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/Subprocess.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/Subprocess.py
@@ -66,8 +66,11 @@ class Subprocess(Process):
         terminate and join its subprocesses. We need to do this
         before this subprocess terminates itself.
         """
-        mode = self._job_parameters["running_mode"][0]
-        if mode == "multicore":
+        if "running_mode" not in self._job_parameters:
+            super().terminate()
+            return
+
+        if self._job_parameters["running_mode"][0] == "multicore":
             if self.queue_0.get() != "started":
                 raise RuntimeError(
                     "For some reason we received a messaged which wasn't "

--- a/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/Subprocess.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/Subprocess.py
@@ -75,7 +75,7 @@ class Subprocess(Process):
                 )
             self.queue_1.put("terminate")
             # Wait until IJob has received the terminate message.
-            while self.queue_1.qsize() != 0:
+            while not self.queue_1.empty():
                 time.sleep(0.1)
             if self.queue_0.get() != "terminated":
                 raise RuntimeError(

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -249,7 +249,6 @@ class JobHolder(QStandardItemModel):
         log_queue = Queue()
 
         main_pipe, child_pipe = Pipe()
-        main_queue = Queue()
         pause_event = Event()
         entry_number = self.next_number
 
@@ -267,7 +266,6 @@ class JobHolder(QStandardItemModel):
                 job_name=job_vars[0],
                 job_parameters=job_vars[1],
                 pipe=child_pipe,
-                queue=main_queue,
                 pause_event=pause_event,
                 log_queue=log_queue,
             )

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -65,7 +65,16 @@ class JobThread(QThread):
 
     @Slot()
     def check_if_alive(self):
-        if self._subprocess._closed or not self._subprocess.is_alive():
+        if self._subprocess._closed:
+            # The subprocess was closed probably by the user, don't need
+            # to keep checking that the subprocess is alive anymore.
+            # Also, no need to send out a status update since it should
+            # already have been updated already when it got terminated.
+            self._keep_running = False
+            self._timer.stop()
+            self.terminate()
+            return
+        if not self._subprocess.is_alive():
             self.fail()
 
     def run(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -65,7 +65,7 @@ class JobThread(QThread):
 
     @Slot()
     def check_if_alive(self):
-        if not self._subprocess.is_alive():
+        if self._subprocess._closed or not self._subprocess.is_alive():
             self.fail()
 
     def run(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
@@ -129,12 +129,14 @@ class RunTable(QTableView):
         )
         result = confirmation_box.exec()
         LOG.info(f"QMessageBox result = {result}")
-        if result == QMessageBox.StandardButton.Yes.value:
+        if result == QMessageBox.StandardButton.Yes:
             entry, _, process, listener = self.getJobObjects()
-            process.terminate()
-            process.join()
-            entry.terminate_job()
-            listener.stop()
+            # process is not alive, the job probably finished already
+            if process.is_alive():
+                process.terminate()
+                process.join()
+                entry.terminate_job()
+                listener.stop()
 
     @Slot(QModelIndex)
     def item_picked(self, index: QModelIndex):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
@@ -90,7 +90,6 @@ class RunTable(QTableView):
         entry, watcher, process, listener = self.getJobObjects()
         try:
             process.close()
-            listener.stop()
         except ValueError:
             LOG.error("The process is still running!")
         else:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
@@ -132,6 +132,7 @@ class RunTable(QTableView):
         if result == QMessageBox.StandardButton.Yes.value:
             entry, _, process, listener = self.getJobObjects()
             process.terminate()
+            process.join()
             entry.terminate_job()
             listener.stop()
 


### PR DESCRIPTION
**Description of work**
Updated so that for multicore jobs its child processes are properly terminated. Fix crashing GUI when terminated jobs are deleted from the run table. Updated the max value of the QSpinBox for the multicore running mode.

**Fixes**
Fixes #495
Fixes #472

**To test**
Run jobs and then terminate them and delete them from the run table. The GUI should not crash. Check the number of python processes that are running, all the child processes should be killed. Check this for both singlecore and multicore running modes. Check jobs complete and results are the same with both singlecore and multicore jobs.