### PR TITLE
Added self part of van Hove function job and updated documentation theory

### DIFF
--- a/Doc/pages/dynamics.rst
+++ b/Doc/pages/dynamics.rst
@@ -13,6 +13,7 @@ This section contains background theory for following plugins:
 -  :ref:`analysis-msd`
 -  :ref:`analysis-op`
 -  :ref:`analysis-pacf`
+-  :ref:`analysis-vhf`
 -  :ref:`analysis-vacf`
 
 .. _analysis-angular-correlation:
@@ -333,6 +334,50 @@ where
    \Delta R_{\alpha}\left( t \right) = R_{\alpha}\left( t \right) - \langle R_{\alpha}\left( t \right) \rangle_{t}
 
 so that the origin dependence of the PACF function is removed.
+
+.. _analysis-vhf:
+
+Van Hove Function
+'''''''''''''''''
+The van Hove function describes the probability of finding a particle
+:math:`j` at a distance :math:`R` at time :math:`t_0 + \Delta t` from a
+particle :math:`i` at a time :math:`t_0`
+
+.. math::
+    G(R,\Delta t) = \frac{1}{N} \left\langle  \sum_{i}^{N}\sum_{j}^{N} \delta [R - R_{j}(t_0 + \Delta t) + R_{i}(t_0)] \right\rangle
+
+and can be rewritten so that
+
+.. math::
+    G(R,\Delta t) &= \frac{1}{N} \left\langle  \int  \sum_{i}^{N}\sum_{j}^{N} \delta [R' + R - R_{j}(t_0 + \Delta t)]\delta [R' - R_{i}(t_0)] \, \mathrm{d} R' \right\rangle \\
+     &= \frac{1}{\rho} \left\langle  \rho (R, t_0 + \Delta t) \rho (0, t_0) \right\rangle
+
+so that the van Hove function is a density-density time-correlation
+function. The van Hove function is related to the intermediate scattering
+function via a Fourier transform and the dynamic structure factor
+via a double Fourier transform
+
+.. math::
+    F(q,\Delta t) &= \int G(R,t) \exp(i q \cdot R) \, \mathrm{d}R \\
+    S(q,\omega) &= \int\int G(R,t) \exp(i q \cdot R - i \omega t) \, \mathrm{d}R\mathrm{d}t
+
+and can be split into distinct and self parts where
+
+.. math::
+    G_{\mathrm{d}}(R,\Delta t) &= \left\langle \frac{1}{N} \sum_{i}^{N}\sum_{j \neq i}^{N} \delta [R - R_{j}(t_0 + \Delta t) + R_{i}(t_0)] \right\rangle \\
+    G_{\mathrm{s}}(R,\Delta t) &= \left\langle \frac{1}{N} \sum_{i} \delta [R - R_{i}(t_0 + \Delta t) + R_{i}(t_0)] \right\rangle
+
+In *MDANSE* the distinct part of the van Hove function is spherically
+averaged and normalised so that for liquid or gaseous systems
+
+.. math::
+    \lim_{r \rightarrow \infty } G_{\mathrm{d}}(r,\Delta t) = \lim_{\Delta t \rightarrow \infty } G_{\mathrm{d}}(r,\Delta t) = 1
+
+and the self part of the van Hove function in *MDANSE* is summed do
+that it only depends on the distance :math:`r`
+
+.. math::
+    G_{\mathrm{s}}(r,\Delta t) = \left\langle \frac{1}{N} \sum_{i} \delta \left[r - \vert R_{i}(t_0 + \Delta t) + R_{i}(t_0) \vert \right] \right\rangle
 
 .. _analysis-vacf:
 

--- a/MDANSE/Extensions/van_hove.pyx
+++ b/MDANSE/Extensions/van_hove.pyx
@@ -44,7 +44,7 @@ def van_hove_distinct(
     times t0 and t1. Distances are calculated using the minimum image
     convention which are all worked out using the fractional coordinates
     with the unit cell of the configuration at time t1. The function can
-    be used to calculate the distinct part of the Van Hove function.
+    be used to calculate the distinct part of the van Hove function.
 
     This function was an generalization of a Pyrex adaptation of a
     FORTRAN implementation made by Miguel Angel Gonzalez (Institut Laue
@@ -103,9 +103,7 @@ def van_hove_distinct(
             rz = sdx*cell[2,0] + sdy*cell[2,1] + sdz*cell[2,2]
 
             r = sqrt(rx*rx + ry*ry + rz*rz)
-
             bin = <int>((r-rmin)/dr)
-
             if ((bin < 0) or (bin >= nbins)):
                 continue
 
@@ -113,3 +111,52 @@ def van_hove_distinct(
                 intra[symbolindex[i],symbolindex[j],bin] += 1.0
             else:
                 inter[symbolindex[i],symbolindex[j],bin] += 1.0
+
+
+def van_hove_self(
+    double[:,:] xyz,
+    double[:,:] histograms,
+    double rmin,
+    double dr,
+    int n_configs,
+    int n_frames
+):
+    """Calculates the distance histogram between an atom at time t0
+    and the same atom at a time t0 + t. The results from this function
+    can be used to calculate the self part of the van Hove function.
+
+    Parameters
+    ----------
+    xyz : np.ndarray
+        The trajectory of an atom.
+    histograms : np.ndarray
+        The histograms to be updated.
+    rmin : float
+        The minimum distance of the histogram.
+    dr : float
+        The distances between histogram bins.
+    n_configs : int
+        Number of configs to be averaged over.
+    n_frames : int
+        Number of correlation frames.
+    """
+    cdef int i, j, bin, nbins
+    cdef double x0, y0, z0, x1, y1, z1, r
+    nbins = histograms.shape[0]
+
+    for i in range(n_configs):
+        x0 = xyz[i,0]
+        y0 = xyz[i,1]
+        z0 = xyz[i,2]
+
+        for j in range(n_frames):
+            rx = xyz[i+j,0] - x0
+            ry = xyz[i+j,1] - y0
+            rz = xyz[i+j,2] - z0
+
+            r = sqrt(rx*rx + ry*ry + rz*rz)
+            bin = <int>((r-rmin)/dr)
+            if ((bin < 0) or (bin >= nbins)):
+                continue
+
+            histograms[bin, j] += 1.0

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
@@ -37,7 +37,9 @@ class DistHistCutoffConfigurator(RangeConfigurator):
             The maximum cutoff for the distance histogram job.
         """
         traj_config = self._configurable[self._dependencies["trajectory"]]["instance"]
-        min_d = np.min([uc.direct for uc in traj_config._trajectory._unit_cells], axis=0)
+        min_d = np.min(
+            [uc.direct for uc in traj_config._trajectory._unit_cells], axis=0
+        )
         vec_a, vec_b, vec_c = min_d
         a = np.linalg.norm(vec_a)
         b = np.linalg.norm(vec_b)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
@@ -37,7 +37,7 @@ class DistHistCutoffConfigurator(RangeConfigurator):
             The maximum cutoff for the distance histogram job.
         """
         traj_config = self._configurable[self._dependencies["trajectory"]]["instance"]
-        min_d = np.min(traj_config._trajectory._h5_file["unit_cell"], axis=0)
+        min_d = np.min([uc.direct for uc in traj_config._trajectory._unit_cells], axis=0)
         vec_a, vec_b, vec_c = min_d
         a = np.linalg.norm(vec_a)
         b = np.linalg.norm(vec_b)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
@@ -7,6 +7,10 @@ from .RangeConfigurator import RangeConfigurator
 
 class DistHistCutoffConfigurator(RangeConfigurator):
 
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
+        self._max_value = kwargs.get("max_value", True)
+
     def configure(self, value):
         """Configure the distance histogram cutoff configurator.
 
@@ -15,7 +19,7 @@ class DistHistCutoffConfigurator(RangeConfigurator):
         value : tuple
             A tuple of the range parameters.
         """
-        if value[1] > floor(self.get_largest_cutoff() * 100) / 100:
+        if self._max_value and value[1] > floor(self.get_largest_cutoff() * 100) / 100:
             self.error_status = (
                 "The cutoff distance goes into the simulation box periodic images."
             )

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
@@ -90,7 +90,7 @@ class VanHoveFunctionDistinct(IJob):
             it.combinations_with_replacement(self.selectedElements, 2)
         )
 
-        self.n_min_points = len(self.configuration["r_values"]["mid_points"])
+        self.n_mid_points = len(self.configuration["r_values"]["mid_points"])
 
         self._outputData.add(
             "r",
@@ -107,21 +107,21 @@ class VanHoveFunctionDistinct(IJob):
         self._outputData.add(
             "g(r,t)_intra_total",
             "SurfaceOutputVariable",
-            (self.n_min_points, self.numberOfSteps),
+            (self.n_mid_points, self.numberOfSteps),
             axis="r|time",
             units="au",
         )
         self._outputData.add(
             "g(r,t)_inter_total",
             "SurfaceOutputVariable",
-            (self.n_min_points, self.numberOfSteps),
+            (self.n_mid_points, self.numberOfSteps),
             axis="r|time",
             units="au",
         )
         self._outputData.add(
             "g(r,t)_total",
             "SurfaceOutputVariable",
-            (self.n_min_points, self.numberOfSteps),
+            (self.n_mid_points, self.numberOfSteps),
             axis="r|time",
             units="au",
         )
@@ -129,21 +129,21 @@ class VanHoveFunctionDistinct(IJob):
             self._outputData.add(
                 "g(r,t)_intra_%s%s" % (x, y),
                 "SurfaceOutputVariable",
-                (self.n_min_points, self.numberOfSteps),
+                (self.n_mid_points, self.numberOfSteps),
                 axis="r|time",
                 units="au",
             )
             self._outputData.add(
                 "g(r,t)_inter_%s%s" % (x, y),
                 "SurfaceOutputVariable",
-                (self.n_min_points, self.numberOfSteps),
+                (self.n_mid_points, self.numberOfSteps),
                 axis="r|time",
                 units="au",
             )
             self._outputData.add(
                 "g(r,t)_total_%s%s" % (x, y),
                 "SurfaceOutputVariable",
-                (self.n_min_points, self.numberOfSteps),
+                (self.n_mid_points, self.numberOfSteps),
                 axis="r|time",
                 units="au",
             )
@@ -171,7 +171,7 @@ class VanHoveFunctionDistinct(IJob):
         # unlike the PDF, g(r, t) may not be zero around r=0 we will use
         # the actual shell volume instead.
         self.shell_volumes = []
-        for i in range(self.n_min_points):
+        for i in range(self.n_mid_points):
             self.shell_volumes.append(
                 (
                     self.configuration["r_values"]["value"][i]
@@ -183,10 +183,10 @@ class VanHoveFunctionDistinct(IJob):
         self.shell_volumes = (4 / 3) * np.pi * np.array(self.shell_volumes)
 
         self.h_intra = np.zeros(
-            (self.nElements, self.nElements, self.n_min_points, self.numberOfSteps)
+            (self.nElements, self.nElements, self.n_mid_points, self.numberOfSteps)
         )
         self.h_inter = np.zeros(
-            (self.nElements, self.nElements, self.n_min_points, self.numberOfSteps)
+            (self.nElements, self.nElements, self.n_mid_points, self.numberOfSteps)
         )
 
     def run_step(self, time: int) -> tuple[int, tuple[np.ndarray, np.ndarray]]:
@@ -199,8 +199,8 @@ class VanHoveFunctionDistinct(IJob):
         time : int
             The time difference.
         """
-        bins_intra = np.zeros((self.nElements, self.nElements, self.n_min_points))
-        bins_inter = np.zeros((self.nElements, self.nElements, self.n_min_points))
+        bins_intra = np.zeros((self.nElements, self.nElements, self.n_mid_points))
+        bins_inter = np.zeros((self.nElements, self.nElements, self.n_mid_points))
 
         # average the distance histograms at the inputted time
         # difference over a number of configuration

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
@@ -192,12 +192,18 @@ class VanHoveFunctionDistinct(IJob):
     def run_step(self, time: int) -> tuple[int, tuple[np.ndarray, np.ndarray]]:
         """Calculates the distance histogram between the configurations
         at the inputted time difference. The distance histograms are
-        then used to calculate the distinct part of the Van Hove function.
+        then used to calculate the distinct part of the van Hove function.
 
         Parameters
         ----------
         time : int
             The time difference.
+
+        Returns
+        -------
+        tuple
+            A tuple containing the time difference and a tuple of the
+            inter and intramolecular distance histograms.
         """
         bins_intra = np.zeros((self.nElements, self.nElements, self.n_mid_points))
         bins_inter = np.zeros((self.nElements, self.nElements, self.n_mid_points))
@@ -237,7 +243,7 @@ class VanHoveFunctionDistinct(IJob):
                 self.configuration["r_values"]["step"],
             )
 
-            # The Van Hove function will be divided by the density,
+            # The van Hove function will be divided by the density,
             # we multiply my the volume here and divide by the number
             # of atoms in finalize.
             bins_intra += conf_t1.unit_cell.volume * intra
@@ -262,7 +268,7 @@ class VanHoveFunctionDistinct(IJob):
 
     def finalize(self):
         """Using the distance histograms calculate, normalize and save the
-        distinct part of the Van Hove function.
+        distinct part of the van Hove function.
         """
         nAtomsPerElement = self.configuration["atom_selection"].get_natoms()
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
@@ -1,0 +1,199 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import collections
+
+import numpy as np
+
+from MDANSE.Extensions import van_hove
+from MDANSE.Framework.Jobs.IJob import IJob
+from MDANSE.Mathematics.Arithmetic import weight
+
+
+class VanHoveFunctionSelf(IJob):
+    """The van Hove function is related to the intermediate scattering
+    function via a Fourier transform and the dynamic structure factor
+    via a double Fourier transform. The van Hove function describes the
+    probability of finding a particle (j) at a distance r at time t from
+    a particle (i) at a time t_0. The van Hove function can be split
+    into self and distinct parts. The self part includes only the
+    contributions from only the same particles (i=j) while the distinct
+    part includes only the contributions between different particles
+    (i≠j). This job calculates a self part of the van Hove function
+    multiplied by 4πr^2.
+    """
+
+    label = "Van Hove Function Self"
+
+    enabled = True
+
+    category = (
+        "Analysis",
+        "Dynamics",
+    )
+
+    settings = collections.OrderedDict()
+    settings["trajectory"] = ("HDFTrajectoryConfigurator", {})
+    settings["frames"] = (
+        "CorrelationFramesConfigurator",
+        {"dependencies": {"trajectory": "trajectory"}},
+    )
+    settings["r_values"] = (
+        "DistHistCutoffConfigurator",
+        {
+            "label": "r values (nm)",
+            "valueType": float,
+            "includeLast": True,
+            "mini": 0.0,
+            "dependencies": {"trajectory": "trajectory"},
+            "max_value": False,
+        },
+    )
+    settings["atom_selection"] = (
+        "AtomSelectionConfigurator",
+        {"dependencies": {"trajectory": "trajectory"}},
+    )
+    settings["weights"] = (
+        "WeightsConfigurator",
+        {"dependencies": {"atom_selection": "atom_selection"}},
+    )
+    settings["output_files"] = (
+        "OutputFilesConfigurator",
+        {"formats": ["MDAFormat", "TextFormat"]},
+    )
+    settings["running_mode"] = ("RunningModeConfigurator", {})
+
+    def initialize(self):
+        super().initialize()
+
+        self.numberOfSteps = self.configuration["atom_selection"]["selection_length"]
+        self.n_configs = self.configuration["frames"]["n_configs"]
+        self.n_frames = self.configuration["frames"]["n_frames"]
+
+        self.selectedElements = self.configuration["atom_selection"]["unique_names"]
+        self.nElements = len(self.selectedElements)
+
+        self.n_mid_points = len(self.configuration["r_values"]["mid_points"])
+
+        self._outputData.add(
+            "r",
+            "LineOutputVariable",
+            self.configuration["r_values"]["mid_points"],
+            units="nm",
+        )
+        self._outputData.add(
+            "time",
+            "LineOutputVariable",
+            self.configuration["frames"]["duration"],
+            units="ps",
+        )
+        self._outputData.add(
+            "g(r,t)_total",
+            "SurfaceOutputVariable",
+            (self.n_mid_points, self.n_frames),
+            axis="r|time",
+            units="au",
+        )
+        for element in self.selectedElements:
+            self._outputData.add(
+                "g(r,t)_%s" % element,
+                "SurfaceOutputVariable",
+                (self.n_mid_points, self.n_frames),
+                axis="r|time",
+                units="au",
+            )
+
+    def run_step(self, atm_index: int) -> tuple[int, tuple[np.ndarray, np.ndarray]]:
+        """Calculates a distance histograms of an atoms displacement.
+        The distance histograms are used to calculate the self part of
+        the van Hove function.
+
+        Parameters
+        ----------
+        atm_index : int
+            The index of the atom which will be used to generate the
+            distance histograms.
+
+        Returns
+        -------
+        tuple
+            A tuple containing the atom index and distance histograms.
+        """
+        histograms = np.zeros((self.n_mid_points, self.n_frames))
+
+        idx = self.configuration["atom_selection"]["indexes"][atm_index][0]
+        series = self.configuration["trajectory"]["instance"].read_atomic_trajectory(
+            idx,
+            first=self.configuration["frames"]["first"],
+            last=self.configuration["frames"]["last"] + 1,
+            step=self.configuration["frames"]["step"],
+        )
+
+        van_hove.van_hove_self(
+            series,
+            histograms,
+            self.configuration["r_values"]["first"],
+            self.configuration["r_values"]["step"],
+            self.n_configs,
+            self.n_frames,
+        )
+
+        return atm_index, histograms
+
+    def combine(self, atm_index: int, histogram: np.ndarray):
+        """Add the results into the histograms for the inputted time
+        difference.
+
+        Parameters
+        ----------
+        atm_index : int
+            The atom index.
+        histogram : np.ndarray
+            A histogram of the distances between an atom at
+            time t0 and t0 + t.
+        """
+        element = self.configuration["atom_selection"]["names"][atm_index]
+        self._outputData["g(r,t)_{}".format(element)][:] += histogram
+
+    def finalize(self):
+        """Using the distance histograms calculate, normalize and save the
+        self part of the Van Hove function.
+        """
+        shellSurfaces = 4.0 * np.pi * self.configuration["r_values"]["mid_points"] ** 2
+
+        nAtomsPerElement = self.configuration["atom_selection"].get_natoms()
+        for element, number in list(nAtomsPerElement.items()):
+            self._outputData["g(r,t)_%s" % element][:] *= shellSurfaces[
+                :, np.newaxis
+            ] / (number * self.n_configs)
+
+        weights = self.configuration["weights"].get_weights()
+        self._outputData["g(r,t)_total"][:] = weight(
+            weights,
+            self._outputData,
+            nAtomsPerElement,
+            1,
+            "g(r,t)_%s",
+            update_partials=True,
+        )
+
+        self._outputData.write(
+            self.configuration["output_files"]["root"],
+            self.configuration["output_files"]["formats"],
+            self._info,
+            self,
+        )
+        self.configuration["trajectory"]["instance"].close()
+        super().finalize()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
@@ -31,8 +31,7 @@ class VanHoveFunctionSelf(IJob):
     into self and distinct parts. The self part includes only the
     contributions from only the same particles (i=j) while the distinct
     part includes only the contributions between different particles
-    (i≠j). This job calculates a self part of the van Hove function
-    multiplied by 4πr^2.
+    (i≠j). This job calculates a self part of the van Hove function.
     """
 
     label = "Van Hove Function Self"
@@ -171,13 +170,10 @@ class VanHoveFunctionSelf(IJob):
         """Using the distance histograms calculate, normalize and save the
         self part of the Van Hove function.
         """
-        shellSurfaces = 4.0 * np.pi * self.configuration["r_values"]["mid_points"] ** 2
 
         nAtomsPerElement = self.configuration["atom_selection"].get_natoms()
         for element, number in list(nAtomsPerElement.items()):
-            self._outputData["g(r,t)_%s" % element][:] *= shellSurfaces[
-                :, np.newaxis
-            ] / (number * self.n_configs)
+            self._outputData["g(r,t)_%s" % element][:] /= number * self.n_configs
 
         weights = self.configuration["weights"].get_weights()
         self._outputData["g(r,t)_total"][:] = weight(

--- a/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
@@ -96,7 +96,7 @@ def parameters():
         },
     )
     parameters["q_values"] = (0.0, 10.0, 0.1)
-    parameters["r_values"] = (0.0, 10.0, 0.1)
+    parameters["r_values"] = (0.0, 1.0, 0.01)
     parameters["per_axis"] = False
     parameters["reference_direction"] = (0, 0, 1)
     parameters["instrument_resolution"] = ("Gaussian", {"sigma": 1.0, "mu": 0.0})
@@ -117,6 +117,8 @@ for tp in [short_traj, mdmc_traj]:
         "DensityOfStates",
         "MeanSquareDisplacement",
         "VelocityAutoCorrelationFunction",
+        "VanHoveFunctionDistinct",
+        "VanHoveFunctionSelf",
         # "OrderParameter",
         "PositionAutoCorrelationFunction",
     ]:

--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -31,30 +31,6 @@ def qvector_spherical_lattice(trajectory):
     )
 
 
-
-@pytest.fixture(scope="module")
-def test_vhfd(trajectory):
-    temp_name = tempfile.mktemp()
-    parameters = {}
-    parameters["atom_selection"] = None
-    parameters["frames"] = (0, 10, 1, 5)
-    parameters["output_files"] = (temp_name, ("MDAFormat", "TextFormat"), "INFO")
-    parameters["running_mode"] = ("single-core",)
-    parameters["trajectory"] = short_traj
-    parameters["weights"] = "equal"
-    vhfd = IJob.create("VanHoveFunctionDistinct")
-    vhfd.run(parameters, status=True)
-    assert path.exists(temp_name + ".mda")
-    assert path.isfile(temp_name + ".mda")
-    os.remove(temp_name + ".mda")
-    assert path.exists(temp_name + "_text.tar")
-    assert path.isfile(temp_name + "_text.tar")
-    os.remove(temp_name + "_text.tar")
-    assert path.exists(temp_name + ".log")
-    assert path.isfile(temp_name + ".log")
-    os.remove(temp_name + ".log")
-
-
 @pytest.fixture(scope="module")
 def dcsf():
     temp_name = tempfile.mktemp()

--- a/MDANSE/Tests/UnitTests/test_ijob.py
+++ b/MDANSE/Tests/UnitTests/test_ijob.py
@@ -40,6 +40,7 @@ ALL_JOBS = [
     "Temperature",
     "UnfoldedTrajectory",
     "VanHoveFunctionDistinct",
+    "VanHoveFunctionSelf",
     "VelocityAutoCorrelationFunction",
     "Voronoi",
     "Converter",


### PR DESCRIPTION
**Description of work**
Added the self part of the van Hove function and updated the theory part of the documentation.

Here is the self part of the van Hove function for an Ar36 trajectory. We can see the argon atoms diffusing through the system as time progresses.
![image](https://github.com/user-attachments/assets/cb6c3406-fe20-4bb8-bc23-f59e31ee6856)

Here is an example with the lammps trajectory
![image](https://github.com/user-attachments/assets/f224dbbe-8d54-48fc-876e-a2afb1042f30)

we can see that the Cu atoms (top left) diffuse through the system via specific sites while the S and Sb atoms are fixed in the lattice.

**To test**
Rebuild MDANSE and run the VanHoveFunctionSelf job and check the results. See Figs. 5 and 6 in https://journals.aps.org/pre/abstract/10.1103/PhysRevE.51.4626 for some examples.
