### PR TITLE
Add time-derivative configurator

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/DerivativeOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DerivativeOrderConfigurator.py
@@ -1,0 +1,59 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from typing import Optional
+
+from MDANSE.Framework.Configurators.IntegerConfigurator import \
+    IntegerConfigurator
+
+
+class DerivativeOrderConfigurator(IntegerConfigurator):
+    """Configurator used when numerical derivatives are required.
+    """
+
+    _default = 3
+
+    def __init__(self, name: str, **kwargs) -> None:
+        """
+        Parameters
+        ----------
+        name : str
+            The name of the configurator as it will appear in the
+            configuration.
+        """
+        IntegerConfigurator.__init__(self, name, **kwargs)
+
+    def configure(self, value: Optional[int]) -> None:
+        """Configure the input derivative order.
+
+        Parameters
+        ----------
+        value : int or None
+            The numerical derivative order to use.
+        """
+        self._original_input = value
+        if value is None:
+            value = self._default
+
+        IntegerConfigurator.configure(self, value)
+
+        if value <= 0 or value > 5:
+            self.error_status = (
+                f"Use an derivative order less than or equal to zero or "
+                f"greater than 5 is not implemented."
+            )
+            return
+
+        self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DerivativeOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DerivativeOrderConfigurator.py
@@ -15,13 +15,11 @@
 #
 from typing import Optional
 
-from MDANSE.Framework.Configurators.IntegerConfigurator import \
-    IntegerConfigurator
+from MDANSE.Framework.Configurators.IntegerConfigurator import IntegerConfigurator
 
 
 class DerivativeOrderConfigurator(IntegerConfigurator):
-    """Configurator used when numerical derivatives are required.
-    """
+    """Configurator used when numerical derivatives are required."""
 
     _default = 3
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DerivativeOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DerivativeOrderConfigurator.py
@@ -34,12 +34,12 @@ class DerivativeOrderConfigurator(IntegerConfigurator):
         IntegerConfigurator.__init__(self, name, **kwargs)
 
     def configure(self, value: Optional[int]) -> None:
-        """Configure the input derivative order.
+        """Configure the input interpolation order.
 
         Parameters
         ----------
         value : int or None
-            The numerical derivative order to use.
+            The interpolation order to use.
         """
         self._original_input = value
         if value is None:
@@ -49,7 +49,7 @@ class DerivativeOrderConfigurator(IntegerConfigurator):
 
         if value <= 0 or value > 5:
             self.error_status = (
-                f"Use an derivative order less than or equal to zero or "
+                f"Use an interpolation order less than or equal to zero or "
                 f"greater than 5 is not implemented."
             )
             return

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
@@ -29,7 +29,7 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
     :note: this configurator depends on 'trajectory' configurator to be configured.
     """
 
-    _default = 1
+    _default = 3
 
     def __init__(self, name, **kwargs):
         """

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MoleculeSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MoleculeSelectionConfigurator.py
@@ -1,5 +1,4 @@
-# **************************************************************************
-#    This file is part of MDANSE_GUI.
+#    This file is part of MDANSE.
 #
 #    MDANSE_GUI is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
@@ -45,6 +45,9 @@ class Infrared(IJob):
         "InstrumentResolutionConfigurator",
         {"dependencies": {"trajectory": "trajectory", "frames": "frames"}},
     )
+    settings["derivative_order"] = (
+        "DerivativeOrderConfigurator", {"label": "d/dt dipole numerical derivative order"},
+    )
     settings["molecule_name"] = (
         "MoleculeSelectionConfigurator",
         {
@@ -160,7 +163,7 @@ class Infrared(IJob):
         for axis in range(3):
             ddipole[:, axis] = differentiate(
                 ddipole[:, axis],
-                order=2,
+                order=self.configuration["derivative_order"]["value"],
                 dt=self.configuration["frames"]["time_step"],
             )
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
@@ -46,7 +46,8 @@ class Infrared(IJob):
         {"dependencies": {"trajectory": "trajectory", "frames": "frames"}},
     )
     settings["derivative_order"] = (
-        "DerivativeOrderConfigurator", {"label": "d/dt dipole numerical derivative order"},
+        "DerivativeOrderConfigurator",
+        {"label": "d/dt dipole numerical derivative order"},
     )
     settings["molecule_name"] = (
         "MoleculeSelectionConfigurator",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
@@ -47,7 +47,7 @@ class Infrared(IJob):
     )
     settings["derivative_order"] = (
         "DerivativeOrderConfigurator",
-        {"label": "d/dt dipole numerical derivative order"},
+        {"label": "d/dt dipole numerical derivative"},
     )
     settings["molecule_name"] = (
         "MoleculeSelectionConfigurator",

--- a/MDANSE/Tests/UnitTests/Analysis/test_infrared.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_infrared.py
@@ -41,6 +41,7 @@ def test_ir_analysis():
     parameters["frames"] = (0, 100, 1, 51)
     parameters["instrument_resolution"] = ("Gaussian", {"sigma": 1.0, "mu": 0.0})
     parameters["output_files"] = (temp_name, ("MDAFormat",), "INFO")
+    parameters["derivative_order"] = 3
     parameters["running_mode"] = ("single-core", 1)
     parameters["trajectory"] = short_traj
     parameters["atom_charges"] = "{}"

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/DerivativeOrderWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/DerivativeOrderWidget.py
@@ -1,0 +1,75 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from qtpy.QtWidgets import QSpinBox, QLabel
+from qtpy.QtCore import Slot
+
+from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
+
+
+suffix_dict = {
+    "1": "st order",
+    "2": "nd order",
+    "3": "rd order",
+    "4": "th order",
+    "5": "th order",
+}
+
+
+class DerivativeOrderWidget(WidgetBase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, layout_type="QHBoxLayout", **kwargs)
+        self._field = QSpinBox(self._base)
+        self._field.setMaximum(5)
+        self._field.setMinimum(1)
+        self._field.setValue(3)
+        label = QLabel("Derivative order", self._base)
+        self.numerator = QLabel("st order")
+        self.adjust_numerator(3)
+
+        self._layout.addWidget(label)
+        self._layout.addWidget(self._field)
+        self._layout.addWidget(self.numerator)
+        self.default_labels()
+        self.update_labels()
+        self.updateValue()
+        if self._tooltip:
+            tooltip_text = self._tooltip
+        else:
+            tooltip_text = "The order of the polynomial function used for interpolating time-dependent variables."
+
+        self._field.setToolTip(tooltip_text)
+        self.numerator.setToolTip(tooltip_text)
+        self._field.valueChanged.connect(self.adjust_numerator)
+
+    def configure_using_default(self):
+        """This is too simple to have a default value"""
+
+    def default_labels(self):
+        if self._label_text == "":
+            self._label_text = "DerivativeOrderWidget"
+        if self._tooltip == "":
+            self._tooltip = "The order of the polynomial function used for interpolating time-dependent variables."
+
+    @Slot(int)
+    def adjust_numerator(self, order: int):
+        text_order = str(order)
+        new_numerator = suffix_dict.get(text_order[-1])
+        self.numerator.setText(new_numerator)
+
+    def get_widget_value(self):
+        value = self._field.value()
+        return value

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/DerivativeOrderWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/DerivativeOrderWidget.py
@@ -36,7 +36,7 @@ class DerivativeOrderWidget(WidgetBase):
         self._field.setMaximum(5)
         self._field.setMinimum(1)
         self._field.setValue(3)
-        label = QLabel("Derivative order", self._base)
+        label = QLabel("Interpolation order", self._base)
         self.numerator = QLabel("st order")
         self.adjust_numerator(3)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/__init__.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/__init__.py
@@ -1,4 +1,4 @@
-#    This file is part of MDANSE.
+#    This file is part of MDANSE_GUI.
 #
 #    MDANSE is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -45,6 +45,7 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "VectorConfigurator": VectorWidget,
     "HDFInputFileConfigurator": InputFileWidget,
     "HDFTrajectoryConfigurator": HDFTrajectoryWidget,
+    "DerivativeOrderConfigurator": DerivativeOrderWidget,
     "InterpolationOrderConfigurator": InterpolationOrderWidget,
     "OutputFilesConfigurator": OutputFilesWidget,
     "ASEFileConfigurator": InputFileWidget,


### PR DESCRIPTION
**Description of work**
- Previously the order of the derivative in infrared job was hard-coded. Added a time-derivative configurator so that the order can be selected.
- Updated the default variable of the interpolation order configurator to 3 like the GUI.
- Corrected a few file headers.

**To test**
Run the infrared job with different derivative orders, jobs should complete without any issues.
