### PR TITLE
Add file extension on autoload if missing

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -159,12 +159,16 @@ class JobEntry(Handler, QObject):
                 try:
                     len(self._parameters["output_files"][1])
                 except TypeError:  # job is a converter
-                    self.for_loading.emit(self._parameters["output_files"][0] + ".mdt")
+                    file_name = self._parameters["output_files"][0]
+                    if ".mdt" not in file_name[-5:]:
+                        file_name += ".mdt"
+                    self.for_loading.emit(file_name)
                 else:  # job is an analysis
                     if "MDAFormat" in self._parameters["output_files"][1]:
-                        self.for_loading.emit(
-                            self._parameters["output_files"][0] + ".mda"
-                        )
+                        file_name = self._parameters["output_files"][0]
+                        if ".mda" not in file_name[-5:]:
+                            file_name += ".mda"
+                        self.for_loading.emit(file_name)
         else:
             self._current_state.fail()
         self.update_fields()


### PR DESCRIPTION
**Description of work**
At the moment, the automatic loading of results would fail or work depending on if the GUI input field contained file name with or without the extension, respectively.

closes #521 

**Fixes**
1. Added a check in JobEntry to add the extension only if it is missing.

**To test**
Run a converter and an analysis job twice, once with a name that contains the extension, and once without the extension. The results should be loaded automatically in both cases.
