### PR TITLE
Reset camera after changing trajectory.

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -135,6 +135,8 @@ class MolecularViewer(QtWidgets.QWidget):
         self._colour_manager = AtomProperties()
         self.dummy_size = 0.0
 
+        self.reset_camera = False
+
     def setDataModel(self, datamodel: TrajectoryAtomData):
         self._datamodel = datamodel
 
@@ -602,6 +604,7 @@ class MolecularViewer(QtWidgets.QWidget):
         if (self._reader is not None) and (reader.filename == self._reader.filename):
             return
 
+        self.reset_camera = True
         self.clear_trajectory()
 
         self._reader = reader
@@ -666,6 +669,11 @@ class MolecularViewer(QtWidgets.QWidget):
         self._renderer.AddActor(self._actors)
 
         # rendering
+        if self.reset_camera:
+            self._renderer.ResetCamera()
+            self._renderer.ResetCameraClippingRange()
+            self.reset_camera = False
+
         self._iren.Render()
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -671,7 +671,6 @@ class MolecularViewer(QtWidgets.QWidget):
         # rendering
         if self.reset_camera:
             self._renderer.ResetCamera()
-            self._renderer.ResetCameraClippingRange()
             self.reset_camera = False
 
         self._iren.Render()


### PR DESCRIPTION
**Description of work**
Reset the camera when the trajectory is changed. This is helpful when working with systems of different sizes so that the user doesn't need to zoom in or out after switching trajectories.

Before:
![Animation45](https://github.com/user-attachments/assets/6130647a-9afa-441f-90f3-2b260806b1dc)


After:
![Animation44](https://github.com/user-attachments/assets/68d2b957-a54e-4d4a-8429-910e9c464a99)


**Fixes**
Fixes #528

**To test**
Try loading system sizes of different size and switch between them. 3D viewer should reset the camera e.g. zoom out if it switches to the bigger trajectory. Test the 3D viewer in the atom selection dialog.
