### PR TITLE
Add a test for pip install MDANSE_GUI

### DIFF
--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -1,4 +1,4 @@
-name: Test MDANSE
+name: Test pip install MDANSE_GUI
 
 on:
   pull_request:
@@ -7,14 +7,13 @@ on:
 
 jobs:
   test:
-    name: Build MDANSE and run tests on ${{ matrix.os }}
+    name: Install MDANSE_GUI on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        # os: [ubuntu-20.04, windows-2019, macOS-11, ubuntu-latest, windows-latest, macOS-latest]
     if: |
       !contains( github.ref, 'legacy' )
     steps:
@@ -24,13 +23,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install pytest
-        run: python -m pip install pytest
-
       - name: install MDANSE
         run: (cd MDANSE && python -m pip install .)
 
-      - name: run unit tests
-        run: |
-          cd MDANSE/Tests/UnitTests
-          python -m pytest
+      - name: install MDANSE_GUI
+        run: (cd MDANSE_GUI && python -m pip install .)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,35 @@ jobs:
         run: |
           cd MDANSE/Tests/UnitTests
           python -m pytest
+
+
+name: Test pip install MDANSE_GUI
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Install MDANSE_GUI on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    if: |
+      !contains( github.ref, 'legacy' )
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: install MDANSE
+        run: (cd MDANSE && python -m pip install .)
+
+      - name: install MDANSE_GUI
+        run: (cd MDANSE_GUI && python -m pip install .)

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "qtpy",
     "vtk",
     "PyQt6",
-    "pyqt6-tools",
     "PyYAML",
 ]
 


### PR DESCRIPTION
**Description of work**
Recently a user encountered problems when installing MDANSE_GUI using pip. We should add a workflow that tries to install MDANSE_GUI on different platforms, just to see if `pip install` produces an error.

**Fixes**
A new test has been added, which only installs MDANSE and MDANSE_GUI.

**To test**
All tests must pass.
