### PR TITLE
Make the sum of partial terms equal to the total for scattering calculations

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -238,16 +238,21 @@ class DensityOfStates(IJob):
             )
 
         weights = self.configuration["weights"].get_weights()
-        weight(
+        self._outputData["vacf_total"][:] = weight(
             weights,
             self._outputData,
             nAtomsPerElement,
             1,
             "vacf_%s",
-            update_values=True,
+            update_partials=True,
         )
-        weight(
-            weights, self._outputData, nAtomsPerElement, 1, "dos_%s", update_values=True
+        self._outputData["dos_total"][:] = weight(
+            weights,
+            self._outputData,
+            nAtomsPerElement,
+            1,
+            "dos_%s",
+            update_partials=True,
         )
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
@@ -260,26 +260,23 @@ class DynamicCoherentStructureFactor(IJob):
                 axis=1,
             )
 
-        fqtTotal = weight(
+        self._outputData["f(q,t)_total"][:] = weight(
             self.configuration["weights"].get_weights(),
             self._outputData,
             nAtomsPerElement,
             2,
             "f(q,t)_%s%s",
-            update_values=True,
+            update_partials=True,
         )
 
-        self._outputData["f(q,t)_total"][:] = fqtTotal
-
-        sqfTotal = weight(
+        self._outputData["s(q,f)_total"][:] = weight(
             self.configuration["weights"].get_weights(),
             self._outputData,
             nAtomsPerElement,
             2,
             "s(q,f)_%s%s",
-            update_values=True,
+            update_partials=True,
         )
-        self._outputData["s(q,f)_total"][:] = sqfTotal
 
         self._outputData.write(
             self.configuration["output_files"]["root"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
@@ -266,6 +266,7 @@ class DynamicCoherentStructureFactor(IJob):
             nAtomsPerElement,
             2,
             "f(q,t)_%s%s",
+            update_values=True,
         )
 
         self._outputData["f(q,t)_total"][:] = fqtTotal
@@ -276,6 +277,7 @@ class DynamicCoherentStructureFactor(IJob):
             nAtomsPerElement,
             2,
             "s(q,f)_%s%s",
+            update_values=True,
         )
         self._outputData["s(q,f)_total"][:] = sqfTotal
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -267,11 +267,21 @@ class DynamicIncoherentStructureFactor(IJob):
         weights = self.configuration["weights"].get_weights()
 
         self._outputData["f(q,t)_total"][:] = weight(
-            weights, self._outputData, nAtomsPerElement, 1, "f(q,t)_%s"
+            weights,
+            self._outputData,
+            nAtomsPerElement,
+            1,
+            "f(q,t)_%s",
+            update_values=True,
         )
 
         self._outputData["s(q,f)_total"][:] = weight(
-            weights, self._outputData, nAtomsPerElement, 1, "s(q,f)_%s"
+            weights,
+            self._outputData,
+            nAtomsPerElement,
+            1,
+            "s(q,f)_%s",
+            update_values=True,
         )
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -272,7 +272,7 @@ class DynamicIncoherentStructureFactor(IJob):
             nAtomsPerElement,
             1,
             "f(q,t)_%s",
-            update_values=True,
+            update_partials=True,
         )
 
         self._outputData["s(q,f)_total"][:] = weight(
@@ -281,7 +281,7 @@ class DynamicIncoherentStructureFactor(IJob):
             nAtomsPerElement,
             1,
             "s(q,f)_%s",
-            update_values=True,
+            update_partials=True,
         )
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -199,7 +199,12 @@ class ElasticIncoherentStructureFactor(IJob):
 
         weights = self.configuration["weights"].get_weights()
         self._outputData["eisf_total"][:] = weight(
-            weights, self._outputData, nAtomsPerElement, 1, "eisf_%s"
+            weights,
+            self._outputData,
+            nAtomsPerElement,
+            1,
+            "eisf_%s",
+            update_values=True,
         )
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -204,7 +204,7 @@ class ElasticIncoherentStructureFactor(IJob):
             nAtomsPerElement,
             1,
             "eisf_%s",
-            update_values=True,
+            update_partials=True,
         )
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -252,11 +252,21 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         weights = self.configuration["weights"].get_weights()
 
         self._outputData["f(q,t)_total"][:] = weight(
-            weights, self._outputData, nAtomsPerElement, 1, "f(q,t)_%s"
+            weights,
+            self._outputData,
+            nAtomsPerElement,
+            1,
+            "f(q,t)_%s",
+            update_values=True,
         )
 
         self._outputData["s(q,f)_total"][:] = weight(
-            weights, self._outputData, nAtomsPerElement, 1, "s(q,f)_%s"
+            weights,
+            self._outputData,
+            nAtomsPerElement,
+            1,
+            "s(q,f)_%s",
+            update_values=True,
         )
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -257,7 +257,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
             nAtomsPerElement,
             1,
             "f(q,t)_%s",
-            update_values=True,
+            update_partials=True,
         )
 
         self._outputData["s(q,f)_total"][:] = weight(
@@ -266,7 +266,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
             nAtomsPerElement,
             1,
             "s(q,f)_%s",
-            update_values=True,
+            update_partials=True,
         )
 
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -43,7 +43,7 @@ def get_weights(props, contents, dim):
     return weights, normFactor
 
 
-def weight(props, values, contents, dim, key, symmetric=True, update_values=False):
+def weight(props, values, contents, dim, key, symmetric=True, update_partials=False):
     weights = get_weights(props, contents, dim)[0]
     weightedSum = None
     matches = dict([(key % k, k) for k in list(weights.keys())])
@@ -63,8 +63,7 @@ def weight(props, values, contents, dim, key, symmetric=True, update_values=Fals
         else:
             weightedSum += w * val
 
-        if update_values:
-            values[key % "total"] += w * val
+        if update_partials:
             values[k][:] = w * val
 
     return weightedSum


### PR DESCRIPTION
**Description of work**
Given that

![image](https://github.com/user-attachments/assets/a5213aba-77e5-4fd0-b94e-4b5824ea66c6)

the total $F(q, t)$ and $S(q, \omega)$ should be a sum of partial terms. In this PR I have updated the DynamicCoherentStructureFactor, DynamicIncoherentStructureFactor, ElasticIncoherentStructureFactor, and GaussianDynamicIncoherentStructureFactor so that the total is a sum of the partial terms.

This makes the results more clear. For example, with the water trajectory and the DISF, EISF, and GDISF calculations below, we can see that the oxygen atoms with b_inc2 = 6.37e-13 do not contribute much to the total since hydrogen atoms have b_inc2 = 6.39e-8.

Water trajectory
**DCSF** 
Before
![image](https://github.com/user-attachments/assets/3eaa8466-e9d8-4e32-b6a1-5ae63d09bec1)
After
![image](https://github.com/user-attachments/assets/cae74dd6-91d5-4948-b109-eeb683dd541b)


**DISF**
Before
![image](https://github.com/user-attachments/assets/687764e3-2229-4b2c-a53f-303a0a462cdd)
After
![image](https://github.com/user-attachments/assets/497e9216-647e-4022-bcd3-d07d569a466d)


**EISF**
Before
![image](https://github.com/user-attachments/assets/7a2172ca-0e32-4f9e-9efc-0137f72febb0)
After
![image](https://github.com/user-attachments/assets/816cd74c-6b0e-46d3-921c-850d82345475)


**GDISF**
Before
![image](https://github.com/user-attachments/assets/b7fac490-73c5-40fc-98eb-6631fb3298c2)
After
![image](https://github.com/user-attachments/assets/e853c5ff-1a57-452a-aa25-a395b1bd76f8)


**To test**
Run the DynamicCoherentStructureFactor, DynamicIncoherentStructureFactor, ElasticIncoherentStructureFactor, GaussianDynamicIncoherentStructureFactor, and DOS calculations. All total results should be a sum of the partial terms.
