### PR TITLE
3D viewer crash fix

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -245,8 +245,11 @@ class MolecularViewer(QtWidgets.QWidget):
         LOG.info("... done")
 
     def create_all_actors(self):
-        line_actor, ball_actor = self.create_traj_actors(self._polydata)
         actors = []
+        if self._polydata is None:
+            return actors
+
+        line_actor, ball_actor = self.create_traj_actors(self._polydata)
         if self._cell_visible:
             uc_actor = self.create_uc_actor()
             actors.append(uc_actor)
@@ -801,6 +804,10 @@ class MolecularViewerWithPicking(MolecularViewer):
         self.update_picked_polydata()
 
     def create_all_actors(self):
+        actors = []
+        if self._polydata is None or self._picked_polydata is None:
+            return actors
+
         line_actor, ball_actor = self.create_traj_actors(
             self._polydata,
             line_opacity=self._polydata_opacity,
@@ -809,7 +816,6 @@ class MolecularViewerWithPicking(MolecularViewer):
         picked_line_actor, picked_ball_actor = self.create_traj_actors(
             self._picked_polydata
         )
-        actors = []
         if self._cell_visible:
             uc_actor = self.create_uc_actor()
             actors.append(uc_actor)


### PR DESCRIPTION
**Description of work**
Fixes the GUI crash when the 3D view settings are changed with no trajectory loaded.

**Fixes**
Fixes #532

**To test**
Load up the GUI and go to the 3D viewer and try the following actions.

- Click the toggle projections button.
- Change to the atom scaling.
- Select/deselect the atoms checkbox.
- Select/deselect the bonds checkbox.
- Select/deselect the axes checkbox.
- Select/deselect of the cell checkbox.

GUI should no longer crash. Load a trajectory and check the 3D viewer works as expected. Check the 3D viewer in the atom selection, transmutation, and atom charges dialog. GUI should continue to work after the trajectory has been removed.
