### PR TITLE
Change filters for output file names in the GUI

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputFilesWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputFilesWidget.py
@@ -43,7 +43,7 @@ class OutputFilesWidget(WidgetBase):
         except AttributeError:
             self.default_path = "."
             LOG.error("AttributeError in OutputFilesWidget - can't get default path.")
-        self.file_association = ".*"
+        self.file_association = "Output file name (*)"
         self._value = default_value
         self._field = QLineEdit(default_value[0], self._base)
         self._field.setPlaceholderText(default_value[0])

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputStructureWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputStructureWidget.py
@@ -44,7 +44,7 @@ class OutputStructureWidget(WidgetBase):
             LOG.error(
                 "AttributeError in OutputTrajectoryWidget - can't get default path."
             )
-        self.file_association = ".*"
+        self.file_association = "Output file name (*)"
         self._value = default_value
         self._field = QLineEdit(default_value[0], self._base)
         self._field.setPlaceholderText(default_value[0])

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
@@ -54,7 +54,7 @@ class OutputTrajectoryWidget(WidgetBase):
             LOG.error(
                 "AttributeError in OutputTrajectoryWidget - can't get default path."
             )
-        self.file_association = ".*"
+        self.file_association = "MDT trajectory (*.mdt)"
         self._value = default_value
         self._field = QLineEdit(default_value[0], self._base)
         self._field.setPlaceholderText(default_value[0])
@@ -120,6 +120,7 @@ class OutputTrajectoryWidget(WidgetBase):
             self.file_association,  # text string specifying the file name filter.
         )
         if len(new_value[0]) > 0:
+            print(new_value)
             self._field.setText(new_value[0])
             self.updateValue()
 


### PR DESCRIPTION
**Description of work**
At the moment on a Mac the file names in the GUI fields end up getting '.*' appended at the end when filled out via the QFileDialog. This PR prevents it from happening.

**Fixes**
Changed filters in file widgets.

**To test**
Try putting some output file names into the GUI with and without the correct extension.

