### PR TITLE
Fix MDANSE when using files with non-standard characters

### DIFF
--- a/MDANSE/Src/MDANSE/Core/Platform.py
+++ b/MDANSE/Src/MDANSE/Core/Platform.py
@@ -197,12 +197,7 @@ class Platform(object, metaclass=abc.ABCMeta):
         :return: the normalized and absolute version of the input path
         :rtype: str
         """
-
-        path = str(path).encode("unicode-escape")
-
-        path = os.path.abspath(os.path.expanduser(path)).decode("utf-8")
-
-        return path
+        return os.path.abspath(os.path.expanduser(path))
 
     def database_default_path(self):
         """


### PR DESCRIPTION
**Description of work**
Allow MDANSE to be used with files with names with non-standard characters.

**Fixes**
Fixes #547

**To test**
Save an MDT trajectory file with a non-standard character filename, run a job with that trajectory, and save the MDA file with a file name with non-standard characters. Plotting and action jobs should run with no issues.
