### PR TITLE
Update the eccentricity calculation so that it follows more standard equations

### DIFF
--- a/Doc/pages/dynamics.rst
+++ b/Doc/pages/dynamics.rst
@@ -373,7 +373,7 @@ averaged and normalised so that for liquid or gaseous systems
 .. math::
     \lim_{r \rightarrow \infty } G_{\mathrm{d}}(r,\Delta t) = \lim_{\Delta t \rightarrow \infty } G_{\mathrm{d}}(r,\Delta t) = 1
 
-and the self part of the van Hove function in *MDANSE* is summed do
+and the self part of the van Hove function in *MDANSE* is summed so
 that it only depends on the distance :math:`r`
 
 .. math::

--- a/Doc/pages/structure.rst
+++ b/Doc/pages/structure.rst
@@ -137,8 +137,8 @@ The eccentricity of a selection of atom is calculated using the equation
 
 where :math:`\lambda_{1}` and :math:`\lambda_{3}` are its smallest and
 largest principal moments of inertia. A spherically symmetric
-selection of atoms will have an eccentricity of 0 and an aspherical
-selection of atoms will have a eccentricity of 1.
+selection of atoms will have an eccentricity approaching 0 and an
+aspherical selection of atoms will have a eccentricity approaching 1.
 
 .. _molecular-trace:
 

--- a/Doc/pages/structure.rst
+++ b/Doc/pages/structure.rst
@@ -128,12 +128,17 @@ regions of interest and tracking changes over time in molecular simulations.
 Eccentricity
 ''''''''''''
 
-Eccentricity analysis in MDANSE quantifies how elongated or
-flattened molecules are, revealing valuable insights into their shape and
-structure. Researchers use it to understand molecular geometry and
-conformation, aiding the differentiation of molecules by shape. This analysis is
-vital for studying structural properties in complex molecular systems and
-characterizing molecular shape and morphology.
+Eccentricity analysis in *MDANSE* quantifies how spherical a system is and
+can be used to observe how the geometry of the system changes over time.
+The eccentricity of a selection of atom is calculated using the equation
+
+.. math::
+    e = \frac{\sqrt{\lambda_{3}^2 - \lambda_{1}^2}}{\lambda_{3}}
+
+where :math:`\lambda_{1}` and :math:`\lambda_{3}` are its smallest and
+largest principal moments of inertia. A spherically symmetric
+selection of atoms will have an eccentricity of 0 and an aspherical
+selection of atoms will have a eccentricity of 1.
 
 .. _molecular-trace:
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
@@ -32,6 +32,7 @@ class Eccentricity(IJob):
     eccentricity will be 1. This job follows the equations used in rdkit
     which was itself taken from https://doi.org/10.1002/9783527618279.ch37.
     """
+
     label = "Eccentricity"
 
     category = (
@@ -78,16 +79,20 @@ class Eccentricity(IJob):
         self._atoms = sorted_atoms(
             self.configuration["trajectory"]["instance"].chemical_system.atom_list
         )
-        self._indexes = np.array([
-            idx
-            for idxs in self._configuration["atom_selection"]["indexes"]
-            for idx in idxs
-        ])
-        self._selectionMasses = np.array([
-            m
-            for masses in self._configuration["atom_selection"]["masses"]
-            for m in masses
-        ])
+        self._indexes = np.array(
+            [
+                idx
+                for idxs in self._configuration["atom_selection"]["indexes"]
+                for idx in idxs
+            ]
+        )
+        self._selectionMasses = np.array(
+            [
+                m
+                for masses in self._configuration["atom_selection"]["masses"]
+                for m in masses
+            ]
+        )
 
     def run_step(self, index: int):
         """Calculate the eccentricity for the selected atoms at the

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
@@ -106,7 +106,7 @@ class Eccentricity(IJob):
         frameIndex = self.configuration["frames"]["value"][index]
 
         conf = self.configuration["trajectory"]["instance"].configuration(frameIndex)
-        conf = conf.continuous_configuration()
+        conf = conf.contiguous_configuration()
         series = conf["coordinates"][self._indexes, :]
 
         com = center_of_mass(series, masses=self._selectionMasses)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
@@ -13,63 +13,25 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-
 import collections
 
 import numpy as np
 
-
-from MDANSE.Chemistry import ATOMS_DATABASE
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Geometry import center_of_mass
 from MDANSE.MolecularDynamics.TrajectoryUtils import sorted_atoms
 
 
 class Eccentricity(IJob):
+    """Computes the eccentricity for a set of atoms e.g. in a micelle.
+    The eccentricity is calculated from the principal moments of
+    inertia via the equation sqrt(pm3**2 - pm1**2) / pm3 where pm1 and
+    pm3 are the smallest and largest principal moments of inertia
+    respectively. Therefore, for a spherically symmetric molecule its
+    eccentricity will be 0 while for an aspherical molecule like CO2 its
+    eccentricity will be 1. This job follows the equations used in rdkit
+    which was itself taken from https://doi.org/10.1002/9783527618279.ch37.
     """
-    Computes the eccentricity for a set of atoms e.g. in a micelle.\n
-
-    **Calculation:** \n
-    Eccentricity is calculated using the principal axes of inertia 'I' along x, y and z: \n
-    .. math:: Eccentricity = 1-\\frac{I_{min}}{I_{average}}
-
-    The ratio of largest to smallest is  \n
-    .. math:: ratio = \\frac{Imax}{Imin}
-
-    The semiaxes a,b and c are those of an ellipsoid \n
-    .. math:: semiaxis_a = \\sqrt{ \\frac{5}{2M} (I_{max}+I_{mid}-I_{min}) }
-    .. math:: semiaxis_b = \\sqrt{ \\frac{5}{2M} (I_{max}+I_{min}-I_{mid}) }
-    .. math:: semiaxis_c = \\sqrt{ \\frac{5}{2M} (I_{mid}+I_{min}-I_{max}) }
-
-    Where:\n
-        - M is the total mass of all the selected atoms
-        - :math:`I_{min}` , :math:`I_{mid}` and :math:`I_{max}` are respectively the smallest, middle and biggest inertia moment values
-
-
-    **Output:** \n
-    #. moment_of_inertia_xx: the moment of inertia in x direction acting on the surface element with its vector normal in x direction
-    #. moment_of_inertia_xy: the moment of inertia in y direction acting on the surface element with its vector normal in x direction
-    #. moment_of_inertia_xz: the moment of inertia in z direction acting on the surface element with its vector normal in x direction
-    #. moment_of_inertia_yy: the moment of inertia in y direction acting on the surface element with its vector normal in y direction
-    #. moment_of_inertia_yz: the moment of inertia in z direction acting on the surface element with its vector normal in y direction
-    #. moment_of_inertia_zz: the moment of inertia in z direction acting on the surface element with its vector normal in z direction
-    #. semiaxis_a: ellipse biggest axis
-    #. semiaxis_b: ellipse middle axis
-    #. semiaxis_c: ellipse smallest axis
-    #. ratio_of_largest_to_smallest
-    #. eccentricity
-    #. radius_of_gyration
-
-
-    **Usage:** \n
-    This analysis can be used to study macro-molecular geometry and sphericity .
-    It was originally conceived to calculate the ellipticity of micelles.
-
-    **Acknowledgement and publication:**\n
-    AOUN Bachir, PELLEGRINI Eric
-
-    """
-
     label = "Eccentricity"
 
     category = (
@@ -89,212 +51,96 @@ class Eccentricity(IJob):
         "AtomSelectionConfigurator",
         {"dependencies": {"trajectory": "trajectory"}},
     )
-    settings["center_of_mass"] = (
-        "AtomSelectionConfigurator",
-        {"dependencies": {"trajectory": "trajectory"}},
-    )
-    settings["weights"] = (
-        "WeightsConfigurator",
-        {"dependencies": {"atom_selection": "atom_selection"}},
-    )
     settings["output_files"] = (
         "OutputFilesConfigurator",
         {"formats": ["MDAFormat", "TextFormat"]},
     )
 
     def initialize(self):
-        """
-        Initialize the input parameters and analysis self variables
-        """
         super().initialize()
 
         self.numberOfSteps = self.configuration["frames"]["number"]
 
-        # Will store the time.
         self._outputData.add(
             "time",
             "LineOutputVariable",
             self.configuration["frames"]["time"],
             units="ps",
         )
-
-        npoints = np.zeros((self.configuration["frames"]["number"]), dtype=np.float64)
-
-        for axis in ["xx", "xy", "xz", "yy", "yz", "zz"]:
-            self._outputData.add(
-                "moment_of_inertia_{}".format(axis),
-                "LineOutputVariable",
-                npoints,
-                axis="time",
-                units="uma nm2",
-            )
-        for axis in ["a", "b", "c"]:
-            self._outputData.add(
-                "semiaxis_{}".format(axis),
-                "LineOutputVariable",
-                npoints,
-                axis="time",
-                units="nm",
-            )
-
         self._outputData.add(
             "eccentricity",
             "LineOutputVariable",
-            npoints,
+            np.zeros((self.configuration["frames"]["number"]), dtype=np.float64),
             axis="time",
             main_result=True,
         )
 
-        self._outputData.add(
-            "ratio_of_largest_to_smallest", "LineOutputVariable", npoints, axis="time"
-        )
-
-        self._outputData.add(
-            "radius_of_gyration", "LineOutputVariable", npoints, axis="time"
-        )
-
-        self._indexes = self.configuration["atom_selection"].get_indexes()
-
-        self._comIndexes = self.configuration["center_of_mass"]["flatten_indexes"]
-
         self._atoms = sorted_atoms(
             self.configuration["trajectory"]["instance"].chemical_system.atom_list
         )
-
-        self._selectionMasses = [
+        self._indexes = np.array([
+            idx
+            for idxs in self._configuration["atom_selection"]["indexes"]
+            for idx in idxs
+        ])
+        self._selectionMasses = np.array([
             m
             for masses in self._configuration["atom_selection"]["masses"]
             for m in masses
-        ]
-        self._selectionTotalMass = np.sum(self._selectionMasses)
+        ])
 
-        self._comMasses = [
-            ATOMS_DATABASE.get_atom_property(self._atoms[idx].symbol, "atomic_weight")
-            for idx in self._comIndexes
-        ]
+    def run_step(self, index: int):
+        """Calculate the eccentricity for the selected atoms at the
+        frame index.
 
-    def run_step(self, index):
+        Parameters
+        ----------
+        index : int
+            The frame index.
         """
-        Runs a single step of the job.\n
-
-        :Parameters:
-            #. index (int): The index of the step.
-        :Returns:
-            #. index (int): The index of the step.
-            #. moment_of_inertia_xx (np.array)
-            #. moment_of_inertia_xy (np.array)
-            #. moment_of_inertia_xz (np.array)
-            #. moment_of_inertia_yy (np.array)
-            #. moment_of_inertia_yz (np.array)
-            #. moment_of_inertia_zz (np.array)
-            #. radius_of_gyration (np.array)
-        """
-        # get the Frame index
         frameIndex = self.configuration["frames"]["value"][index]
 
         conf = self.configuration["trajectory"]["instance"].configuration(frameIndex)
         conf = conf.continuous_configuration()
+        series = conf["coordinates"][self._indexes, :]
 
-        series = conf["coordinates"]
+        com = center_of_mass(series, masses=self._selectionMasses)
 
-        com = center_of_mass(series[self._comIndexes, :], masses=self._comMasses)
+        # calculate the inertia moments
+        mass = np.array(self._selectionMasses)
+        x, y, z = (series - com).T
+        xx = np.sum(mass * (y**2 + z**2))
+        xy = np.sum(-mass * x * y)
+        xz = np.sum(-mass * x * z)
+        yy = np.sum(mass * (x**2 + z**2))
+        yz = np.sum(-mass * y * z)
+        zz = np.sum(mass * (x**2 + y**2))
 
-        # calculate the inertia moments and the radius of gyration
-        xx = xy = xz = yy = yz = zz = 0
-        for name, idxs in list(self._indexes.items()):
-            atomsCoordinates = series[idxs, :]
-            difference = atomsCoordinates - com
+        moi = np.array(
+            [
+                [xx, xy, xz],
+                [xy, yy, yz],
+                [xz, yz, zz],
+            ]
+        )
 
-            w = ATOMS_DATABASE.get_atom_property(
-                name, self.configuration["weights"]["property"]
-            )
+        pm1, pm2, pm3 = np.linalg.eigvalsh(moi)
+        eccentricity = np.sqrt(pm3**2 - pm1**2) / pm3
+        return index, eccentricity
 
-            xx += np.add.reduce(
-                w
-                * (
-                    difference[:, 1] * difference[:, 1]
-                    + difference[:, 2] * difference[:, 2]
-                )
-            )
-            xy -= np.add.reduce(w * (difference[:, 0] * difference[:, 1]))
-            xz -= np.add.reduce(w * (difference[:, 0] * difference[:, 2]))
+    def combine(self, frame_idx: int, eccentricity: float):
+        """Save the calculated eccentricity of the selected atoms.
 
-            yy += np.add.reduce(
-                w
-                * (
-                    difference[:, 0] * difference[:, 0]
-                    + difference[:, 2] * difference[:, 2]
-                )
-            )
-            yz -= np.add.reduce(w * (difference[:, 1] * difference[:, 2]))
-
-            zz += np.add.reduce(
-                w
-                * (
-                    difference[:, 0] * difference[:, 0]
-                    + difference[:, 1] * difference[:, 1]
-                )
-            )
-
-        rog = np.sum((series - com) ** 2)
-
-        return index, (xx, xy, xz, yy, yz, zz, rog)
-
-    def combine(self, index, x):
+        Parameters
+        ----------
+        frame_idx : int
+            The frame index.
+        eccentricity : float
+            The eccentricity for the selected atom at frame_idx.
         """
-        Combines returned results of run_step.\n
-        :Parameters:
-            #. index (int): The index of the step.\n
-            #. x (any): The returned result(s) of run_step
-        """
-
-        Imin = min(x[0], x[3], x[5])
-        Imax = max(x[0], x[3], x[5])
-        Imid = [x[0], x[3], x[5]]
-        Imid.pop(Imid.index(Imin))
-        Imid.pop(Imid.index(Imax))
-        Imid = Imid[0]
-
-        average = (x[0] + x[3] + x[5]) / 3
-
-        # moment of inertia
-        self._outputData["moment_of_inertia_xx"][index] = x[0]
-        self._outputData["moment_of_inertia_xy"][index] = x[1]
-        self._outputData["moment_of_inertia_xz"][index] = x[2]
-        self._outputData["moment_of_inertia_yy"][index] = x[3]
-        self._outputData["moment_of_inertia_yz"][index] = x[4]
-        self._outputData["moment_of_inertia_zz"][index] = x[5]
-
-        # eccentricity = 0 for spherical objects
-        self._outputData["eccentricity"][index] = 1 - Imin / average
-
-        # ratio_of_largest_to_smallest = 1 for spherical objects
-        self._outputData["ratio_of_largest_to_smallest"][index] = Imax / Imin
-
-        # semiaxis
-        self._outputData["semiaxis_a"][index] = np.sqrt(
-            5.0 / (2.0 * self._selectionTotalMass) * (Imax + Imid - Imin)
-        )
-        self._outputData["semiaxis_b"][index] = np.sqrt(
-            5.0 / (2.0 * self._selectionTotalMass) * (Imax + Imin - Imid)
-        )
-        self._outputData["semiaxis_c"][index] = np.sqrt(
-            5.0 / (2.0 * self._selectionTotalMass) * (Imid + Imin - Imax)
-        )
-
-        # radius_of_gyration is a measure of the distribution of the mass
-        # of atomic groups or molecules that constitute the aqueous core
-        # relative to its center of mass
-        self._outputData["radius_of_gyration"][index] = np.sqrt(
-            x[6] / self.configuration["atom_selection"]["selection_length"]
-        )
+        self._outputData["eccentricity"][frame_idx] = eccentricity
 
     def finalize(self):
-        """
-        Finalizes the calculations (e.g. averaging the total term, output files creations ...).
-        """
-
-        # Write the output variables.
         self._outputData.write(
             self.configuration["output_files"]["root"],
             self.configuration["output_files"]["formats"],


### PR DESCRIPTION
**Description of work**
Updated the eccentricity calculation so that it follows more standard equations. Specificaly it is now changed so that it follows the equations that are used in rdkit https://www.rdkit.org/docs/source/rdkit.Chem.Descriptors3D.html. 

Single rigid water trajectory
BEFORE
![image](https://github.com/user-attachments/assets/23e56236-a8f8-488f-b857-edd03aac9607)
At some points, it's nearly zero therefore nearly perfectly spherical this looks wrong.

AFTER
![image](https://github.com/user-attachments/assets/70094e89-a586-418a-9585-aa855d6d4b8a)
Now the rigid water molecule has a near-constant value for its eccentricity.

Single flexible water trajectory
BEFORE
![image](https://github.com/user-attachments/assets/a7785003-5deb-4183-a935-56e59ec39113)
It seems to change far more than it should. Again at some points, it's nearly zero therefore nearly perfectly spherical which is wrong.

AFTER
![image](https://github.com/user-attachments/assets/688a50ce-6260-487b-b508-60c29d2497c5)
A flexible water molecule eccentricity changes with time. What is nice is that we can see that water geometry changes in a nice oscillatory manner but mostly stays the same.

**Fixes**
(Fixes #552) The new equations that are used are do not depend on the orientation of the selected atoms.
(Fixes #378) Weight setting is removed as it is not meaningful for this calculation.
(Fixes #380) ROG calculation has been removed.

**To test**
Run the eccentricity calculation which specific atom selections and check that results are consistent with expectations e.g. spherical atom selections should have small values of the eccentricity.
