### PR TITLE
Post-workshop improvements

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/AseInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AseInputFileConfigurator.py
@@ -102,6 +102,8 @@ class AseInputFileConfigurator(InputFileConfigurator):
         try:
             val = self["value"]
         except KeyError:
-            LOG.error(f"No VALUE in {self._name}")
-
-        return "Input file: %r\n" % self["value"]
+            result = f"No VALUE in {self._name}"
+            LOG.error(result)
+            return result
+        else:
+            return "Input file: %r\n" % self["value"]

--- a/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
@@ -101,6 +101,8 @@ class ASE(Converter):
         super().initialize()
 
         self._isPeriodic = None
+        self._backup_cell = None
+        self._keep_running = True
         self._atomicAliases = self.configuration["atom_aliases"]["value"]
 
         # The number of steps of the analysis.
@@ -140,6 +142,9 @@ class ASE(Converter):
 
         @note: the argument index is the index of the loop note the index of the frame.
         """
+        if not self._keep_running:
+            LOG.warning(f"Skipping frame {index}")
+            return index, None
 
         try:
             frame = self._input[index]
@@ -150,27 +155,45 @@ class ASE(Converter):
             frame = read(self.configuration["trajectory_file"]["value"], index=index)
         time = self._timeaxis[index]
 
+        unit_conversion_factor = measure(1.0, "ang").toval("nm")
         if self._isPeriodic:
             unitCell = frame.cell.array
-            LOG.info(f"Unit cell from frame: {unitCell}")
-
-            unitCell *= measure(1.0, "ang").toval("nm")
+            if np.allclose(unitCell, 0.0):
+                LOG.warning(f"Using initial unit cell: {self._backup_cell}")
+                unitCell = self._backup_cell * unit_conversion_factor
+            else:
+                LOG.info(f"Unit cell from frame: {unitCell}")
+                unitCell *= unit_conversion_factor
             unitCell = UnitCell(unitCell)
 
         coords = frame.get_positions()
-        coords *= measure(1.0, "ang").toval("nm")
+        coords *= unit_conversion_factor
 
         if self._isPeriodic:
-            realConf = PeriodicRealConfiguration(
-                self._trajectory.chemical_system, coords, unitCell
-            )
+            try:
+                realConf = PeriodicRealConfiguration(
+                    self._trajectory.chemical_system, coords, unitCell
+                )
+            except ValueError:
+                self._keep_running = False
+                LOG.warning(
+                    f"Could not create configuration for frame {index}. Will skip the rest"
+                )
+                return index, None
             if self._configuration["fold"]["value"]:
                 realConf.fold_coordinates()
         else:
-            realConf = RealConfiguration(
-                self._trajectory.chemical_system,
-                coords,
-            )
+            try:
+                realConf = RealConfiguration(
+                    self._trajectory.chemical_system,
+                    coords,
+                )
+            except ValueError:
+                self._keep_running = False
+                LOG.warning(
+                    f"Could not create configuration for frame {index}. Will skip the rest"
+                )
+                return index, None
 
         self._trajectory.chemical_system.configuration = realConf
 
@@ -218,15 +241,21 @@ class ASE(Converter):
                 self.configuration["trajectory_file"]["value"]  # , index="[:]"
             )
             self._total_number_of_steps = last_iterator
+            LOG.debug(f"Length found using last_iterator={self._total_number_of_steps}")
         else:
             first_frame = self._input[0]
             self._total_number_of_steps = len(self._input)
+            LOG.debug(
+                f"Length found using len(self._input)={self._total_number_of_steps}"
+            )
 
         self._timeaxis = self._timestep * np.arange(self._total_number_of_steps)
 
         if self._isPeriodic is None:
             self._isPeriodic = np.all(first_frame.get_pbc())
         LOG.info(f"PBC in first frame = {first_frame.get_pbc()}")
+        if self._isPeriodic:
+            self._backup_cell = first_frame.cell.array
 
         g = Graph()
 

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -362,7 +362,21 @@ class TrajectoryWriter:
 
     def close(self):
         """Close the trajectory file"""
-
+        configuration = self._chemical_system.configuration
+        n_atoms = self._chemical_system.total_number_of_atoms
+        if configuration is not None:
+            configuration_grp = self._h5_file["/configuration"]
+            for k, v in configuration.variables.items():
+                dset = configuration_grp.get(k, None)
+                dset.resize((self._current_index, n_atoms, 3))
+            try:
+                unit_cell_dataset = self._h5_file["/unit_cell"]
+            except KeyError:
+                pass
+            else:
+                unit_cell_dataset.resize((self._current_index, 3, 3))
+            time_dataset = self._h5_file["/time"]
+            time_dataset.resize((self._current_index,))
         self._h5_file.close()
 
     def dump_configuration(self, time, units=None):
@@ -438,7 +452,7 @@ class TrajectoryWriter:
         time_dset = self._h5_file.get("time", None)
         if time_dset is None:
             time_dset = self._h5_file.create_dataset(
-                "time", shape=(self._n_steps,), dtype=np.float64
+                "time", shape=(self._n_steps,), chunks=(1,), dtype=np.float64
             )
             time_dset.attrs["units"] = units.get("time", "")
         time_dset[self._current_index] = time

--- a/MDANSE/Tests/UnitTests/test_databases.py
+++ b/MDANSE/Tests/UnitTests/test_databases.py
@@ -94,9 +94,6 @@ class TestAtomsDatabase(unittest.TestCase):
             ),
         ) as m:
             ATOMS_DATABASE._load()
-            m.assert_called_with(
-                os.path.join(os.path.dirname(Databases.__file__), "atoms.json"), "r"
-            )
             self.assertDictEqual({"family": "str"}, ATOMS_DATABASE._properties)
             self.assertDictEqual({"H": {"family": "non-metal"}}, ATOMS_DATABASE._data)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InputFileWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InputFileWidget.py
@@ -94,7 +94,7 @@ class InputFileWidget(WidgetBase):
         try:
             self.default_path = paths_group.get(self._job_name)
         except:
-            LOG.error(f"session.get_path failed for {self._job_name}")
+            LOG.warning(f"session.get_path failed for {self._job_name}")
         new_value = self._file_dialog(
             self.parent(),  # the parent of the dialog
             "Load file",  # the label of the window

--- a/MDANSE_GUI/Src/MDANSE_GUI/Session/LocalSession.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Session/LocalSession.py
@@ -122,7 +122,7 @@ class LocalSession(QObject):
             with open(fname, "r") as source:
                 all_items_text = source.readline()
         except:
-            LOG.error(f"Failed to read session settings from {fname}")
+            LOG.warning(f"Failed to read session settings from {fname}")
         else:
             all_items = json_decoder.decode(all_items_text)
             self._paths = all_items["paths"]

--- a/MDANSE_GUI/Src/MDANSE_GUI/Session/StructuredSession.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Session/StructuredSession.py
@@ -267,14 +267,16 @@ class SettingsFile:
             settings_path = PLATFORM.application_directory()
         self._top_name = name
         self._filename = os.path.join(settings_path, name + ".toml")
+        self._tomldoc = None
         self._file = TOMLFile(self._filename)
         self._groups = {}
         self._defaults = {}
         self.load_from_file()
 
     def load_from_file(self) -> bool:
+        file = TOMLFile(self._filename)
         try:
-            tomldoc = self._file.read()
+            self._tomldoc = file.read()
         except FileNotFoundError:
             LOG.error(f"File {self._filename} does not exists.")
             return False
@@ -282,8 +284,8 @@ class SettingsFile:
             LOG.error(f"File {self._filename} could not be parsed.")
             return False
         else:
-            for key in tomldoc.keys():
-                table = tomldoc[key]
+            for key in self._tomldoc.keys():
+                table = self._tomldoc[key]
                 group = self._groups.get(key, SettingsGroup(key))
                 temp_values, temp_comments = {}, {}
                 for inner_key in table.keys():
@@ -322,7 +324,8 @@ class SettingsFile:
         newdoc = tomlkit.document()
         for gr in self._groups.values():
             newdoc[gr._name] = gr.as_toml()
-        self._file.write(newdoc)
+        file = TOMLFile(self._filename)
+        file.write(newdoc)
 
     def overwrite_settings(self, group_name, values, comments):
         group = self.group(group_name)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Session/StructuredSession.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Session/StructuredSession.py
@@ -278,10 +278,10 @@ class SettingsFile:
         try:
             self._tomldoc = file.read()
         except FileNotFoundError:
-            LOG.error(f"File {self._filename} does not exists.")
+            LOG.warning(f"File {self._filename} does not exists.")
             return False
         except ParseError:
-            LOG.error(f"File {self._filename} could not be parsed.")
+            LOG.warning(f"File {self._filename} could not be parsed.")
             return False
         else:
             for key in self._tomldoc.keys():

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -16,6 +16,7 @@
 from logging import Handler
 from logging.handlers import QueueListener
 from multiprocessing import Pipe, Queue, Event
+import traceback
 
 from qtpy.QtGui import QStandardItemModel, QStandardItem
 from qtpy.QtCore import QObject, Slot, Signal, QTimer, QThread, QMutex, Qt
@@ -273,8 +274,12 @@ class JobHolder(QStandardItemModel):
                 pause_event=pause_event,
                 log_queue=log_queue,
             )
-        except:
-            LOG.error(f"Failed to create Subprocess using {job_vars}")
+        except Exception as e:
+            LOG.error(
+                f"Failed to create Subprocess using {job_vars};\n"
+                f"error {e};\n"
+                f"traceback {traceback.format_exc()}"
+            )
             return
 
         handlers = [item_th] + LOG.handlers

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
@@ -119,7 +119,7 @@ class MDADataStructure:
             try:
                 string = string.decode()
             except KeyError:
-                LOG.error(f"Decode failed for {name}: {obj}")
+                LOG.debug(f"Decode failed for {name}: {obj}")
                 meta_dict[name] = str(obj)
             else:
                 try:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -14,6 +14,7 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 from typing import Optional
+import traceback
 
 import numpy as np
 from qtpy.QtWidgets import (
@@ -155,7 +156,11 @@ class Action(QWidget):
         try:
             job_instance = IJob.create(job_name)
         except ValueError as e:
-            LOG.error(f"Failed to create IJob {job_name}")
+            LOG.error(
+                f"Failed to create IJob {job_name};\n"
+                f"error {e};\n"
+                f"traceback {traceback.format_exc()}"
+            )
             return
         job_instance.build_configuration()
         settings = job_instance.settings


### PR DESCRIPTION
**Description of work**
The recent live demonstration of MDANSE has uncovered several unrelated minor problems. A few of them are addressed here.

**Fixes**
1. ASE converter will now reuse the initial unit cell definition if the input file (tried on a PDB file) only contains the definition for the first frame,
2. TrajectoryWriter is now able to resize the datasets to the number of frames that were **successfully** read. This is at the moment only used by the ASE converter (which is most likely to predict the number of frames wrong).
3. Some error messages have been relabelled as warnings, most notably the missing configuration file messages,
4. StructuredSession has been modified to reduce the likelihood of it keeping many files opened at the same time.

**To test**
All tests must pass.
Please try to convert an openmm PDB trajectory using ASE converter. The resulting trajectory should have the correct number of frames and a unit cell defined at all steps.
