### PR TITLE
Frame setting updates animation while it still running.

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -301,10 +301,12 @@ class ViewerControls(QWidget):
     @Slot(int)
     def setTimeStep(self, new_value: int):
         self._time_per_frame = new_value
+        self.animate()
 
     @Slot(int)
     def setFrameSkip(self, new_value: int):
         self._frame_factor = new_value
+        self.animate()
 
     @Slot(float)
     def setAtomSize(self, new_value: float):


### PR DESCRIPTION
**Description of work**
Updated the time per frame and show every N frames setting so that they work while the animation is running. The means that the user doesn't need to stop and start the animation everytime they change those settings.

**Fixes**
Closes #329 

**To test**
Load a trajectory and run the animation, change the time step and frame skip. The animation speed should change while it's still running. Check this is working in the atom selection dialog.
