### PR TITLE
Text output in the plotter

### DIFF
--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -37,8 +37,9 @@ def get_weights(props, contents, dim):
         else:
             normFactor += fact
 
-    for k in list(weights.keys()):
-        weights[k] /= np.float64(normFactor)
+    if abs(normFactor) > 0.0:  # if normFactor is 0, all weights are 0 too.
+        for k in list(weights.keys()):
+            weights[k] /= np.float64(normFactor)
 
     return weights, normFactor
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -107,6 +107,9 @@ class TabbedWindow(QMainWindow):
         self._tabs["Plot Creator"]._visualiser.create_new_plot.connect(
             self._tabs["Plot Holder"]._visualiser.new_plot
         )
+        self._tabs["Plot Creator"]._visualiser.create_new_text.connect(
+            self._tabs["Plot Holder"]._visualiser.new_text
+        )
 
     def createCommonModels(self):
         self._trajectory_model = GeneralModel()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/LoggingTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/LoggingTab.py
@@ -84,8 +84,13 @@ class LoggingTab(GeneralTab):
             )
 
     def add_handler(self, new_handler):
+        try:
+            current_level = self._loglevel_combo.currentText()
+        except:
+            current_level = "INFO"
         self._extra_handler = new_handler
         self._extra_handler.add_visualiser(self._visualiser)
+        self.change_log_level(current_level)
 
     def log_qt_handler(self, m_type, m_context, m_text):
         self._visualiser.append_text(f"Qt log message (type={m_type})=" + m_text)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -94,7 +94,7 @@ class SingleDataset:
                 self._axes_units[aname] = source[aname].attrs["units"]
 
     def available_x_axes(self) -> List[str]:
-        return list(self._axes_units.values())
+        return list(self._axes_units.keys())
 
     def longest_axis(self) -> str:
         length = -1

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -332,6 +332,8 @@ class PlottingContext(QStandardItemModel):
                 subitems = temp.standard_items(newkey + f":{counter}")
                 items[0].appendRow(subitems)
                 counter += 1
+        elif len(curves) == 1:
+            LOG.debug("A single curve output from PlottingContext.")
         else:
             LOG.error("No curves!")
         self.appendRow(items)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotSelectionTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotSelectionTab.py
@@ -48,10 +48,11 @@ class PlotSelectionTab(GeneralTab):
         results += [
             [
                 "dialogs",
-                {"new_plot": "True", "data_plotted": "True"},
+                {"new_plot": "True", "data_plotted": "True", "new_text": "True"},
                 {
                     "new_plot": "Show a pop-up dialog EVERY TIME a new plot is created",
                     "data_plotted": "Show a pop-up dialog EVERY TIME a data set is plotted",
+                    "new_text": "Show a pop-up dialog EVERY TIME a new data view is created",
                 },
             ]
         ]

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
@@ -18,6 +18,8 @@ from functools import partial
 from qtpy.QtCore import Slot
 from qtpy.QtWidgets import QWidget
 
+from MDANSE.MLogging import LOG
+
 from MDANSE_GUI.Tabs.GeneralTab import GeneralTab
 from MDANSE_GUI.Tabs.Layouts.MultiPanel import MultiPanel
 from MDANSE_GUI.Session.LocalSession import LocalSession
@@ -101,8 +103,16 @@ class PlotTab(GeneralTab):
 
     @Slot(object)
     def accept_external_data(self, data_model):
-        self._visualiser.model.accept_external_data(data_model)
-        self._visualiser.plotter.plot_data()
+        LOG.debug(f"accept_external_data received {data_model}")
+        try:
+            self._visualiser.model.accept_external_data(data_model)
+        except Exception as e:
+            LOG.error(f"Visualiser failed to pass data model: {e.with_traceback()}")
+        else:
+            try:
+                self._visualiser.plotter.plot_data()
+            except Exception as e2:
+                LOG.error(f"Visualiser failed to plot data: {e2.with_traceback()}")
 
     @Slot(int)
     def switch_model(self, tab_id):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
@@ -107,12 +107,12 @@ class PlotTab(GeneralTab):
         try:
             self._visualiser.model.accept_external_data(data_model)
         except Exception as e:
-            LOG.error(f"Visualiser failed to pass data model: {e.with_traceback()}")
+            LOG.error(f"Visualiser failed to pass data model: {e}")
         else:
             try:
                 self._visualiser.plotter.plot_data()
             except Exception as e2:
-                LOG.error(f"Visualiser failed to plot data: {e2.with_traceback()}")
+                LOG.error(f"Visualiser failed to plot data: {e2}")
 
     @Slot(int)
     def switch_model(self, tab_id):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Grid.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Grid.py
@@ -47,6 +47,7 @@ class Grid(Plotter):
         update_only=False,
         toolbar=None,
     ):
+        self.enable_slider(False)
         target = self.get_figure(figure)
         self.get_mpl_colors()
         if colours is not None:
@@ -57,7 +58,7 @@ class Grid(Plotter):
         if toolbar is not None:
             self._toolbar = toolbar
         if plotting_context.set_axes() is None:
-            LOG.error("Axis check failed.")
+            LOG.debug("Axis check failed.")
             return
         self._axes = []
         self.apply_settings(plotting_context, colours)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Heatmap.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Heatmap.py
@@ -114,6 +114,7 @@ class Heatmap(Plotter):
         update_only=False,
         toolbar=None,
     ):
+        self.enable_slider(True)
         target = self.get_figure(figure)
         if target is None:
             return
@@ -131,7 +132,7 @@ class Heatmap(Plotter):
             self._last_axes_units = {}
         self.apply_settings(plotting_context, colours)
         if plotting_context.set_axes() is None:
-            LOG.error("Axis check failed.")
+            LOG.debug("Axis check failed.")
             return
         nplots = 0
         for databundle in plotting_context.datasets().values():

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Plotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Plotter.py
@@ -82,7 +82,7 @@ class Plotter(metaclass=SubclassFactory):
         if colours is not None:
             self._current_colours = colours
         if plotting_context.set_axes() is None:
-            LOG.error("Axis check failed.")
+            LOG.debug("Axis check failed.")
             return
         try:
             matplotlib_style = colours["style"]
@@ -107,6 +107,14 @@ class Plotter(metaclass=SubclassFactory):
             if col_seq is not None:
                 for axes in self._axes:
                     axes.set_prop_cycle("color", col_seq)
+
+    def enable_slider(self, allow_slider: bool = True):
+        if allow_slider:
+            self._slider_reference.setEnabled(True)
+            self._slider_reference.blockSignals(False)
+        else:
+            self._slider_reference.setEnabled(False)
+            self._slider_reference.blockSignals(True)
 
     def handle_slider(self, new_value: List[float]):
         self._slider_values = new_value

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Single.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Single.py
@@ -106,6 +106,7 @@ class Single(Plotter):
         update_only=False,
         toolbar=None,
     ):
+        self.enable_slider(False)
         target = self.get_figure(figure)
         if target is None:
             return
@@ -121,7 +122,7 @@ class Single(Plotter):
         self.apply_settings(plotting_context, colours)
         self.height_max, self.length_max = 0.0, 0.0
         if plotting_context.set_axes() is None:
-            LOG.error("Axis check failed.")
+            LOG.debug("Axis check failed.")
             return
         if len(plotting_context.datasets()) == 0:
             target.clear()
@@ -187,6 +188,8 @@ class Single(Plotter):
                             LOG.error(f"x_axis={dataset._axes[best_axis]}")
                             LOG.error(f"values={value}")
                             return
+        if len(self._backup_curves) > 1:
+            self.enable_slider(True)
         if update_only:
             axes.set_xlim((self._backup_limits[0], self._backup_limits[1]))
             axes.set_ylim((self._backup_limits[2], self._backup_limits[3]))

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
@@ -15,13 +15,15 @@
 #
 from typing import TYPE_CHECKING, List
 
+import numpy as np
+
 from MDANSE.Framework.Units import measure
 from MDANSE.MLogging import LOG
 
 from MDANSE_GUI.Tabs.Plotters.Plotter import Plotter
 
 if TYPE_CHECKING:
-    from matplotlib.figure import Figure
+    from qtpy.QtWidgets import QTextBrowser
     from MDANSE_GUI.Tabs.Models.PlottingContext import PlottingContext
 
 
@@ -37,7 +39,7 @@ class Text(Plotter):
         self._curve_limit_per_dataset = 12
         self.height_max, self.length_max = 0.0, 0.0
 
-    def clear(self, figure: "Figure" = None):
+    def clear(self, figure: "QTextBrowser" = None):
         if figure is None:
             target = self._figure
         else:
@@ -46,7 +48,7 @@ class Text(Plotter):
             return
         target.clear()
 
-    def get_figure(self, figure: "Figure" = None):
+    def get_figure(self, figure: "QTextBrowser" = None):
         if figure is None:
             target = self._figure
         else:
@@ -57,51 +59,10 @@ class Text(Plotter):
         target.clear()
         return target
 
-    def slider_labels(self) -> List[str]:
-        return ["Y offset", "X offset"]
-
-    def slider_limits(self) -> List[str]:
-        return self._number_of_sliders * [[-1.0, 1.0, 0.01]]
-
-    def handle_slider(self, new_value: List[float]):
-        super().handle_slider(new_value)
-        self.offset_curves()
-
-    def offset_curves(self):
-        target = self._figure
-        if target is None:
-            return
-        if len(self._active_curves) == 0:
-            return
-        new_value = self._slider_values
-        saved_xmin, saved_xmax, saved_ymin, saved_ymax = self._backup_limits
-        for num, curve in enumerate(self._active_curves):
-            xdata = self._backup_curves[num][0]
-            ydata = self._backup_curves[num][1]
-            new_xdata = xdata + num * self.length_max * new_value[1]
-            new_ydata = ydata + num * self.height_max * new_value[0]
-            curve.set_xdata(new_xdata)
-            curve.set_ydata(new_ydata)
-            xmin, xmax = new_xdata.min(), new_xdata.max()
-            ymin, ymax = new_ydata.min(), new_ydata.max()
-            saved_xmin = min(xmin, saved_xmin)
-            saved_xmax = max(xmax, saved_xmax)
-            saved_ymin = min(ymin, saved_ymin)
-            saved_ymax = max(ymax, saved_ymax)
-        self._backup_limits = [saved_xmin, saved_xmax, saved_ymin, saved_ymax]
-        self._axes[0].relim()
-        self._axes[0].autoscale()
-        if self._toolbar is not None:
-            self._toolbar.update()
-            self._toolbar.push_current()
-        self._axes[0].set_xlim(saved_xmin, saved_xmax)
-        self._axes[0].set_ylim(saved_ymin, saved_ymax)
-        target.canvas.draw()
-
     def plot(
         self,
         plotting_context: "PlottingContext",
-        figure: "Figure" = None,
+        figure: "QTextBrowser" = None,
         colours=None,
         update_only=False,
         toolbar=None,
@@ -115,9 +76,6 @@ class Text(Plotter):
         xaxis_unit = None
         self._active_curves = []
         self._backup_curves = []
-        self.get_mpl_colors()
-        axes = target.add_subplot(111)
-        self._axes = [axes]
         self.apply_settings(plotting_context, colours)
         self.height_max, self.length_max = 0.0, 0.0
         if plotting_context.set_axes() is None:
@@ -125,11 +83,15 @@ class Text(Plotter):
             return
         if len(plotting_context.datasets()) == 0:
             target.clear()
-            target.canvas.draw()
+        new_header = "# MDANSE Data \n"
+        new_text = ""
+        top_line = []
+        left_column = [""]
+        all_fields = []
         for name, databundle in plotting_context.datasets().items():
-            dataset, colour, linestyle, marker, _ = databundle
+            dataset, _, _, _, _ = databundle
             best_unit, best_axis = dataset.longest_axis()
-            plotlabel = dataset._labels["medium"]
+            other_axes = {}
             xaxis_unit = plotting_context.get_conversion_factor(best_unit)
             try:
                 conversion_factor = measure(1.0, best_unit, equivalent=True).toval(
@@ -139,62 +101,34 @@ class Text(Plotter):
                 continue
             else:
                 if dataset._n_dim == 1:
-                    [temp] = axes.plot(
-                        dataset._axes[best_axis] * conversion_factor,
-                        dataset._data,
-                        linestyle=linestyle,
-                        label=plotlabel,
-                        color=colour,
-                    )
-                    try:
-                        temp.set_marker(marker)
-                    except ValueError:
-                        try:
-                            temp.set_marker(int(marker))
-                        except:
-                            pass
-                    self._active_curves.append(temp)
-                    self._backup_curves.append([temp.get_xdata(), temp.get_ydata()])
-                    self.height_max = max(self.height_max, temp.get_ydata().max())
-                    self.length_max = max(self.length_max, temp.get_xdata().max())
-                else:
-                    multi_curves = dataset.curves_vs_axis(best_unit)
-                    counter = 0
-                    for key, value in multi_curves.items():
-                        counter += 1
-                        if counter >= self._curve_limit_per_dataset:
+                    temp = np.vstack(
+                        [dataset._axes[best_axis] * conversion_factor, dataset._data]
+                    ).T
+                elif dataset._n_dim == 2:
+                    shape = list(dataset._data.shape)
+                    for name, axis in dataset._axes.items():
+                        if name == best_axis:
+                            continue
+                        axis_unit = dataset._axes_units[name]
+                        new_axis_unit = plotting_context.get_conversion_factor(
+                            axis_unit
+                        )
+                        conv_factor = measure(1.0, axis_unit, equivalent=True).toval(
+                            new_axis_unit
+                        )
+                        other_axes[name] = axis * conv_factor
+                    for key, value in other_axes.items():
+                        if len(value) in shape:
+                            otheraxis = other_axes[key]
                             break
-                        try:
-                            [temp] = axes.plot(
-                                dataset._axes[best_axis] * conversion_factor,
-                                value,
-                                label=plotlabel + ":" + dataset._curve_labels[key],
-                            )
-                            self._active_curves.append(temp)
-                            self._backup_curves.append(
-                                [temp.get_xdata(), temp.get_ydata()]
-                            )
-                            self.height_max = max(
-                                self.height_max, temp.get_ydata().max()
-                            )
-                            self.length_max = max(
-                                self.length_max, temp.get_xdata().max()
-                            )
-                        except ValueError:
-                            LOG.error(
-                                f"Plotting failed for {plotlabel} using {best_axis}"
-                            )
-                            LOG.error(f"x_axis={dataset._axes[best_axis]}")
-                            LOG.error(f"values={value}")
-                            return
-        if update_only:
-            axes.set_xlim((self._backup_limits[0], self._backup_limits[1]))
-            axes.set_ylim((self._backup_limits[2], self._backup_limits[3]))
-        else:
-            xlimits, ylimits = axes.get_xlim(), axes.get_ylim()
-            self._backup_limits = [xlimits[0], xlimits[1], ylimits[0], ylimits[1]]
-        if xaxis_unit is not None:
-            axes.set_xlabel(xaxis_unit)
-        axes.grid(True)
-        axes.legend(loc=0)
-        self.offset_curves()
+                    temp = np.hstack(
+                        [dataset._axes[best_axis] * conversion_factor, dataset._data]
+                    )
+                    temp = np.vstack([np.concatenate([[0.0], otheraxis]), temp])
+                else:
+                    return
+                text_data = "\n".join(
+                    [" ".join([str(x) for x in line]) for line in temp]
+                )
+                new_text = "\n".join([new_header, text_data])
+        target.setText(new_text)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
@@ -1,0 +1,200 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from typing import TYPE_CHECKING, List
+
+from MDANSE.Framework.Units import measure
+from MDANSE.MLogging import LOG
+
+from MDANSE_GUI.Tabs.Plotters.Plotter import Plotter
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
+    from MDANSE_GUI.Tabs.Models.PlottingContext import PlottingContext
+
+
+class Text(Plotter):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._figure = None
+        self._current_colours = []
+        self._active_curves = []
+        self._backup_curves = []
+        self._backup_limits = []
+        self._curve_limit_per_dataset = 12
+        self.height_max, self.length_max = 0.0, 0.0
+
+    def clear(self, figure: "Figure" = None):
+        if figure is None:
+            target = self._figure
+        else:
+            target = figure
+        if target is None:
+            return
+        target.clear()
+
+    def get_figure(self, figure: "Figure" = None):
+        if figure is None:
+            target = self._figure
+        else:
+            target = figure
+        if target is None:
+            LOG.error(f"PlottingContext can't plot to {target}")
+            return
+        target.clear()
+        return target
+
+    def slider_labels(self) -> List[str]:
+        return ["Y offset", "X offset"]
+
+    def slider_limits(self) -> List[str]:
+        return self._number_of_sliders * [[-1.0, 1.0, 0.01]]
+
+    def handle_slider(self, new_value: List[float]):
+        super().handle_slider(new_value)
+        self.offset_curves()
+
+    def offset_curves(self):
+        target = self._figure
+        if target is None:
+            return
+        if len(self._active_curves) == 0:
+            return
+        new_value = self._slider_values
+        saved_xmin, saved_xmax, saved_ymin, saved_ymax = self._backup_limits
+        for num, curve in enumerate(self._active_curves):
+            xdata = self._backup_curves[num][0]
+            ydata = self._backup_curves[num][1]
+            new_xdata = xdata + num * self.length_max * new_value[1]
+            new_ydata = ydata + num * self.height_max * new_value[0]
+            curve.set_xdata(new_xdata)
+            curve.set_ydata(new_ydata)
+            xmin, xmax = new_xdata.min(), new_xdata.max()
+            ymin, ymax = new_ydata.min(), new_ydata.max()
+            saved_xmin = min(xmin, saved_xmin)
+            saved_xmax = max(xmax, saved_xmax)
+            saved_ymin = min(ymin, saved_ymin)
+            saved_ymax = max(ymax, saved_ymax)
+        self._backup_limits = [saved_xmin, saved_xmax, saved_ymin, saved_ymax]
+        self._axes[0].relim()
+        self._axes[0].autoscale()
+        if self._toolbar is not None:
+            self._toolbar.update()
+            self._toolbar.push_current()
+        self._axes[0].set_xlim(saved_xmin, saved_xmax)
+        self._axes[0].set_ylim(saved_ymin, saved_ymax)
+        target.canvas.draw()
+
+    def plot(
+        self,
+        plotting_context: "PlottingContext",
+        figure: "Figure" = None,
+        colours=None,
+        update_only=False,
+        toolbar=None,
+    ):
+        target = self.get_figure(figure)
+        if target is None:
+            return
+        if toolbar is not None:
+            self._toolbar = toolbar
+        self._figure = target
+        xaxis_unit = None
+        self._active_curves = []
+        self._backup_curves = []
+        self.get_mpl_colors()
+        axes = target.add_subplot(111)
+        self._axes = [axes]
+        self.apply_settings(plotting_context, colours)
+        self.height_max, self.length_max = 0.0, 0.0
+        if plotting_context.set_axes() is None:
+            LOG.error("Axis check failed.")
+            return
+        if len(plotting_context.datasets()) == 0:
+            target.clear()
+            target.canvas.draw()
+        for name, databundle in plotting_context.datasets().items():
+            dataset, colour, linestyle, marker, _ = databundle
+            best_unit, best_axis = dataset.longest_axis()
+            plotlabel = dataset._labels["medium"]
+            xaxis_unit = plotting_context.get_conversion_factor(best_unit)
+            try:
+                conversion_factor = measure(1.0, best_unit, equivalent=True).toval(
+                    xaxis_unit
+                )
+            except:
+                continue
+            else:
+                if dataset._n_dim == 1:
+                    [temp] = axes.plot(
+                        dataset._axes[best_axis] * conversion_factor,
+                        dataset._data,
+                        linestyle=linestyle,
+                        label=plotlabel,
+                        color=colour,
+                    )
+                    try:
+                        temp.set_marker(marker)
+                    except ValueError:
+                        try:
+                            temp.set_marker(int(marker))
+                        except:
+                            pass
+                    self._active_curves.append(temp)
+                    self._backup_curves.append([temp.get_xdata(), temp.get_ydata()])
+                    self.height_max = max(self.height_max, temp.get_ydata().max())
+                    self.length_max = max(self.length_max, temp.get_xdata().max())
+                else:
+                    multi_curves = dataset.curves_vs_axis(best_unit)
+                    counter = 0
+                    for key, value in multi_curves.items():
+                        counter += 1
+                        if counter >= self._curve_limit_per_dataset:
+                            break
+                        try:
+                            [temp] = axes.plot(
+                                dataset._axes[best_axis] * conversion_factor,
+                                value,
+                                label=plotlabel + ":" + dataset._curve_labels[key],
+                            )
+                            self._active_curves.append(temp)
+                            self._backup_curves.append(
+                                [temp.get_xdata(), temp.get_ydata()]
+                            )
+                            self.height_max = max(
+                                self.height_max, temp.get_ydata().max()
+                            )
+                            self.length_max = max(
+                                self.length_max, temp.get_xdata().max()
+                            )
+                        except ValueError:
+                            LOG.error(
+                                f"Plotting failed for {plotlabel} using {best_axis}"
+                            )
+                            LOG.error(f"x_axis={dataset._axes[best_axis]}")
+                            LOG.error(f"values={value}")
+                            return
+        if update_only:
+            axes.set_xlim((self._backup_limits[0], self._backup_limits[1]))
+            axes.set_ylim((self._backup_limits[2], self._backup_limits[3]))
+        else:
+            xlimits, ylimits = axes.get_xlim(), axes.get_ylim()
+            self._backup_limits = [xlimits[0], xlimits[1], ylimits[0], ylimits[1]]
+        if xaxis_unit is not None:
+            axes.set_xlabel(xaxis_unit)
+        axes.grid(True)
+        axes.legend(loc=0)
+        self.offset_curves()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
@@ -41,6 +41,7 @@ class DatasetFormatter:
         self._new_text = []
         self._is_preview = True
         self._preview_lines = 10
+        self._preview_columns = 10
         self._rounding_prec = 5
         self._comment = "#"
         self._separator = " "
@@ -192,17 +193,19 @@ class DatasetFormatter:
         LOG.debug(f"Data shape: {dataset._data.shape}")
         if self._is_preview:
             nlines = self._preview_lines
+            ncols = self._preview_columns
             nlines = min(nlines, len(new_axes[axis_numbers[0]]))
+            ncols = min(ncols, len(new_axes[axis_numbers[1]]))
             temp = np.hstack(
                 [
                     new_axes[axis_numbers[0]][:nlines].reshape((nlines, 1)),
-                    dataset._data,
+                    dataset._data[:nlines, :ncols],
                 ]
             )
             temp = np.vstack(
                 [
-                    np.concatenate([[0], new_axes[axis_numbers[1]]]).reshape(
-                        (1, dataset._data.shape[1] + 1)
+                    np.concatenate([[0], new_axes[axis_numbers[1]][:ncols]]).reshape(
+                        (1, ncols + 1)
                     ),
                     temp,
                 ]
@@ -297,12 +300,19 @@ class Text(Plotter):
         LOG.debug("Text.clear finished")
 
     def adjust_formatter(
-        self, preview=False, preview_lines=10, rounding=15, separator=" ", comment="#"
+        self,
+        preview=False,
+        preview_lines=10,
+        preview_columns=10,
+        rounding=15,
+        separator=" ",
+        comment="#",
     ):
         if self._formatter is None or self._pc_backup is None or self._figure is None:
             return
         self._formatter._is_preview = preview
         self._formatter._preview_lines = preview_lines
+        self._formatter._preview_columns = preview_columns
         self._formatter._rounding_prec = rounding
         self._formatter._separator = separator
         self._formatter._comment = comment

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
@@ -418,7 +418,7 @@ class Text(Plotter):
         self.apply_settings(plotting_context, colours)
         self.height_max, self.length_max = 0.0, 0.0
         if plotting_context.set_axes() is None:
-            LOG.error("Axis check failed.")
+            LOG.debug("Axis check failed.")
             return
         if len(plotting_context.datasets()) == 0:
             target.clear()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
@@ -70,25 +70,50 @@ class DatasetFormatter:
         for name, databundle in self._plotting_context.datasets().items():
             dataset, _, _, _, _ = databundle
             if dataset._n_dim == 1:
-                header, data = self.process_1D_data(dataset, separator=self._separator)
+                header, data = self.process_1D_data(
+                    dataset, separator=self._separator, is_preview=self._is_preview
+                )
                 self._new_text.append(
                     self.join_for_gui(header, data, separator=self._separator)
                 )
             elif dataset._n_dim == 2:
                 header, data = self.process_2D_data(
-                    dataset, name, separator=self._separator
+                    dataset,
+                    name,
+                    separator=self._separator,
+                    is_preview=self._is_preview,
                 )
                 self._new_text.append(
                     self.join_for_gui(header, data, separator=self._separator)
                 )
             else:
                 header, data = self.process_ND_data(
-                    dataset, name, separator=self._separator
+                    dataset,
+                    name,
+                    separator=self._separator,
+                    is_preview=self._is_preview,
                 )
                 self._new_text.append(
                     self.join_for_gui(header, data, separator=self._separator)
                 )
         return self._new_text
+
+    def datasets_for_csv(self):
+        if self._plotting_context is None:
+            return ["No data selected"]
+        for name, databundle in self._plotting_context.datasets().items():
+            dataset, _, _, _, _ = databundle
+            if dataset._n_dim == 1:
+                header, data = self.process_1D_data(dataset, separator=self._separator)
+            elif dataset._n_dim == 2:
+                header, data = self.process_2D_data(
+                    dataset, name, separator=self._separator
+                )
+            else:
+                header, data = self.process_ND_data(
+                    dataset, name, separator=self._separator
+                )
+            yield header, data
 
     def make_dataset_header(self, dataset: "SingleDataset", comment_character="#"):
         """Extracts information related to the input dataset, and converts them
@@ -130,7 +155,9 @@ class DatasetFormatter:
         new_header = "\n".join(header_lines)
         return new_header + "\n" + text_data
 
-    def process_1D_data(self, dataset: "SingleDataset", separator=" "):
+    def process_1D_data(
+        self, dataset: "SingleDataset", separator=" ", is_preview=False
+    ):
         """Formats a 1D array as a 2-column table with a commented header.
         The first column is determined using the information stored
         in the PlottingContext.
@@ -163,7 +190,7 @@ class DatasetFormatter:
             header_lines.append(
                 f"{self._comment} col1:{best_axis}:{xaxis_unit} col2:data:{dataset._data_unit}"
             )
-            if self._is_preview:
+            if is_preview:
                 temp = np.vstack(
                     [
                         dataset._axes[best_axis][: self._preview_lines]
@@ -177,7 +204,9 @@ class DatasetFormatter:
                 ).T
             return header_lines, temp
 
-    def process_2D_data(self, dataset: "SingleDataset", name: str, separator=" "):
+    def process_2D_data(
+        self, dataset: "SingleDataset", name: str, separator=" ", is_preview=False
+    ):
         header_lines, comment_char = self.make_dataset_header(
             dataset, comment_character=self._comment
         )
@@ -203,7 +232,7 @@ class DatasetFormatter:
                     f"{comment_char} first row is {ax_key} in units {new_unit}"
                 )
         LOG.debug(f"Data shape: {dataset._data.shape}")
-        if self._is_preview:
+        if is_preview:
             nlines = self._preview_lines
             ncols = self._preview_columns
             nlines = min(nlines, len(new_axes[axis_numbers[0]]))
@@ -239,7 +268,9 @@ class DatasetFormatter:
             )
         return header_lines, temp
 
-    def process_ND_data(self, dataset: "SingleDataset", name: str, separator=" "):
+    def process_ND_data(
+        self, dataset: "SingleDataset", name: str, separator=" ", is_preview=False
+    ):
         header_lines, comment_char = self.make_dataset_header(
             dataset, comment_character=self._comment
         )

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
@@ -87,11 +87,23 @@ class DatasetFormatter:
 
     def process_2D_data(self, dataset: "SingleDataset", name: str):
         header_lines = self.make_dataset_header(dataset)
-        return header_lines
+        temp = []
+        if len(temp) > 0:
+            text_data = "\n".join([" ".join([str(x) for x in line]) for line in temp])
+        else:
+            text_data = ""
+        new_header = "\n".join(header_lines)
+        return new_header + "\n" + text_data
 
     def process_ND_data(self, dataset: "SingleDataset", name: str):
         header_lines = self.make_dataset_header(dataset)
-        return header_lines
+        temp = []
+        if len(temp) > 0:
+            text_data = "\n".join([" ".join([str(x) for x in line]) for line in temp])
+        else:
+            text_data = ""
+        new_header = "\n".join(header_lines)
+        return new_header + "\n" + text_data
 
 
 class Text(Plotter):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
@@ -40,6 +40,7 @@ class Text(Plotter):
         self.height_max, self.length_max = 0.0, 0.0
 
     def clear(self, figure: "QTextBrowser" = None):
+        LOG.debug("Text.clear stared")
         if figure is None:
             target = self._figure
         else:
@@ -47,8 +48,10 @@ class Text(Plotter):
         if target is None:
             return
         target.clear()
+        LOG.debug("Text.clear finished")
 
     def get_figure(self, figure: "QTextBrowser" = None):
+        LOG.debug("Text.get_figure stared")
         if figure is None:
             target = self._figure
         else:
@@ -57,7 +60,16 @@ class Text(Plotter):
             LOG.error(f"PlottingContext can't plot to {target}")
             return
         target.clear()
+        LOG.debug("Text.get_figure finished")
         return target
+
+    def apply_settings(self, plotting_context: "PlottingContext", colours=None):
+        LOG.debug("Text.apply_settings stared")
+        if colours is not None:
+            self._current_colours = colours
+        if plotting_context.set_axes() is None:
+            LOG.error("Axis check failed.")
+            return
 
     def plot(
         self,
@@ -67,6 +79,7 @@ class Text(Plotter):
         update_only=False,
         toolbar=None,
     ):
+        LOG.debug("Text.plot stared")
         target = self.get_figure(figure)
         if target is None:
             return

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -36,7 +36,7 @@ class PlotDataView(QTreeView):
         self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.click_position = None
         self.clicked.connect(self.on_select_dataset)
-        self.data_dialog = DataDialog(self)
+        # self.data_dialog = DataDialog(self)
         self._data_packet = None
 
     def mousePressEvent(self, e: QMouseEvent) -> None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -21,6 +21,7 @@ from qtpy.QtGui import QMouseEvent, QDrag, QContextMenuEvent, QStandardItem
 
 from MDANSE_GUI.Tabs.Visualisers.DataPlotter import DataPlotter
 from MDANSE_GUI.Tabs.Visualisers.PlotDataInfo import PlotDataInfo
+from MDANSE_GUI.Widgets.DataDialog import DataDialog
 
 
 class PlotDataView(QTreeView):
@@ -35,6 +36,8 @@ class PlotDataView(QTreeView):
         self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.click_position = None
         self.clicked.connect(self.on_select_dataset)
+        self.data_dialog = DataDialog(self)
+        self._data_packet = None
 
     def mousePressEvent(self, e: QMouseEvent) -> None:
         self.click_position = e.position()
@@ -50,7 +53,15 @@ class PlotDataView(QTreeView):
         model = self.model()
         qitem = model.itemFromIndex(index)
         if qitem.parent() is not None:
-            return
+            model = self.model()
+            item = model.itemFromIndex(index)
+            text = item.text()
+            mda_data_structure = model.inner_object(index)
+            try:
+                packet = text, mda_data_structure._file
+            except AttributeError:
+                packet = text, mda_data_structure.file
+            self._data_packet = packet
         menu = QMenu()
         item = model.itemData(index)
         self.populateMenu(menu, item)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
@@ -37,6 +37,7 @@ class DataPlotter(QWidget):
     data_for_plotting = Signal(object)
     data_for_new_plot = Signal(object)
     create_new_plot = Signal(str)
+    create_new_text = Signal(object)
 
     def __init__(self, *args, unit_lookup=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -52,6 +53,7 @@ class DataPlotter(QWidget):
             ("Plot Data", self.plot_data),
             ("Clear", self.clear),
             ("New Plot", self.new_plot),
+            ("Show as Text", self.new_text),
         ]
         for name, function in buttons:
             button = QPushButton(name, button_bar)
@@ -90,6 +92,29 @@ class DataPlotter(QWidget):
             if plot_added_box == QMessageBox.StandardButton.No:
                 group = self._settings.group("dialogs")
                 group.set("new_plot", "False")
+
+    @Slot()
+    def new_text(self):
+        if self._model is None:
+            return
+        self.create_new_text.emit(self._model)
+        group = self._settings.group("dialogs")
+        try:
+            show_it = group.get("new_text")
+        except KeyError:
+            show_it = group.get_default("dialogs", "new_text")
+        if show_it != "False":
+            plot_added_box = QMessageBox.information(
+                self,
+                "Plot created",
+                "A new text view has been created in the next tab (called 'Plot Holder').\n"
+                "Should this message be shown every time this happens?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.Yes,
+            )
+            if plot_added_box == QMessageBox.StandardButton.No:
+                group = self._settings.group("dialogs")
+                group.set("new_text", "False")
 
     @Slot()
     def plot_data(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
@@ -37,7 +37,7 @@ class DataPlotter(QWidget):
     data_for_plotting = Signal(object)
     data_for_new_plot = Signal(object)
     create_new_plot = Signal(str)
-    create_new_text = Signal(object)
+    create_new_text = Signal(str)
 
     def __init__(self, *args, unit_lookup=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -53,7 +53,7 @@ class DataPlotter(QWidget):
             ("Plot Data", self.plot_data),
             ("Clear", self.clear),
             ("New Plot", self.new_plot),
-            ("Show as Text", self.new_text),
+            ("New Data View (Text)", self.new_text),
         ]
         for name, function in buttons:
             button = QPushButton(name, button_bar)
@@ -95,9 +95,7 @@ class DataPlotter(QWidget):
 
     @Slot()
     def new_text(self):
-        if self._model is None:
-            return
-        self.create_new_text.emit(self._model)
+        self.create_new_text.emit("Text view")
         group = self._settings.group("dialogs")
         try:
             show_it = group.get("new_text")
@@ -119,9 +117,9 @@ class DataPlotter(QWidget):
     @Slot()
     def plot_data(self):
         if self._model is not None:
-            self.data_for_plotting.emit(self._model)
             if len(self._model.datasets()) == 0:
                 return
+            self.data_for_plotting.emit(self._model)
             group = self._settings.group("dialogs")
             try:
                 show_it = group.get("data_plotted")

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
@@ -132,8 +132,23 @@ class DataWidget(QWidget):
             self._current_path = os.path.split(new_value[0])[0]
 
     @Slot()
-    def save_to_file():
-        pass
+    def save_to_file(self):
+        target_path = self._output_widget.text()
+        try:
+            target = open(target_path, "w")
+        except:
+            LOG.error(f"Could not open file for writing: {target_path}")
+        else:
+            writer = csv.writer(
+                target,
+                dialect=self._dialect_combo.currentText,
+            )
+            for header, data in self._plotter._formatter.datasets_for_csv():
+                for line in header:
+                    target.write(line + "\n")
+                for row in data:
+                    writer.writerow(row)
+            target.close()
 
     @Slot(object)
     def slider_change(self, new_values: object):
@@ -208,11 +223,10 @@ class DataWidget(QWidget):
                 update_only=None,
                 toolbar=None,
             )
-            temp = self._plotting_context.datasets().values()
-            if len(temp) > 0:
-                self._current_path = os.path.split(temp[0]._filename)[0]
-            else:
-                self._current_path = "."
+            for _, databundle in self._plotting_context.datasets().items():
+                dataset, _, _, _, _ = databundle
+                self._current_path = os.path.split(dataset._filename)[0]
+                break
         except Exception as e:
             LOG.error(f"DataWidget error: {e}")
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
@@ -107,13 +107,23 @@ class DataWidget(QWidget):
     def make_bottom_bar(self):
         layout = QHBoxLayout()
         self.layout().addLayout(layout)
+        layout.addWidget(QLabel("Output file:"))
         self._output_widget = QLineEdit("", self)
         layout.addWidget(self._output_widget)
         self._browse_button = QPushButton("Browse", self)
         self._browse_button.clicked.connect(self.output_file_dialog)
         layout.addWidget(self._browse_button)
+        tooltip = (
+            "CSV dialect option, as implemented by the Python CSV module. "
+            "It should mainly affect delimiters and newline characters. "
+            "Most of the time there is no need to change it."
+        )
+        templabel = QLabel("CSV dialect:", self)
+        templabel.setToolTip(tooltip)
+        layout.addWidget(templabel)
         self._dialect_combo = QComboBox(self)
         self._dialect_combo.addItems(csv.list_dialects())
+        self._dialect_combo.setToolTip(tooltip)
         layout.addWidget(self._dialect_combo)
         self._output_button = QPushButton("Save file", self)
         self._output_button.clicked.connect(self.save_to_file)
@@ -144,7 +154,7 @@ class DataWidget(QWidget):
             if nsets == 0:  # do not create a file if there are no data
                 return
         try:
-            target = open(target_path, "w")
+            target = open(target_path, "w", newline="")
         except:
             LOG.error(f"Could not open file for writing: {target_path}")
         else:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
@@ -1,0 +1,143 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from MDANSE_GUI.Tabs.Models.PlottingContext import PlottingContext
+
+import numpy as np
+from qtpy.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QComboBox,
+    QLabel,
+    QGridLayout,
+    QDoubleSpinBox,
+)
+from qtpy.QtCore import Slot, Signal, Qt
+
+from MDANSE.MLogging import LOG
+
+from MDANSE_GUI.Widgets.RestrictedSlider import RestrictedSlider
+from MDANSE_GUI.Tabs.Plotters.Plotter import Plotter
+
+
+class DataWidget(QWidget):
+
+    change_slider_labels = Signal(object)
+    change_slider_limits = Signal(object)
+    reset_slider_values = Signal(bool)
+    change_slider_coupling = Signal(bool)
+
+    def __init__(self, *args, colours=None, settings=None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._plotter = None
+        self._sliderpack = None
+        self._plotting_context = None
+        self._colours = colours
+        self._settings = settings
+        self._slider_max = 100
+        self.make_canvas()
+        self.set_plotter("Text")
+
+    def set_context(self, new_context: "PlottingContext"):
+        self._plotting_context = new_context
+        self._plotting_context._figure = self._figure
+
+    @Slot(str)
+    def set_plotter(self, plotter_option: str):
+        try:
+            self._plotter = Plotter.create(plotter_option)
+        except:
+            self._plotter = Plotter()
+        self._plotter._settings = self._settings
+        self.change_slider_labels.emit(self._plotter.slider_labels())
+        self.change_slider_limits.emit(self._plotter.slider_limits())
+        self.change_slider_coupling.emit(self._plotter.sliders_coupled())
+        self.reset_slider_values.emit(self._plotter._value_reset_needed)
+        self._plotter._slider_reference = self._sliderpack
+        self.plot_data()
+
+    @Slot(object)
+    def slider_change(self, new_values: object):
+        self._plotter.handle_slider(new_values)
+
+    @Slot(bool)
+    def set_slider_values(self, reset_needed: bool):
+        if reset_needed and self._sliderpack is not None:
+            values = self._plotter._initial_values
+            self._sliderpack.set_values(values)
+
+    def available_plotters(self) -> List[str]:
+        return [str(x) for x in Plotter.indirect_subclasses()]
+
+    def plot_data(self, update_only=False):
+        if self._plotter is None:
+            LOG.info("No plotter present in PlotWidget.")
+            return
+        if self._plotting_context is None:
+            return
+        self._plotter.plot(
+            self._plotting_context,
+            self._figure,
+            colours=self._colours,
+            update_only=update_only,
+            toolbar=self._toolbar,
+        )
+
+    def make_canvas(self, width=12.0, height=9.0, dpi=100):
+        """Creates a matplotlib figure for plotting
+
+        Parameters
+        ----------
+        width : float, optional
+            Figure width in inches, by default 12.0
+        height : float, optional
+            Figure height in inches, by default 9.0
+        dpi : int, optional
+            Figure resolution in dots per inch, by default 100
+
+        Returns
+        -------
+        QWidget
+            a widget containing both the figure and a toolbar below
+        """
+        canvas = self
+        layout = QVBoxLayout(canvas)
+        figure = mpl.figure(figsize=[width, height], dpi=dpi, frameon=True)
+        figAgg = FigureCanvasQTAgg(figure)
+        figAgg.setParent(canvas)
+        figAgg.updateGeometry()
+        toolbar = NavigationToolbar2QTAgg(figAgg, canvas)
+        toolbar.update()
+        layout.addWidget(figAgg)
+        slider = SliderPack(self)
+        self.change_slider_labels.connect(slider.new_slider_labels)
+        self.change_slider_limits.connect(slider.new_limits)
+        self.change_slider_coupling.connect(slider.new_coupling)
+        self.reset_slider_values.connect(self.set_slider_values)
+        slider.new_values.connect(self.slider_change)
+        self._sliderpack = slider
+        layout.addWidget(slider)
+        layout.addWidget(toolbar)
+        self._figure = figure
+        self._toolbar = toolbar
+        plot_selector = QComboBox(self)
+        layout.addWidget(plot_selector)
+        plot_selector.addItems(self.available_plotters())
+        plot_selector.setCurrentText("Single")
+        plot_selector.currentTextChanged.connect(self.set_plotter)
+        self.set_plotter(plot_selector.currentText())

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
@@ -125,7 +125,7 @@ class DataWidget(QWidget):
             self,  # the parent of the dialog
             "Save data to a CSV file",  # the label of the window
             self._current_path,  # the initial search path
-            "Output file name (*)",  # text string specifying the file name filter.
+            "Comma-separated values (*.csv);;Output file name (*)",  # text string specifying the file name filter.
         )
         if len(new_value[0]) > 0:
             self._output_widget.setText(new_value[0])
@@ -134,6 +134,15 @@ class DataWidget(QWidget):
     @Slot()
     def save_to_file(self):
         target_path = self._output_widget.text()
+        try:
+            nsets = len(self._plotter._pc_backup.datasets())
+        except AttributeError:
+            return
+        except:
+            LOG.warning("DataWidget could not determine the number of datasets.")
+        else:
+            if nsets == 0:  # do not create a file if there are no data
+                return
         try:
             target = open(target_path, "w")
         except:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
@@ -63,7 +63,7 @@ class DataWidget(QWidget):
         try:
             self._plotter = Plotter.create(plotter_option)
         except Exception as e:
-            LOG.error(f"DataWidget failed to create Text plotter: {e.with_traceback()}")
+            LOG.error(f"DataWidget failed to create Text plotter: {e}")
         else:
             LOG.debug(f"DataWidget created plotter {plotter_option}: {self._plotter}")
             self._plotter._settings = self._settings
@@ -101,7 +101,7 @@ class DataWidget(QWidget):
                 toolbar=None,
             )
         except Exception as e:
-            LOG.error(f"DataWidget error: {e.with_traceback()}")
+            LOG.error(f"DataWidget error: {e}")
 
     def make_canvas(self):
         """Creates a matplotlib figure for plotting

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
@@ -75,12 +75,16 @@ class DataWidget(QWidget):
         self._lines_widget = QSpinBox(self)
         self._lines_widget.setValue(10)
         self._lines_widget.valueChanged.connect(self.update_plotter_params)
+        self._columns_widget = QSpinBox(self)
+        self._columns_widget.setValue(10)
+        self._columns_widget.valueChanged.connect(self.update_plotter_params)
         # populate the layout
         column = 0
         row = 0
         for label_text, widget in [
             ("Preview only (truncate)", self._preview_widget),
             ("Preview lines:", self._lines_widget),
+            ("Preview columns:", self._columns_widget),
             ("Rounding precision", self._precision_widget),
             ("Separator character", self._separator_widget),
             ("Comment character", self._comment_widget),
@@ -125,9 +129,11 @@ class DataWidget(QWidget):
         comment_char = self._comment_widget.text()
         separator_char = self._separator_widget.text()
         preview_lines = self._lines_widget.value()
+        preview_columns = self._columns_widget.value()
         self._plotter.adjust_formatter(
             preview=is_preview,
             preview_lines=preview_lines,
+            preview_columns=preview_columns,
             rounding=rounding_precision,
             separator=separator_char,
             comment=comment_char,

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
@@ -19,14 +19,7 @@ if TYPE_CHECKING:
     from MDANSE_GUI.Tabs.Models.PlottingContext import PlottingContext
 
 import numpy as np
-from qtpy.QtWidgets import (
-    QWidget,
-    QVBoxLayout,
-    QComboBox,
-    QLabel,
-    QGridLayout,
-    QDoubleSpinBox,
-)
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QTextBrowser
 from qtpy.QtCore import Slot, Signal, Qt
 
 from MDANSE.MLogging import LOG
@@ -51,7 +44,7 @@ class DataWidget(QWidget):
         self._settings = settings
         self._slider_max = 100
         self.make_canvas()
-        self.set_plotter("Text")
+        # self.set_plotter("Text")
 
     def set_context(self, new_context: "PlottingContext"):
         self._plotting_context = new_context
@@ -64,11 +57,6 @@ class DataWidget(QWidget):
         except:
             self._plotter = Plotter()
         self._plotter._settings = self._settings
-        self.change_slider_labels.emit(self._plotter.slider_labels())
-        self.change_slider_limits.emit(self._plotter.slider_limits())
-        self.change_slider_coupling.emit(self._plotter.sliders_coupled())
-        self.reset_slider_values.emit(self._plotter._value_reset_needed)
-        self._plotter._slider_reference = self._sliderpack
         self.plot_data()
 
     @Slot(object)
@@ -98,7 +86,7 @@ class DataWidget(QWidget):
             toolbar=self._toolbar,
         )
 
-    def make_canvas(self, width=12.0, height=9.0, dpi=100):
+    def make_canvas(self):
         """Creates a matplotlib figure for plotting
 
         Parameters
@@ -115,29 +103,7 @@ class DataWidget(QWidget):
         QWidget
             a widget containing both the figure and a toolbar below
         """
-        canvas = self
-        layout = QVBoxLayout(canvas)
-        figure = mpl.figure(figsize=[width, height], dpi=dpi, frameon=True)
-        figAgg = FigureCanvasQTAgg(figure)
-        figAgg.setParent(canvas)
-        figAgg.updateGeometry()
-        toolbar = NavigationToolbar2QTAgg(figAgg, canvas)
-        toolbar.update()
-        layout.addWidget(figAgg)
-        slider = SliderPack(self)
-        self.change_slider_labels.connect(slider.new_slider_labels)
-        self.change_slider_limits.connect(slider.new_limits)
-        self.change_slider_coupling.connect(slider.new_coupling)
-        self.reset_slider_values.connect(self.set_slider_values)
-        slider.new_values.connect(self.slider_change)
-        self._sliderpack = slider
-        layout.addWidget(slider)
-        layout.addWidget(toolbar)
-        self._figure = figure
-        self._toolbar = toolbar
-        plot_selector = QComboBox(self)
-        layout.addWidget(plot_selector)
-        plot_selector.addItems(self.available_plotters())
-        plot_selector.setCurrentText("Single")
-        plot_selector.currentTextChanged.connect(self.set_plotter)
-        self.set_plotter(plot_selector.currentText())
+        layout = QVBoxLayout(self)
+        self.setLayout(layout)
+        self._figure = QTextBrowser(self)
+        layout.addWidget(self._figure)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
@@ -19,6 +19,7 @@ from qtpy.QtCore import Slot, Signal
 from MDANSE.MLogging import LOG
 
 from MDANSE_GUI.Tabs.Visualisers.PlotWidget import PlotWidget
+from MDANSE_GUI.Tabs.Visualisers.DataWidget import DataWidget
 from MDANSE_GUI.Tabs.Models.PlottingContext import PlottingContext
 
 
@@ -53,6 +54,21 @@ class PlotHolder(QTabWidget):
         plotting_context = PlottingContext(unit_lookup=self._unit_lookup)
         plotting_context.needs_an_update.connect(self.update_plots)
         plotter = PlotWidget(self)
+        plotter.set_context(plotting_context)
+        tab_id = self.addTab(plotter, tab_name)
+        LOG.info(f"PlotHolder created tab: {tab_id}")
+        self._context.append(plotting_context)
+        self._plotter.append(plotter)
+        self.setCurrentIndex(tab_id)
+        return tab_id
+
+    @Slot(object)
+    def new_text(self, data_model) -> int:
+        tab_name = f"New text view {self._last_number}"
+        self._last_number += 1
+        plotting_context = PlottingContext(unit_lookup=self._unit_lookup)
+        plotting_context.needs_an_update.connect(self.update_plots)
+        plotter = DataWidget(self)
         plotter.set_context(plotting_context)
         tab_id = self.addTab(plotter, tab_name)
         LOG.info(f"PlotHolder created tab: {tab_id}")

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
@@ -128,4 +128,4 @@ class PlotHolder(QTabWidget):
             try:
                 plotter.plot_data(update_only=True)
             except Exception as e:
-                LOG.error(f"Plotting failed: {e.with_traceback()}")
+                LOG.error(f"Plotting failed: {e}")

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
@@ -62,8 +62,8 @@ class PlotHolder(QTabWidget):
         self.setCurrentIndex(tab_id)
         return tab_id
 
-    @Slot(object)
-    def new_text(self, data_model) -> int:
+    @Slot(str)
+    def new_text(self, ignored_name: str) -> int:
         tab_name = f"New text view {self._last_number}"
         self._last_number += 1
         plotting_context = PlottingContext(unit_lookup=self._unit_lookup)
@@ -125,4 +125,7 @@ class PlotHolder(QTabWidget):
         """This will change the line colour, thickness, etc.
         At the moment it doesn't do anything."""
         for plotter in self._plotter:
-            plotter.plot_data(update_only=True)
+            try:
+                plotter.plot_data(update_only=True)
+            except Exception as e:
+                LOG.error(f"Plotting failed: {e.with_traceback()}")

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotWidget.py
@@ -195,7 +195,7 @@ class PlotWidget(QWidget):
             self._sliderpack.set_values(values)
 
     def available_plotters(self) -> List[str]:
-        return [str(x) for x in Plotter.indirect_subclasses()]
+        return [str(x) for x in Plotter.indirect_subclasses() if str(x) != "Text"]
 
     def plot_data(self, update_only=False):
         if self._plotter is None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotWidget.py
@@ -182,6 +182,7 @@ class PlotWidget(QWidget):
         self.change_slider_coupling.emit(self._plotter.sliders_coupled())
         self.reset_slider_values.emit(self._plotter._value_reset_needed)
         self._plotter._slider_reference = self._sliderpack
+        self._sliderpack.setEnabled(False)
         self.plot_data()
 
     @Slot(object)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/DataDialog.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/DataDialog.py
@@ -1,0 +1,70 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Optional, List
+
+import numpy as np
+from qtpy.QtWidgets import (
+    QDialog,
+    QPushButton,
+    QVBoxLayout,
+    QHBoxLayout,
+    QComboBox,
+    QTextEdit,
+)
+from qtpy.QtCore import Signal, Slot, QObject
+
+from MDANSE.Framework.Jobs.IJob import IJob
+
+
+class DataDialog(QDialog):
+    new_style = Signal(str)
+    icon_swap = Signal(bool)
+
+    def __init__(
+        self,
+        *args,
+        input_data: List[np.ndarray],
+        input_units: List[str],
+        is_input=False,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+
+        self._data = input_data
+
+        layout = QVBoxLayout(self)
+        self.setLayout(layout)
+        top_layout = QHBoxLayout()
+        layout.addChildLayout(top_layout)
+        self._input_units = input_units
+        self._unit_boxes = [QComboBox(self), QComboBox(self), QComboBox(self)]
+        for box in self._unit_boxes:
+            top_layout.addWidget(box)
+        self._display = QTextEdit(self)
+        layout.addWidget(self._display)
+        if is_input:
+            self._confirm = QPushButton("Apply", self)
+            self._confirm.clicked.connect(self.commitChanges)
+            layout.addWidget(self._confirm)
+
+    def commitChanges(self):
+        text = self._display.document().toPlainText()
+        self.new_style.emit(text)
+        label = self._selector.currentText()
+        if "dark" in label:
+            self.icon_swap.emit(True)
+        else:
+            self.icon_swap.emit(False)

--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -30,6 +30,17 @@ from MDANSE_GUI.TabbedWindow import TabbedWindow
 os.environ["OMP_NUM_THREADS"] = "1"
 
 
+# an additonal section which will pass exception information to the logger
+def catch_exceptions(t, val, tb):
+    LOG.error(f"EXCEPTION:\n{t}\n{val}\n{tb}")
+    old_hook(t, val, tb)
+
+
+old_hook = sys.excepthook
+sys.excepthook = catch_exceptions
+# end of exception handling part.
+
+
 def startGUI(some_args):
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel("INFO")


### PR DESCRIPTION
**Description of work**
To make it easier for the users to transfer their results to other software (e.g. for fitting), we add another view to the Plot Holder. It is a text viewer, which shows the analysis results as plain text.

**Fixes**
1. Improved the logger handling of exceptions and error messages.
2. Created DataWidget as an equivalent to PlotWidget.
3. Created Text as subclass of Plotter, to be used with DataWidget.

**To test**
Please load analysis results with 1D and 2D arrays (e.g. DOS and DISF). Make sure that they can be plotted.
Create a text output using the new button in plot selector.
"Plot" the results in the new tab. Check the following actions:
1. Changing the units of the axes.
5. Selecting/deselecting datasets.
6. Changing other plot properties in the dataset table on the left.
Plot properties should not affect the text output.
