### PR TITLE
Add missing function name to ResolutionCalculator output

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
@@ -28,7 +28,6 @@ from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
 from MDANSE_GUI.Widgets.ResolutionDialog import ResolutionDialog
 from MDANSE_GUI.Widgets.ResolutionWidget import widget_text_map
 
-reverse_lookup = {value: key for key, value in widget_text_map.items()}
 
 init_parameters = {
     "ideal": {},
@@ -128,7 +127,7 @@ class InstrumentResolutionWidget(WidgetBase):
         else:
             new_params = optional_parameters
         self._type_combo.blockSignals(True)
-        self._type_combo.setCurrentText(reverse_lookup[function])
+        self._type_combo.setCurrentText(widget_text_map[function])
         self._type_combo.blockSignals(False)
         self.set_field_values(new_params)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
@@ -97,6 +97,7 @@ class SimpleInstrument:
         except Exception as e:
             LOG.error(f"recalculate_peak failed: {e}")
         _, results = calculator.summarise_results()
+        results.pop("function", None)
         mdanse_tuple = (widget_text_map[self._resolution_type], results)
         self._resolution_results = mdanse_tuple
         return mdanse_tuple

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/ResolutionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/ResolutionWidget.py
@@ -233,7 +233,7 @@ class ResolutionCalculator:
             LOG.warning(f"Could not find {key} in {self._resolution._configuration}")
 
     def summarise_results(self, rounding_precision=3):
-        results = {}
+        results = {"function": self._resolution_name}
         text = ""
         for key, value in self._resolution._configuration.items():
             original_value = value["value"]
@@ -460,6 +460,7 @@ class ResolutionWidget(QWidget):
         self._output_field.setText(text + temp_text)
         self._results = results
 
+    @Slot()
     def apply_changes(self):
         self.parameters_changed.emit(self._results)
 


### PR DESCRIPTION
**Description of work**
PR https://github.com/ISISNeutronMuon/MDANSE/pull/529 restructured the resolution calculation. This interfered with the resolution helper dialog, which requires one additional item in the parameter dictionary.

**Fixes**
1. The missing function name has been added to the output of ResolutionCalculator.
2. InstrumentInfo removes the function name from the dictionary, so it does not appear twice.

**To test**
Try setting the resolution in a scattering job when no instrument is selected.
Try changing the resolution type in an instrument profile in the instrument tab.
Both should work and create valid resolution parameters.
