### PR TITLE
Update the keyword variables in weight

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
@@ -219,7 +219,7 @@ class PositionPowerSpectrum(IJob):
             )
 
         weights = self.configuration["weights"].get_weights()
-        weight(
+        self._outputData["pacf_total"][:] = weight(
             weights,
             self._outputData,
             nAtomsPerElement,
@@ -227,7 +227,7 @@ class PositionPowerSpectrum(IJob):
             "pacf_%s",
             update_partials=True,
         )
-        weight(
+        self._outputData["pps_total"][:] = weight(
             weights,
             self._outputData,
             nAtomsPerElement,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
@@ -225,10 +225,15 @@ class PositionPowerSpectrum(IJob):
             nAtomsPerElement,
             1,
             "pacf_%s",
-            update_values=True,
+            update_partials=True,
         )
         weight(
-            weights, self._outputData, nAtomsPerElement, 1, "pps_%s", update_values=True
+            weights,
+            self._outputData,
+            nAtomsPerElement,
+            1,
+            "pps_%s",
+            update_partials=True,
         )
 
         self._outputData.write(


### PR DESCRIPTION
**Description of work**
A recent PR changed the keyword name in `weight` function. This PR updates the PositionPowerSpectrum accordingly.

**Fixes**
Changed `update_values` to `update_partials` in `weight`

**To test**
All tests must pass. Run PPS again and compare results.
