### PR TITLE
Remove explicit PyQt6 imports

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
@@ -13,7 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-from PyQt6.sip import voidptr
+
 from qtpy.QtWidgets import (
     QWidget,
     QVBoxLayout,

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/RestrictedSlider.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/RestrictedSlider.py
@@ -13,7 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from PyQt6.QtWidgets import QAbstractSlider
+
 from qtpy.QtCore import Slot, Signal, QObject, QTimer
 from qtpy.QtWidgets import QSlider
 


### PR DESCRIPTION
**Description of work**
We still had two lines importing an object from PyQt6 instead of qtpy. I think that the IDE inserts those automatically, that's why they are easy to overlook. If present, these will make it more difficult to switch between PyQt versions.

**Fixes**
- removed the two import lines referring to PyQt6.

**To test**
MDANSE_GUI should start normally using
`mdanse_gui`
but also if PyQt5 is installed and
`QT_API=pyqt5 mdanse_gui`
is used.
