### PR TITLE
Correct path saving mechanism for actions

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InputFileWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InputFileWidget.py
@@ -105,15 +105,15 @@ class InputFileWidget(WidgetBase):
             if new_value[0]:
                 self._field.setText(new_value[0])
                 self.updateValue()
-            try:
-                print(
-                    f"Settings path of {self._job_name} to {os.path.split(new_value[0])[0]}"
-                )
-                paths_group.set(self._job_name, os.path.split(new_value[0])[0])
-            except:
-                LOG.error(
-                    f"session.set_path failed for {self._job_name}, {os.path.split(new_value[0])[0]}"
-                )
+                try:
+                    LOG.info(
+                        f"Settings path of {self._job_name} to {os.path.split(new_value[0])[0]}"
+                    )
+                    paths_group.set(self._job_name, os.path.split(new_value[0])[0])
+                except:
+                    LOG.error(
+                        f"session.set_path failed for {self._job_name}, {os.path.split(new_value[0])[0]}"
+                    )
 
     def get_widget_value(self):
         """Collect the results from the input widgets and return the value."""

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotSettings.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotSettings.py
@@ -184,7 +184,7 @@ class PlotSettings(QWidget):
             try:
                 current_cmap = colour_group.get("colormap")
             except KeyError:
-                print(f"Could not get colormap from colours")
+                LOG.warning(f"Could not get colormap from colours")
                 colour_group.add(
                     "colormap",
                     "viridis",
@@ -195,7 +195,7 @@ class PlotSettings(QWidget):
                 if current_cmap not in mpl.colormaps():
                     current_cmap = "viridis"
         except:
-            print(f"Could not get the colours group")
+            LOG.warning(f"Could not get the colours group")
             current_cmap = "viridis"
         cmap_selector = QComboBox(self)
         cmap_selector.addItems(mpl.colormaps())

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "matplotlib",
     "qtpy",
     "vtk",
-    "PyQt6",
+    "PyQt6<=6.7.0",
     "PyYAML",
     "tomlkit"
 ]


### PR DESCRIPTION
**Description of work**
Last improvements to the code consistency before the second alpha release.

**Fixes**
1. Corrected the path saving mechanism, so it does not save the path if the user cancels the file dialog.
2. Replaced several `print` statements with MLogger equivalents.
3. Limited the maximum PyQt version to 6.7.0 (preventing the problem with PyQt 6.7.1 depending on glibc 2.35).

**To test**
1. Pick some input files for a converter, e.g. `/some/path/to/files/input.txt`
2. Now try to pick another file, but cancel the file dialog instead of loading the file.
3. Open the dialog again. The dialog should open in `/some/path/to/files/`.
