### PR TITLE
Update Gromacs converter

### DIFF
--- a/MDANSE/Extensions/xtc/include/xdr_seek.h
+++ b/MDANSE/Extensions/xtc/include/xdr_seek.h
@@ -12,5 +12,6 @@
 
 int64_t xdr_tell(XDRFILE *xd);
 int xdr_seek(XDRFILE *xd, int64_t pos, int whence);
+int xdr_flush(XDRFILE* xd);
 
 #endif

--- a/MDANSE/Extensions/xtc/include/xdrfile.h
+++ b/MDANSE/Extensions/xtc/include/xdrfile.h
@@ -31,8 +31,8 @@
  *  \brief Interface to read/write portabile binary files using XDR.
  *
  * This file provides an interface to read & write portably binary files,
- * using XDR - the external data representation standard defined in RFC 1014. 
- * 
+ * using XDR - the external data representation standard defined in RFC 1014.
+ *
  * There are several advantages to the XDR approach:
  *
  * -# It is portable. And not just portable between big/small integer endian,
@@ -46,8 +46,8 @@
  * -# XDR libraries are required for NFS and lots of other network functions.
  *    This means there isn't a single Unix-like system that doesn't have them.
  * -# There is NO extra metadata whatsoever, and we write plain XDR files.
- *    If you write a float, it will take exactly 4 bytes in the file. 
- *    (All basic datatypes are 4 bytes, double fp 8 bytes). 
+ *    If you write a float, it will take exactly 4 bytes in the file.
+ *    (All basic datatypes are 4 bytes, double fp 8 bytes).
  * -# You can read/write the files by calling the system XDR routines directly
  *    too - you don't have to use the routines defined in this file.
  * -# It is no problem if your system doesn't have XDR libraries (MS Windows).
@@ -66,7 +66,7 @@
  * your system supports it; it is just the random access we cannot trust!
  *
  * We also provide wrapper routines so this module can be used from FORTRAN -
- * see the file xdrfile_fortran.txt in the Gromacs distribution for 
+ * see the file xdrfile_fortran.txt in the Gromacs distribution for
  * documentation on the FORTRAN interface!
  */
 
@@ -75,26 +75,26 @@
 
 
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 {
 #endif
 
-	/*! \brief Abstract datatype for an portable binary file handle 
+	/*! \brief Abstract datatype for an portable binary file handle
 	 *
 	 *  This datatype essentially works just like the standard FILE type in C.
 	 *  The actual contents is hidden in the implementation, so you can only
-	 *  define pointers to it, for use with the xdrfile routines. 
-	 *  
+	 *  define pointers to it, for use with the xdrfile routines.
+	 *
 	 *  If you \a really need to see the definition it is in xdrfile.c, but you
 	 *  cannot access elements of the structure outside that file.
 	 *
 	 *  \warning The implementation is completely different from the C standard
-	 *  library FILE, so don't even think about using an XDRFILE pointer as an 
+	 *  library FILE, so don't even think about using an XDRFILE pointer as an
 	 *  argument to a routine that needs a standard FILE pointer.
 	 */
 	typedef struct XDRFILE XDRFILE;
 
-	enum { exdrOK, exdrHEADER, exdrSTRING, exdrDOUBLE, 
+	enum { exdrOK, exdrHEADER, exdrSTRING, exdrDOUBLE,
 		   exdrINT, exdrFLOAT, exdrUINT, exdr3DX, exdrCLOSE, exdrMAGIC,
 		   exdrNOMEM, exdrENDOFFILE, exdrFILENOTFOUND, exdrNR };
 
@@ -119,7 +119,7 @@ extern "C"
 	 *
 	 */
 	XDRFILE *
-	xdrfile_open    (const char *    path, 
+	xdrfile_open    (const char *    path,
 					 const char *    mode);
 
 
@@ -128,10 +128,10 @@ extern "C"
 	 *  Use this routine much like calls to the standard library function
 	 *  fopen(). The only difference is that it is used for an XDRFILE handle
 	 *  instead of a FILE handle.
-	 * 
+	 *
 	 *  \param xfp  Pointer to an abstract XDRFILE datatype
 	 *
-	 *  \return     0 on success, non-zero on error. 
+	 *  \return     0 on success, non-zero on error.
 	 */
 	int
 	xdrfile_close   (XDRFILE *       xfp);
@@ -139,7 +139,7 @@ extern "C"
 
 
 
-	/*! \brief Read one or more \a char type variable(s) 
+	/*! \brief Read one or more \a char type variable(s)
 	 *
 	 *  \param ptr    Pointer to memory where data should be written
 	 *  \param ndata  Number of characters to read
@@ -148,28 +148,28 @@ extern "C"
 	 *  \return       Number of characters read
 	 */
 	int
-	xdrfile_read_char(char *      ptr, 
-					  int         ndata, 
+	xdrfile_read_char(char *      ptr,
+					  int         ndata,
 					  XDRFILE *   xfp);
 
 
 
 	/*! \brief Write one or more \a characters type variable(s)
 	 *
-	 *  \param ptr    Pointer to memory where data should be read 
+	 *  \param ptr    Pointer to memory where data should be read
 	 *  \param ndata  Number of characters to write.
 	 *  \param xfp    Handle to portable binary file, created with xdrfile_open()
 	 *
 	 *  \return       Number of characters written
 	 */
 	int
-	xdrfile_write_char(char *      ptr, 
-					   int         ndata, 
+	xdrfile_write_char(char *      ptr,
+					   int         ndata,
 					   XDRFILE *   xfp);
 
 
 
-	/*! \brief Read one or more \a unsigned \a char type variable(s) 
+	/*! \brief Read one or more \a unsigned \a char type variable(s)
 	 *
 	 *  \param ptr    Pointer to memory where data should be written
 	 *  \param ndata  Number of unsigned characters to read
@@ -178,28 +178,28 @@ extern "C"
 	 *  \return       Number of unsigned characters read
 	 */
 	int
-	xdrfile_read_uchar(unsigned char *    ptr, 
-					   int		          ndata, 
+	xdrfile_read_uchar(unsigned char *    ptr,
+					   int		          ndata,
 					   XDRFILE *          xfp);
 
 
 
 	/*! \brief Write one or more \a unsigned \a characters type variable(s)
 	 *
-	 *  \param ptr    Pointer to memory where data should be read 
+	 *  \param ptr    Pointer to memory where data should be read
 	 *  \param ndata  Number of unsigned characters to write.
 	 *  \param xfp    Handle to portable binary file, created with xdrfile_open()
 	 *
 	 *  \return       Number of unsigned characters written
 	 */
 	int
-	xdrfile_write_uchar(unsigned char *   ptr, 
-						int               ndata, 
+	xdrfile_write_uchar(unsigned char *   ptr,
+						int               ndata,
 						XDRFILE *         xfp);
 
 
 
-	/*! \brief Read one or more \a short type variable(s) 
+	/*! \brief Read one or more \a short type variable(s)
 	 *
 	 *  \param ptr    Pointer to memory where data should be written
 	 *  \param ndata  Number of shorts to read
@@ -208,28 +208,28 @@ extern "C"
 	 *  \return       Number of shorts read
 	 */
 	int
-	xdrfile_read_short(short *             ptr, 
-					   int                 ndata, 
+	xdrfile_read_short(short *             ptr,
+					   int                 ndata,
 					   XDRFILE *           xfp);
 
 
 
 	/*! \brief Write one or more \a short type variable(s)
 	 *
-	 *  \param ptr    Pointer to memory where data should be read 
+	 *  \param ptr    Pointer to memory where data should be read
 	 *  \param ndata  Number of shorts to write.
 	 *  \param xfp    Handle to portable binary file, created with xdrfile_open()
 	 *
 	 *  \return       Number of shorts written
 	 */
 	int
-	xdrfile_write_short(short *            ptr, 
-						int                ndata, 
+	xdrfile_write_short(short *            ptr,
+						int                ndata,
 						XDRFILE *          xfp);
 
 
 
-	/*! \brief Read one or more \a unsigned \a short type variable(s) 
+	/*! \brief Read one or more \a unsigned \a short type variable(s)
 	 *
 	 *  \param ptr    Pointer to memory where data should be written
 	 *  \param ndata  Number of unsigned shorts to read
@@ -238,27 +238,27 @@ extern "C"
 	 *  \return       Number of unsigned shorts read
 	 */
 	int
-	xdrfile_read_ushort(unsigned short *   ptr, 
-						int                ndata, 
+	xdrfile_read_ushort(unsigned short *   ptr,
+						int                ndata,
 						XDRFILE *          xfp);
 
 
 
 	/*! \brief Write one or more \a unsigned \a short type variable(s)
 	 *
-	 *  \param ptr    Pointer to memory where data should be read 
+	 *  \param ptr    Pointer to memory where data should be read
 	 *  \param ndata  Number of unsigned shorts to write.
 	 *  \param xfp    Handle to portable binary file, created with xdrfile_open()
 	 *
 	 *  \return       Number of unsigned shorts written
 	 */
 	int
-	xdrfile_write_ushort(unsigned short *     ptr, 
-						 int                  ndata, 
+	xdrfile_write_ushort(unsigned short *     ptr,
+						 int                  ndata,
 						 XDRFILE *            xfp);
 
 
-	/*! \brief Read one or more \a integer type variable(s) 
+	/*! \brief Read one or more \a integer type variable(s)
 	 *
 	 *  \param ptr    Pointer to memory where data should be written
 	 *  \param ndata  Number of integers to read
@@ -275,15 +275,15 @@ extern "C"
 	 *  Split your 64-bit data into two 32-bit integers for portability!
 	 */
 	int
-	xdrfile_read_int(int *         ptr, 
-					 int           ndata, 
+	xdrfile_read_int(int *         ptr,
+					 int           ndata,
 					 XDRFILE *     xfp);
 
 
 
 	/*! \brief Write one or more \a integer type variable(s)
 	 *
-	 *  \param ptr    Pointer to memory where data should be read 
+	 *  \param ptr    Pointer to memory where data should be read
 	 *  \param ndata  Number of integers to write.
 	 *  \param xfp    Handle to portable binary file, created with xdrfile_open()
 	 *
@@ -293,16 +293,16 @@ extern "C"
 	 *
 	 *  We do not provide any routines for reading/writing 64-bit integers, since
 	 *  - Not all XDR implementations support it
-	 *  - Not all machines have 64-bit integers 
+	 *  - Not all machines have 64-bit integers
 	 *
 	 *  Split your 64-bit data into two 32-bit integers for portability!
 	 */
 	int
-	xdrfile_write_int(int *        ptr, 
-					  int          ndata, 
+	xdrfile_write_int(int *        ptr,
+					  int          ndata,
 					  XDRFILE *    xfp);
 
-	/*! \brief Read one or more \a unsigned \a integers type variable(s) 
+	/*! \brief Read one or more \a unsigned \a integers type variable(s)
 	 *
 	 *  \param ptr    Pointer to memory where data should be written
 	 *  \param ndata  Number of unsigned integers to read
@@ -319,15 +319,15 @@ extern "C"
 	 *  Split your 64-bit data into two 32-bit integers for portability!
 	 */
 	int
-	xdrfile_read_uint(unsigned int *    ptr, 
-					  int               ndata, 
+	xdrfile_read_uint(unsigned int *    ptr,
+					  int               ndata,
 					  XDRFILE *         xfp);
 
 
 
 	/*! \brief Write one or more \a unsigned \a integer type variable(s)
 	 *
-	 *  \param ptr    Pointer to memory where data should be read 
+	 *  \param ptr    Pointer to memory where data should be read
 	 *  \param ndata  Number of unsigned integers to write.
 	 *  \param xfp    Handle to portable binary file, created with xdrfile_open()
 	 *
@@ -337,18 +337,18 @@ extern "C"
 	 *
 	 *  We do not provide any routines for reading/writing 64-bit integers, since
 	 *  - Not all XDR implementations support it
-	 *  - Not all machines have 64-bit integers 
+	 *  - Not all machines have 64-bit integers
 	 *
 	 *  Split your 64-bit data into two 32-bit integers for portability!
 	 */
 	int
-	xdrfile_write_uint(unsigned int *    ptr, 
-					   int               ndata,  
+	xdrfile_write_uint(unsigned int *    ptr,
+					   int               ndata,
 					   XDRFILE *         xfp);
 
 
 
-	/*! \brief Read one or more \a float type variable(s) 
+	/*! \brief Read one or more \a float type variable(s)
 	 *
 	 *  \param ptr    Pointer to memory where data should be written
 	 *  \param ndata  Number of floats to read
@@ -357,28 +357,28 @@ extern "C"
 	 *  \return       Number of floats read
 	 */
 	int
-	xdrfile_read_float(float *           ptr, 
-					   int               ndata, 
+	xdrfile_read_float(float *           ptr,
+					   int               ndata,
 					   XDRFILE *         xfp);
 
 
 
 	/*! \brief Write one or more \a float type variable(s)
 	 *
-	 *  \param ptr    Pointer to memory where data should be read 
+	 *  \param ptr    Pointer to memory where data should be read
 	 *  \param ndata  Number of floats to write.
 	 *  \param xfp    Handle to portable binary file, created with xdrfile_open()
 	 *
 	 *  \return       Number of floats written
 	 */
 	int
-	xdrfile_write_float(float *          ptr, 
-						int              ndata, 
+	xdrfile_write_float(float *          ptr,
+						int              ndata,
 						XDRFILE *        xfp);
 
 
 
-	/*! \brief Read one or more \a double type variable(s) 
+	/*! \brief Read one or more \a double type variable(s)
 	 *
 	 *  \param ptr    Pointer to memory where data should be written
 	 *  \param ndata  Number of doubles to read
@@ -387,23 +387,23 @@ extern "C"
 	 *  \return       Number of doubles read
 	 */
 	int
-	xdrfile_read_double(double *          ptr, 
-						int               ndata, 
+	xdrfile_read_double(double *          ptr,
+						int               ndata,
 						XDRFILE *         xfp);
 
 
 
 	/*! \brief Write one or more \a double type variable(s)
 	 *
-	 *  \param ptr    Pointer to memory where data should be read 
+	 *  \param ptr    Pointer to memory where data should be read
 	 *  \param ndata  Number of double to write.
 	 *  \param xfp    Handle to portable binary file, created with xdrfile_open()
 	 *
 	 *  \return       Number of doubles written
 	 */
 	int
-	xdrfile_write_double(double *        ptr, 
-						 int             ndata, 
+	xdrfile_write_double(double *        ptr,
+						 int             ndata,
 						 XDRFILE *       xfp);
 
 
@@ -418,8 +418,8 @@ extern "C"
 	 *  \return        Number of characters read, including end-of-string
 	 */
 	int
-	xdrfile_read_string(char *          ptr, 
-						int             maxlen, 
+	xdrfile_read_string(char *          ptr,
+						int             maxlen,
 						XDRFILE *       xfp);
 
 
@@ -432,7 +432,7 @@ extern "C"
 	 *  \return        Number of characters written, including end-of-string
 	 */
 	int
-	xdrfile_write_string(char *          ptr, 
+	xdrfile_write_string(char *          ptr,
 						 XDRFILE *       xfp);
 
 
@@ -446,8 +446,8 @@ extern "C"
 	 *  \return        Number of bytes read from file
 	 */
 	int
-	xdrfile_read_opaque(char *             ptr, 
-						int                nbytes, 
+	xdrfile_read_opaque(char *             ptr,
+						int                nbytes,
 						XDRFILE *          xfp);
 
 
@@ -462,8 +462,8 @@ extern "C"
 	 *  \return        Number of bytes written to file
 	 */
 	int
-	xdrfile_write_opaque(char *            ptr, 
-						 int               nbytes, 
+	xdrfile_write_opaque(char *            ptr,
+						 int               nbytes,
 						 XDRFILE *         xfp);
 
 
@@ -485,19 +485,19 @@ extern "C"
 	 *
 	 *  \param ptr        Pointer to coordinates to compress (length 3*ncoord)
 	 *  \param ncoord     Number of coordinate triplets in data
-	 *  \param precision  Scaling factor for lossy compression. If it is <=0, 
+	 *  \param precision  Scaling factor for lossy compression. If it is <=0,
 	 *                    the default value of 1000.0 is used.
 	 *  \param xfp        Handle to portably binary file
 	 *
-	 *  \return           Number of coordinate triplets written. 
+	 *  \return           Number of coordinate triplets written.
 	 *                    IMPORTANT: Check that this is equal to ncoord - if it is
-	 *                    negative, an error occured. This should not happen with 
+	 *                    negative, an error occured. This should not happen with
 	 *	   	              normal data, but if your coordinates are NaN or very
 	 *                    large (>1e6) it is not possible to use the compression.
 	 *
 	 *  \warning          The compression algorithm is not part of the XDR standard,
-	 *                    and very complicated, so you will need this xdrfile module 
-	 *                    to read it later. 
+	 *                    and very complicated, so you will need this xdrfile module
+	 *                    to read it later.
 	 */
 	int
 	xdrfile_compress_coord_float(float *     ptr,
@@ -510,7 +510,7 @@ extern "C"
 
 	/*! \brief Decompress coordiates from XDR file to array of floats
 	 *
-	 *  This routine will decompress three-dimensional coordinate data previously 
+	 *  This routine will decompress three-dimensional coordinate data previously
 	 *  stored in an XDR file and store it in the specified array of floats.
 	 *
 	 *  The precision used during the earlier compression is read from the file
@@ -528,13 +528,13 @@ extern "C"
 	 *  \return           Number of coordinate triplets read. If this is negative,
 	 *                    an error occured.
 	 *
-	 *  \warning          Since we cannot count on being able to set/get the 
+	 *  \warning          Since we cannot count on being able to set/get the
 	 *                    position of large files (>2Gb), it is not possible to
-	 *                    recover from errors by re-reading the frame if the 
-	 *                    storage area you provided was too small. To avoid this 
-	 *                    from happening, we recommend that you store the number of 
+	 *                    recover from errors by re-reading the frame if the
+	 *                    storage area you provided was too small. To avoid this
+	 *                    from happening, we recommend that you store the number of
 	 *                    coordinates triplet as an integer either in a header or
-	 *                    just before the compressed coordinate data, so you can 
+	 *                    just before the compressed coordinate data, so you can
 	 *                    read it first and allocated enough memory.
 	 */
 	int
@@ -566,15 +566,15 @@ extern "C"
 	 *                    default value of 1000.0 is used.
 	 *  \param xfp        Handle to portably binary file
 	 *
-	 *  \return           Number of coordinate triplets written. 
+	 *  \return           Number of coordinate triplets written.
 	 *                    IMPORTANT: Check that this is equal to ncoord - if it is
-	 *                    negative, an error occured. This should not happen with 
+	 *                    negative, an error occured. This should not happen with
 	 *                    normal data, but if your coordinates are NaN or very
 	 *                    large (>1e6) it is not possible to use the compression.
 	 *
 	 *  \warning          The compression algorithm is not part of the XDR standard,
-	 *                    and very complicated, so you will need this xdrfile module 
-	 *                    to read it later. 
+	 *                    and very complicated, so you will need this xdrfile module
+	 *                    to read it later.
 	 */
 	int
 	xdrfile_compress_coord_double(double *     ptr,
@@ -587,9 +587,9 @@ extern "C"
 
 	/*! \brief Decompress coordiates from XDR file to array of doubles
 	 *
-	 *  This routine will decompress three-dimensional coordinate data previously 
+	 *  This routine will decompress three-dimensional coordinate data previously
 	 *  stored in an XDR file and store it in the specified array of doubles.
-	 *  Double will NOT give you any extra precision since the coordinates are 
+	 *  Double will NOT give you any extra precision since the coordinates are
 	 *  compressed. This routine just avoids allocating a temporary array of floats.
 	 *
 	 *  The precision used during the earlier compression is read from the file
@@ -607,13 +607,13 @@ extern "C"
 	 *  \return           Number of coordinate triplets read. If this is negative,
 	 *                    an error occured.
 	 *
-	 *  \warning          Since we cannot count on being able to set/get the 
+	 *  \warning          Since we cannot count on being able to set/get the
 	 *                    position of large files (>2Gb), it is not possible to
-	 *                    recover from errors by re-reading the frame if the 
-	 *                    storage area you provided was too small. To avoid this 
-	 *                    from happening, we recommend that you store the number of 
+	 *                    recover from errors by re-reading the frame if the
+	 *                    storage area you provided was too small. To avoid this
+	 *                    from happening, we recommend that you store the number of
 	 *                    coordinates triplet as an integer either in a header or
-	 *                    just before the compressed coordinate data, so you can 
+	 *                    just before the compressed coordinate data, so you can
 	 *                    read it first and allocated enough memory.
 	 */
 	int
@@ -629,4 +629,3 @@ extern "C"
 #endif
 
 #endif /* _XDRFILE_H_ */
-

--- a/MDANSE/Extensions/xtc/include/xdrfile_trr.h
+++ b/MDANSE/Extensions/xtc/include/xdrfile_trr.h
@@ -35,15 +35,15 @@ extern "C" {
 #endif
 
 #include "xdrfile.h"
-  
+
   /* All functions return exdrOK if successful.
    * (error codes defined in xdrfile.h).
-   */  
-   
+   */
+
   /* This function returns the number of atoms in the xtc file in *natoms */
   extern int read_trr_natoms(char *fn,int *natoms);
   extern int read_trr_nframes(char* fn, unsigned long *nframes);
-  
+
   /* Read one frame of an open xtc file. If either of x,v,f,box are
      NULL the arrays will be read from the file but not used.  */
   extern int read_trr(XDRFILE *xd,int natoms,int *step,float *t,float *lambda,
@@ -53,7 +53,7 @@ extern "C" {
   extern int write_trr(XDRFILE *xd,int natoms,int step,float t,float lambda,
 		       matrix box,rvec *x,rvec *v,rvec *f);
 
-  
+
 #ifdef __cplusplus
 }
 #endif

--- a/MDANSE/Extensions/xtc/include/xdrfile_xtc.h
+++ b/MDANSE/Extensions/xtc/include/xdrfile_xtc.h
@@ -35,25 +35,25 @@ extern "C" {
 #endif
 
 #include "xdrfile.h"
-  
-  /* All functions return exdrOK if succesfull. 
+
+  /* All functions return exdrOK if succesfull.
    * (error codes defined in xdrfile.h).
-   */  
-   
+   */
+
   /* This function returns the number of atoms in the xtc file in *natoms */
   extern int read_xtc_natoms(char *fn,int *natoms);
-  
+
   int read_xtc_nframes(char* fn, unsigned long *nframes);
 
   /* Read one frame of an open xtc file */
   extern int read_xtc(XDRFILE *xd,int natoms,int *step,float *time,
 		      matrix box,rvec *x,float *prec);
-  
+
   /* Write a frame to xtc file */
   extern int write_xtc(XDRFILE *xd,
 		       int natoms,int step,float time,
 		       matrix box,rvec *x,float prec);
-  
+
 #ifdef __cplusplus
 }
 #endif

--- a/MDANSE/Extensions/xtc/src/README
+++ b/MDANSE/Extensions/xtc/src/README
@@ -1,0 +1,17 @@
+Low-level C libraries for manipulating GROMACS XTC and TRR files. This code
+is derived from xdrfile-1.1.4, available at
+
+http://www.gromacs.org/Developer_Zone/Programming_Guide/XTC_Library
+ftp://ftp.gromacs.org/pub/contrib/xdrfile-1.1.4.tar.gz
+
+These files are licensed under a BSD 2-clause license, and copyright
+Erik Lindahl, David van der Spoel, Robert T. McGibbon.
+
+Changes from upsteam's xdrfile-1.1.4 include:
+ - More descriptive error strings printed inside xdrfile.c
+ - Fix for a segfault on malformed xtc files inside xdrfile_decompress_coord_float (https://github.com/mdtraj/mdtraj/pull/607, https://mailman-1.sys.kth.se/pipermail/gromacs.org_gmx-developers/2014-September/007942.html)
+ - Addition of read_xtc_nframes function in xdrfile_xtc.c
+ - Addition of read_trr_nframes function in xdrfile_trr.c
+ - Bugfix in do_trnheader to return the appropriate error code when reading magic, and properly check the value of the magic in xdrfile_trr.c
+ - Bugfix of float exception (divide by zero) in xdrfile.c, see https://github.com/SimTk/mdtraj/issues/616
+ - Implemented efficient seeking pattern inspired by xdrlib2 (part of MDAnalysis)

--- a/MDANSE/Extensions/xtc/src/xdr_seek.c
+++ b/MDANSE/Extensions/xtc/src/xdr_seek.c
@@ -38,7 +38,7 @@ int xdr_seek(XDRFILE *xd, int64_t pos, int whence)
 #ifndef _WIN32
 	// use posix 64 bit ftell version
 	result = fseeko(fptr, pos, whence) < 0 ? exdrNR : exdrOK;
-#elif _MSC_VER && !__INTEL_COMPILER
+#elif _MSVC_VER && !__INTEL_COMPILER
 	result = _fseeki64(fptr, pos, whence) < 0 ? exdrNR : exdrOK;
 #else
 	result = fseek(fptr, pos, whence) < 0 ? exdrNR : exdrOK;
@@ -47,4 +47,9 @@ int xdr_seek(XDRFILE *xd, int64_t pos, int whence)
 		return result;
 
 	return exdrOK;
+}
+
+int xdr_flush(XDRFILE* xdr)
+{
+    return fflush(xdr->fp);
 }

--- a/MDANSE/Extensions/xtc/src/xdrfile.c
+++ b/MDANSE/Extensions/xtc/src/xdrfile.c
@@ -61,9 +61,9 @@
 #endif
 
 char *exdr_message[exdrNR] = {
-	"OK", 
+	"OK",
 	"Header",
-	"String", 
+	"String",
 	"Double",
 	"Integer",
 	"Float",
@@ -73,7 +73,7 @@ char *exdr_message[exdrNR] = {
 	"Magic number",
 	"Not enough memory",
 	"End of file",
-	"File not found" 
+	"File not found"
 };
 
 /*
@@ -118,7 +118,7 @@ typedef struct XDR XDR;
 
 struct XDR
 {
-	enum xdr_op x_op;		
+	enum xdr_op x_op;
 	struct xdr_ops
 	{
 		int (*x_getlong) (XDR *__xdrs, int32_t *__lp);
@@ -126,11 +126,11 @@ struct XDR
 		int (*x_getbytes) (XDR *__xdrs, char *__addr, unsigned int __len);
 		int (*x_putbytes) (XDR *__xdrs, char *__addr, unsigned int __len);
 		/* two next routines are not 64-bit IO safe - don't use! */
-		unsigned int (*x_getpostn) (XDR *__xdrs); 
+		unsigned int (*x_getpostn) (XDR *__xdrs);
 		int (*x_setpostn) (XDR *__xdrs, unsigned int __pos);
-		void (*x_destroy) (XDR *__xdrs); 
-	} 
-    *x_ops;	    
+		void (*x_destroy) (XDR *__xdrs);
+	}
+    *x_ops;
 	char *x_private;
 };
 
@@ -164,26 +164,26 @@ static void xdrstdio_create (XDR *xdrs, FILE *fp, enum xdr_op xop);
 /** Contents of the abstract XDRFILE data structure.
  *
  *  @internal
- * 
+ *
  *  This structure is used to provide an XDR file interface that is
  *  virtual identical to the standard UNIX fopen/fread/fwrite/fclose.
  */
-struct XDRFILE 
-{ 
+struct XDRFILE
+{
     FILE *   fp;       /**< pointer to standard C library file handle */
     XDR *    xdr;      /**< pointer to corresponding XDR handle       */
     char     mode;     /**< r=read, w=write, a=append                 */
     int *    buf1;     /**< Buffer for internal use                   */
-    int      buf1size; /**< Current allocated length of buf1          */    
+    int      buf1size; /**< Current allocated length of buf1          */
     int *    buf2;     /**< Buffer for internal use                   */
-    int      buf2size; /**< Current allocated length of buf2          */ 
+    int      buf2size; /**< Current allocated length of buf2          */
 };
 
 
 
 
 /*************************************************************
- * Implementation of higher-level routines to read/write     * 
+ * Implementation of higher-level routines to read/write     *
  * portable data based on the XDR standard. These should be  *
  * called from C - see further down for Fortran77 wrappers.  *
  *************************************************************/
@@ -194,13 +194,13 @@ xdrfile_open(const char *path, const char *mode)
 	char newmode[5];
 	enum xdr_op xdrmode;
 	XDRFILE *xfp;
-  
+
 	/* make sure XDR files are opened in binary mode... */
-	if(*mode=='w' || *mode=='W') 
+	if(*mode=='w' || *mode=='W')
     {
 		sprintf(newmode,"wb+");
 		xdrmode=XDR_ENCODE;
-	} else if(*mode == 'a' || *mode == 'A') 
+	} else if(*mode == 'a' || *mode == 'A')
     {
 		sprintf(newmode,"ab+");
 		xdrmode = XDR_ENCODE;
@@ -210,7 +210,7 @@ xdrfile_open(const char *path, const char *mode)
 		xdrmode = XDR_DECODE;
 	} else /* cannot determine mode */
 		return NULL;
-  
+
 	if((xfp=(XDRFILE *)malloc(sizeof(XDRFILE)))==NULL)
 		return NULL;
 	if((xfp->fp=fopen(path,newmode))==NULL)
@@ -218,7 +218,7 @@ xdrfile_open(const char *path, const char *mode)
 		free(xfp);
 		return NULL;
 	}
-	if((xfp->xdr=(XDR *)malloc(sizeof(XDR)))==NULL) 
+	if((xfp->xdr=(XDR *)malloc(sizeof(XDR)))==NULL)
     {
 		fclose(xfp->fp);
 		free(xfp);
@@ -231,11 +231,11 @@ xdrfile_open(const char *path, const char *mode)
 	return xfp;
 }
 
-int 
+int
 xdrfile_close(XDRFILE *xfp)
 {
 	int ret=exdrCLOSE;
-	if(xfp) 
+	if(xfp)
     {
 		/* flush and destroy XDR stream */
 		if(xfp->xdr)
@@ -254,149 +254,149 @@ xdrfile_close(XDRFILE *xfp)
 
 
 
-int 
-xdrfile_read_int(int *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_read_int(int *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
 
 	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_int((XDR *)(xfp->xdr),ptr+i))
 		i++;
-  
+
 	return i;
 }
 
-int 
-xdrfile_write_int(int *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_write_int(int *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
-  
-	/* read write is encoded in the XDR struct */  
+
+	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_int((XDR *)(xfp->xdr),ptr+i))
 		i++;
 	return i;
 }
 
 
-int 
-xdrfile_read_uint(unsigned int *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_read_uint(unsigned int *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
 
 	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_u_int((XDR *)(xfp->xdr),ptr+i))
 		i++;
-  
+
 	return i;
 }
 
-int 
-xdrfile_write_uint(unsigned int *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_write_uint(unsigned int *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
-  
-	/* read write is encoded in the XDR struct */  
+
+	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_u_int((XDR *)(xfp->xdr),ptr+i))
 		i++;
 	return i;
 }
 
-int 
-xdrfile_read_char(char *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_read_char(char *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
 
 	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_char((XDR *)(xfp->xdr),ptr+i))
 		i++;
-  
+
 	return i;
 }
 
-int 
-xdrfile_write_char(char *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_write_char(char *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
-  
-	/* read write is encoded in the XDR struct */  
+
+	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_char((XDR *)(xfp->xdr),ptr+i))
 		i++;
 	return i;
 }
 
 
-int 
-xdrfile_read_uchar(unsigned char *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_read_uchar(unsigned char *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
 
 	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_u_char((XDR *)(xfp->xdr),ptr+i))
 		i++;
-  
+
 	return i;
 }
 
-int 
-xdrfile_write_uchar(unsigned char *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_write_uchar(unsigned char *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
-  
-	/* read write is encoded in the XDR struct */  
+
+	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_u_char((XDR *)(xfp->xdr),ptr+i))
 		i++;
 	return i;
 }
 
-int 
-xdrfile_read_short(short *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_read_short(short *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
 
 	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_short((XDR *)(xfp->xdr),ptr+i))
 		i++;
-  
+
 	return i;
 }
 
-int 
-xdrfile_write_short(short *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_write_short(short *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
-  
-	/* read write is encoded in the XDR struct */  
+
+	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_short((XDR *)(xfp->xdr),ptr+i))
 		i++;
 	return i;
 }
 
 
-int 
-xdrfile_read_ushort(unsigned short *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_read_ushort(unsigned short *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
 
 	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_u_short((XDR *)(xfp->xdr),ptr+i))
 		i++;
-  
+
 	return i;
 }
 
-int 
-xdrfile_write_ushort(unsigned short *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_write_ushort(unsigned short *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
-  
-	/* read write is encoded in the XDR struct */  
+
+	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_u_short((XDR *)(xfp->xdr),ptr+i))
 		i++;
 	return i;
 }
 
-int 
-xdrfile_read_float(float *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_read_float(float *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
 	/* read write is encoded in the XDR struct */
@@ -405,18 +405,18 @@ xdrfile_read_float(float *ptr, int ndata, XDRFILE* xfp)
 	return i;
 }
 
-int 
-xdrfile_write_float(float *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_write_float(float *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
-	/* read write is encoded in the XDR struct */  
+	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_float((XDR *)(xfp->xdr),ptr+i))
 		i++;
 	return i;
 }
 
-int 
-xdrfile_read_double(double *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_read_double(double *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
 	/* read write is encoded in the XDR struct */
@@ -425,11 +425,11 @@ xdrfile_read_double(double *ptr, int ndata, XDRFILE* xfp)
 	return i;
 }
 
-int 
-xdrfile_write_double(double *ptr, int ndata, XDRFILE* xfp) 
+int
+xdrfile_write_double(double *ptr, int ndata, XDRFILE* xfp)
 {
 	int i=0;
-	/* read write is encoded in the XDR struct */  
+	/* read write is encoded in the XDR struct */
 	while(i<ndata && xdr_double((XDR *)(xfp->xdr),ptr+i))
 		i++;
 	return i;
@@ -455,8 +455,8 @@ int
 xdrfile_write_string(char *ptr, XDRFILE* xfp)
 {
 	int len=strlen(ptr)+1;
-  
-	if(xdr_string((XDR *)(xfp->xdr),&ptr,len)) 
+
+	if(xdr_string((XDR *)(xfp->xdr),&ptr,len))
 		return len;
 	else
 		return 0;
@@ -468,7 +468,7 @@ xdrfile_read_opaque(char *ptr, int cnt, XDRFILE* xfp)
 {
 	if(xdr_opaque((XDR *)(xfp->xdr),ptr,cnt))
 		return cnt;
-	else 
+	else
 		return 0;
 }
 
@@ -483,16 +483,16 @@ xdrfile_write_opaque(char *ptr, int cnt, XDRFILE* xfp)
 }
 
 
-/* Internal support routines for reading/writing compressed coordinates 
+/* Internal support routines for reading/writing compressed coordinates
  * sizeofint - calculate smallest number of bits necessary
  * to represent a certain integer.
  */
-static int 
+static int
 sizeofint(int size) {
     unsigned int num = 1;
     int num_of_bits = 0;
-    
-    while (size >= num && num_of_bits < 32) 
+
+    while (size >= num && num_of_bits < 32)
     {
 		num_of_bits++;
 		num <<= 1;
@@ -507,13 +507,13 @@ sizeofint(int size) {
  * given a number of small unsigned integers and the maximum value
  * return the number of bits needed to read or write them with the
  * routines encodeints/decodeints. You need this parameter when
- * calling those routines. 
- * (However, in some cases we can just use the variable 'smallidx' 
+ * calling those routines.
+ * (However, in some cases we can just use the variable 'smallidx'
  * which is the exact number of bits, and them we dont need to call
  * this routine).
  */
-static int 
-sizeofints(int num_of_ints, unsigned int sizes[]) 
+static int
+sizeofints(int num_of_ints, unsigned int sizes[])
 {
     int i, num;
     unsigned int num_of_bytes, num_of_bits, bytes[32], bytecnt, tmp;
@@ -521,7 +521,7 @@ sizeofints(int num_of_ints, unsigned int sizes[])
     bytes[0] = 1;
     num_of_bits = 0;
     for (i=0; i < num_of_ints; i++)
-    {	
+    {
 		tmp = 0;
 		for (bytecnt = 0; bytecnt < num_of_bytes; bytecnt++)
         {
@@ -529,7 +529,7 @@ sizeofints(int num_of_ints, unsigned int sizes[])
 			bytes[bytecnt] = tmp & 0xff;
 			tmp >>= 8;
 		}
-		while (tmp != 0) 
+		while (tmp != 0)
         {
 			bytes[bytecnt++] = tmp & 0xff;
 			tmp >>= 8;
@@ -538,7 +538,7 @@ sizeofints(int num_of_ints, unsigned int sizes[])
     }
     num = 1;
     num_of_bytes--;
-    while (bytes[num_of_bytes] >= num) 
+    while (bytes[num_of_bytes] >= num)
     {
 		num_of_bits++;
 		num *= 2;
@@ -546,7 +546,7 @@ sizeofints(int num_of_ints, unsigned int sizes[])
     return num_of_bits + num_of_bytes * 8;
 
 }
-    
+
 
 /*
  * encodebits - encode num into buf using the specified number of bits
@@ -556,14 +556,14 @@ sizeofints(int num_of_ints, unsigned int sizes[])
  * better make sure that this number of bits is enough to hold the value.
  * Num must also be positive.
  */
-static void 
-encodebits(int buf[], int num_of_bits, int num) 
+static void
+encodebits(int buf[], int num_of_bits, int num)
 {
-    
+
     unsigned int cnt, lastbyte;
     int lastbits;
     unsigned char * cbuf;
-    
+
     cbuf = ((unsigned char *)buf) + 3 * sizeof(*buf);
     cnt = (unsigned int) buf[0];
     lastbits = buf[1];
@@ -578,7 +578,7 @@ encodebits(int buf[], int num_of_bits, int num)
     {
 		lastbyte = (lastbyte << num_of_bits) | num;
 		lastbits += num_of_bits;
-		if (lastbits >= 8) 
+		if (lastbits >= 8)
         {
 			lastbits -= 8;
 			cbuf[cnt++] = lastbyte >> lastbits;
@@ -587,7 +587,7 @@ encodebits(int buf[], int num_of_bits, int num)
     buf[0] = cnt;
     buf[1] = lastbits;
     buf[2] = lastbyte;
-    if (lastbits>0) 
+    if (lastbits>0)
     {
 		cbuf[cnt] = lastbyte << (8 - lastbits);
     }
@@ -607,10 +607,10 @@ encodebits(int buf[], int num_of_bits, int num)
  * THese things are checked in the calling routines, so make sure not
  * to remove those checks...
  */
- 
-static void 
+
+static void
 encodeints(int buf[], int num_of_ints, int num_of_bits,
-		   unsigned int sizes[], unsigned int nums[]) 
+		   unsigned int sizes[], unsigned int nums[])
 {
 
     int i;
@@ -618,13 +618,13 @@ encodeints(int buf[], int num_of_ints, int num_of_bits,
 
     tmp = nums[0];
     num_of_bytes = 0;
-    do 
+    do
     {
 		bytes[num_of_bytes++] = tmp & 0xff;
 		tmp >>= 8;
     } while (tmp != 0);
 
-    for (i = 1; i < num_of_ints; i++) 
+    for (i = 1; i < num_of_ints; i++)
     {
 		if (nums[i] >= sizes[i])
         {
@@ -632,9 +632,9 @@ encodeints(int buf[], int num_of_ints, int num_of_bits,
 					"match size %u\n", nums[i], sizes[i]);
 			abort();
 		}
-		/* use one step multiply */    
+		/* use one step multiply */
 		tmp = nums[i];
-		for (bytecnt = 0; bytecnt < num_of_bytes; bytecnt++) 
+		for (bytecnt = 0; bytecnt < num_of_bytes; bytecnt++)
         {
 			tmp = bytes[bytecnt] * sizes[i] + tmp;
 			bytes[bytecnt] = tmp & 0xff;
@@ -647,14 +647,14 @@ encodeints(int buf[], int num_of_ints, int num_of_bits,
 		}
 		num_of_bytes = bytecnt;
     }
-    if (num_of_bits >= num_of_bytes * 8) 
+    if (num_of_bits >= num_of_bytes * 8)
     {
-		for (i = 0; i < num_of_bytes; i++) 
+		for (i = 0; i < num_of_bytes; i++)
         {
 			encodebits(buf, 8, bytes[i]);
 		}
 		encodebits(buf, num_of_bits - num_of_bytes * 8, 0);
-    } 
+    }
     else
     {
 		for (i = 0; i < num_of_bytes-1; i++)
@@ -668,17 +668,17 @@ encodeints(int buf[], int num_of_ints, int num_of_bits,
 
 /*
  * decodebits - decode number from buf using specified number of bits
- * 
+ *
  * extract the number of bits from the array buf and construct an integer
  * from it. Return that value.
  *
  */
 
-static int 
-decodebits(int buf[], int num_of_bits) 
+static int
+decodebits(int buf[], int num_of_bits)
 {
 
-    int cnt, num; 
+    int cnt, num;
     unsigned int lastbits, lastbyte;
     unsigned char * cbuf;
     int mask = (1 << num_of_bits) -1;
@@ -687,7 +687,7 @@ decodebits(int buf[], int num_of_bits)
     cnt = buf[0];
     lastbits = (unsigned int) buf[1];
     lastbyte = (unsigned int) buf[2];
-    
+
     num = 0;
     while (num_of_bits >= 8)
     {
@@ -695,9 +695,9 @@ decodebits(int buf[], int num_of_bits)
 		num |=  (lastbyte >> lastbits) << (num_of_bits - 8);
 		num_of_bits -=8;
     }
-    if (num_of_bits > 0) 
+    if (num_of_bits > 0)
     {
-		if (lastbits < num_of_bits) 
+		if (lastbits < num_of_bits)
         {
 			lastbits += 8;
 			lastbyte = (lastbyte << 8) | cbuf[cnt++];
@@ -709,7 +709,7 @@ decodebits(int buf[], int num_of_bits)
     buf[0] = cnt;
     buf[1] = lastbits;
     buf[2] = lastbyte;
-    return num; 
+    return num;
 }
 
 /*
@@ -722,14 +722,14 @@ decodebits(int buf[], int num_of_bits)
  *
  */
 
-static void 
+static void
 decodeints(int buf[], int num_of_ints, int num_of_bits,
 		   unsigned int sizes[], int nums[])
 {
 
 	int bytes[32];
 	int i, j, num_of_bytes, p, num;
-  
+
 	bytes[1] = bytes[2] = bytes[3] = 0;
 	num_of_bytes = 0;
 	while (num_of_bits > 8)
@@ -741,10 +741,10 @@ decodeints(int buf[], int num_of_ints, int num_of_bits,
     {
 		bytes[num_of_bytes++] = decodebits(buf, num_of_bits);
 	}
-	for (i = num_of_ints-1; i > 0; i--) 
+	for (i = num_of_ints-1; i > 0; i--)
     {
 		num = 0;
-		for (j = num_of_bytes-1; j >=0; j--) 
+		for (j = num_of_bytes-1; j >=0; j--)
         {
 			num = (num << 8) | bytes[j];
 			p = num / sizes[i];
@@ -755,17 +755,17 @@ decodeints(int buf[], int num_of_ints, int num_of_bits,
 	}
 	nums[0] = bytes[0] | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24);
 }
-    
 
-static const int magicints[] = 
+
+static const int magicints[] =
 {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 10, 12, 16, 20, 25, 32, 40, 50, 64,
     80, 101, 128, 161, 203, 256, 322, 406, 512, 645, 812, 1024, 1290,
-    1625, 2048, 2580, 3250, 4096, 5060, 6501, 8192, 10321, 13003, 
-    16384, 20642, 26007, 32768, 41285, 52015, 65536,82570, 104031, 
-    131072, 165140, 208063, 262144, 330280, 416127, 524287, 660561, 
-    832255, 1048576, 1321122, 1664510, 2097152, 2642245, 3329021, 
-    4194304, 5284491, 6658042, 8388607, 10568983, 13316085, 16777216 
+    1625, 2048, 2580, 3250, 4096, 5060, 6501, 8192, 10321, 13003,
+    16384, 20642, 26007, 32768, 41285, 52015, 65536,82570, 104031,
+    131072, 165140, 208063, 262144, 330280, 416127, 524287, 660561,
+    832255, 1048576, 1321122, 1664510, 2097152, 2642245, 3329021,
+    4194304, 5284491, 6658042, 8388607, 10568983, 13316085, 16777216
 };
 
 #define FIRSTIDX 9
@@ -782,15 +782,15 @@ xdrfile_decompress_coord_float(float     *ptr,
 							   XDRFILE*   xfp)
 {
 	int minint[3], maxint[3], *lip;
-	int smallidx;
+	int smallidx, minidx, maxidx;
 	unsigned sizeint[3], sizesmall[3], bitsizeint[3], size3;
 	int k, *buf1, *buf2, lsize, flag;
-	int smallnum, smaller, i, is_smaller, run;
+	int smallnum, smaller, larger, i, is_smaller, run;
 	float *lfp, inv_precision;
 	int tmp, *thiscoord,  prevcoord[3];
 	unsigned int bitsize;
 	const float* ptrstart = ptr;
-  
+
     bitsizeint[0] = 0;
     bitsizeint[1] = 0;
     bitsizeint[2] = 0;
@@ -804,7 +804,7 @@ xdrfile_decompress_coord_float(float     *ptr,
         fprintf(stderr, "(xdrfile error) Size could not be read\n");
 		return -1; /* return if we could not read size */
 	}
-	if (*size < lsize) 
+	if (*size < lsize)
     {
 		fprintf(stderr, "(xdrfile error) Requested to decompress %d coords, file contains %d\n",
 				*size, lsize);
@@ -812,12 +812,12 @@ xdrfile_decompress_coord_float(float     *ptr,
 	}
 	*size = lsize;
 	size3 = *size * 3;
-	if(size3>xfp->buf1size) 
+	if(size3>xfp->buf1size)
     {
-		if((xfp->buf1=(int *)malloc(sizeof(int)*size3))==NULL) 
+		if((xfp->buf1=(int *)malloc(sizeof(int)*size3))==NULL)
         {
 			fprintf(stderr, "(xdrfile error) Cannot allocate memory for decompressing coordinates.\n");
-			return -1; 
+			return -1;
 		}
 		xfp->buf1size=size3;
 		xfp->buf2size=size3*1.2;
@@ -828,26 +828,26 @@ xdrfile_decompress_coord_float(float     *ptr,
 		}
 	}
 	/* Dont bother with compression for three atoms or less */
-	if(*size<=9) 
+	if(*size<=9)
     {
 		return xdrfile_read_float(ptr,size3,xfp)/3;
 		/* return number of coords, not floats */
 	}
 	/* Compression-time if we got here. Read precision first */
 	xdrfile_read_float(precision,1,xfp);
-  
+
 	/* avoid repeated pointer dereferencing. */
-	buf1=xfp->buf1; 
+	buf1=xfp->buf1;
 	buf2=xfp->buf2;
 	/* buf2[0-2] are special and do not contain actual data */
 	buf2[0] = buf2[1] = buf2[2] = 0;
 	xdrfile_read_int(minint,3,xfp);
 	xdrfile_read_int(maxint,3,xfp);
-  
+
 	sizeint[0] = maxint[0] - minint[0]+1;
 	sizeint[1] = maxint[1] - minint[1]+1;
 	sizeint[2] = maxint[2] - minint[2]+1;
-	
+
 	/* check if one of the sizes is to big to be multiplied */
 	if ((sizeint[0] | sizeint[1] | sizeint[2] ) > 0xffffff)
     {
@@ -856,24 +856,27 @@ xdrfile_decompress_coord_float(float     *ptr,
 		bitsizeint[2] = sizeofint(sizeint[2]);
 		bitsize = 0; /* flag the use of large sizes */
 	}
-    else 
+    else
     {
 		bitsize = sizeofints(3, sizeint);
 	}
-	
+
 	if (xdrfile_read_int(&smallidx,1,xfp) == 0)	{
 	    fprintf(stderr,"(xdrfile error) Undocumented error 1");
 		return 0; /* not sure what has happened here or why we return... */
 	}
 	tmp=smallidx+8;
+	maxidx = (LASTIDX<tmp) ? LASTIDX : tmp;
+	minidx = maxidx - 8; /* often this equal smallidx */
 	tmp = smallidx-1;
 	tmp = (FIRSTIDX>tmp) ? FIRSTIDX : tmp;
 	smaller = magicints[tmp] / 2;
 	smallnum = magicints[smallidx] / 2;
 	sizesmall[0] = sizesmall[1] = sizesmall[2] = magicints[smallidx] ;
+	larger = magicints[maxidx];
 
 	/* buf2[0] holds the length in bytes */
-  
+
 	if (xdrfile_read_int(buf2,1,xfp) == 0) {
 	    fprintf(stderr, "(xdrfile error) Undocumented error 2");
 		return 0;
@@ -883,17 +886,17 @@ xdrfile_decompress_coord_float(float     *ptr,
         return 0;
 	}
 	buf2[0] = buf2[1] = buf2[2] = 0;
-  
+
 	lfp = ptr;
 	inv_precision = 1.0 / * precision;
 	run = 0;
 	i = 0;
 	lip = buf1;
-	while ( i < lsize ) 
+	while ( i < lsize )
     {
 		thiscoord = (int *)(lip) + i * 3;
-    
-		if (bitsize == 0) 
+
+		if (bitsize == 0)
         {
 			thiscoord[0] = decodebits(buf2, bitsizeint[0]);
 			thiscoord[1] = decodebits(buf2, bitsizeint[1]);
@@ -903,19 +906,19 @@ xdrfile_decompress_coord_float(float     *ptr,
         {
 			decodeints(buf2, 3, bitsize, sizeint, thiscoord);
 		}
-    
+
 		i++;
 		thiscoord[0] += minint[0];
 		thiscoord[1] += minint[1];
 		thiscoord[2] += minint[2];
-    
+
 		prevcoord[0] = thiscoord[0];
 		prevcoord[1] = thiscoord[1];
 		prevcoord[2] = thiscoord[2];
-    
+
 		flag = decodebits(buf2, 1);
 		is_smaller = 0;
-		if (flag == 1) 
+		if (flag == 1)
         {
 			run = decodebits(buf2, 5);
 			is_smaller = run % 3;
@@ -930,7 +933,7 @@ xdrfile_decompress_coord_float(float     *ptr,
 		if (run > 0)
         {
 			thiscoord += 3;
-			for (k = 0; k < run; k+=3) 
+			for (k = 0; k < run; k+=3)
             {
 				decodeints(buf2, 3, smallidx, sizesmall, thiscoord);
 				i++;
@@ -959,27 +962,27 @@ xdrfile_decompress_coord_float(float     *ptr,
 				*lfp++ = thiscoord[1] * inv_precision;
 				*lfp++ = thiscoord[2] * inv_precision;
 			}
-		} 
+		}
         else
         {
 			*lfp++ = thiscoord[0] * inv_precision;
 			*lfp++ = thiscoord[1] * inv_precision;
-			*lfp++ = thiscoord[2] * inv_precision;		
+			*lfp++ = thiscoord[2] * inv_precision;
 		}
 		smallidx += is_smaller;
-		if (is_smaller < 0) 
+		if (is_smaller < 0)
         {
 			smallnum = smaller;
-            
-			if (smallidx > FIRSTIDX) 
+
+			if (smallidx > FIRSTIDX)
             {
 				smaller = magicints[smallidx - 1] /2;
-			} 
-            else 
+			}
+            else
             {
 				smaller = 0;
 			}
-		} 
+		}
         else if (is_smaller > 0)
         {
 			smaller = smallnum;
@@ -1010,19 +1013,20 @@ xdrfile_compress_coord_float(float   *ptr,
 	float *lfp, lf;
 	int tmp, tmpsum, *thiscoord,  prevcoord[3];
 	unsigned int tmpcoord[30];
+	int errval=1;
 	unsigned int bitsize;
-  
+
 	if(xfp==NULL)
 		return -1;
 	size3=3*size;
-    
+
     bitsizeint[0] = 0;
     bitsizeint[1] = 0;
     bitsizeint[2] = 0;
 
 	if(size3>xfp->buf1size)
     {
-		if((xfp->buf1=(int *)malloc(sizeof(int)*size3))==NULL) 
+		if((xfp->buf1=(int *)malloc(sizeof(int)*size3))==NULL)
         {
 			fprintf(stderr, "(xdrfile error) Cannot allocate memory for compressing coordinates.\n");
 			return -1;
@@ -1038,7 +1042,7 @@ xdrfile_compress_coord_float(float   *ptr,
 	if(xdrfile_write_int(&size,1,xfp)==0)
 		return -1; /* return if we could not write size */
 	/* Dont bother with compression for three atoms or less */
-	if(size<=9) 
+	if(size<=9)
     {
 		return xdrfile_write_float(ptr,size3,xfp)/3;
 		/* return number of coords, not floats */
@@ -1048,7 +1052,7 @@ xdrfile_compress_coord_float(float   *ptr,
 		precision = 1000;
 	xdrfile_write_float(&precision,1,xfp);
 	/* avoid repeated pointer dereferencing. */
-	buf1=xfp->buf1; 
+	buf1=xfp->buf1;
 	buf2=xfp->buf2;
 	/* buf2[0-2] are special and do not contain actual data */
 	buf2[0] = buf2[1] = buf2[2] = 0;
@@ -1066,10 +1070,11 @@ xdrfile_compress_coord_float(float   *ptr,
 			lf = *lfp * precision + 0.5;
 		else
 			lf = *lfp * precision - 0.5;
-		if (fabs(lf) > INT_MAX-2) 
+		if (fabs(lf) > INT_MAX-2)
         {
 			/* scaling would cause overflow */
 			fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
+			errval=0;
 		}
 		lint1 = lf;
 		if (lint1 < minint[0]) minint[0] = lint1;
@@ -1084,6 +1089,7 @@ xdrfile_compress_coord_float(float   *ptr,
         {
 			/* scaling would cause overflow */
 			fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
+			errval=0;
 		}
 		lint2 = lf;
 		if (lint2 < minint[1]) minint[1] = lint2;
@@ -1094,6 +1100,10 @@ xdrfile_compress_coord_float(float   *ptr,
 			lf = *lfp * precision + 0.5;
 		else
 			lf = *lfp * precision - 0.5;
+		if (fabs(lf) > INT_MAX-2)
+        {
+			errval=0;
+		}
 		lint3 = lf;
 		if (lint3 < minint[2]) minint[2] = lint3;
 		if (lint3 > maxint[2]) maxint[2] = lint3;
@@ -1105,10 +1115,10 @@ xdrfile_compress_coord_float(float   *ptr,
 		oldlint1 = lint1;
 		oldlint2 = lint2;
 		oldlint3 = lint3;
-	}  
+	}
 	xdrfile_write_int(minint,3,xfp);
 	xdrfile_write_int(maxint,3,xfp);
-  
+
 	if ((float)maxint[0] - (float)minint[0] >= INT_MAX-2 ||
 		(float)maxint[1] - (float)minint[1] >= INT_MAX-2 ||
 		(float)maxint[2] - (float)minint[2] >= INT_MAX-2) {
@@ -1116,11 +1126,12 @@ xdrfile_compress_coord_float(float   *ptr,
 		 * would cause overflow
 		 */
 		fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
+		errval=0;
 	}
 	sizeint[0] = maxint[0] - minint[0]+1;
 	sizeint[1] = maxint[1] - minint[1]+1;
 	sizeint[2] = maxint[2] - minint[2]+1;
-  
+
 	/* check if one of the sizes is to big to be multiplied */
 	if ((sizeint[0] | sizeint[1] | sizeint[2] ) > 0xffffff)
     {
@@ -1151,7 +1162,7 @@ xdrfile_compress_coord_float(float   *ptr,
 	sizesmall[0] = sizesmall[1] = sizesmall[2] = magicints[smallidx];
 	larger = magicints[maxidx] / 2;
 	i = 0;
-	while (i < size) 
+	while (i < size)
     {
 		is_small = 0;
 		thiscoord = (int *)(luip) + i * 3;
@@ -1160,8 +1171,8 @@ xdrfile_compress_coord_float(float   *ptr,
 			abs(thiscoord[1] - prevcoord[1]) < larger &&
 			abs(thiscoord[2] - prevcoord[2]) < larger) {
 			is_smaller = 1;
-		} 
-        else if (smallidx > minidx) 
+		}
+        else if (smallidx > minidx)
         {
 			is_smaller = -1;
 		}
@@ -1169,11 +1180,11 @@ xdrfile_compress_coord_float(float   *ptr,
         {
 			is_smaller = 0;
 		}
-		if (i + 1 < size) 
+		if (i + 1 < size)
         {
 			if (abs(thiscoord[0] - thiscoord[3]) < smallnum &&
 				abs(thiscoord[1] - thiscoord[4]) < smallnum &&
-				abs(thiscoord[2] - thiscoord[5]) < smallnum) 
+				abs(thiscoord[2] - thiscoord[5]) < smallnum)
             {
 				/* interchange first with second atom for better
 				 * compression of water molecules
@@ -1185,17 +1196,17 @@ xdrfile_compress_coord_float(float   *ptr,
 				tmp = thiscoord[2]; thiscoord[2] = thiscoord[5];
 				thiscoord[5] = tmp;
 				is_small = 1;
-			} 
+			}
 		}
 		tmpcoord[0] = thiscoord[0] - minint[0];
 		tmpcoord[1] = thiscoord[1] - minint[1];
 		tmpcoord[2] = thiscoord[2] - minint[2];
-		if (bitsize == 0) 
+		if (bitsize == 0)
         {
 			encodebits(buf2, bitsizeint[0], tmpcoord[0]);
 			encodebits(buf2, bitsizeint[1], tmpcoord[1]);
 			encodebits(buf2, bitsizeint[2], tmpcoord[2]);
-		} 
+		}
         else
         {
 			encodeints(buf2, 3, bitsize, sizeint, tmpcoord);
@@ -1212,7 +1223,7 @@ xdrfile_compress_coord_float(float   *ptr,
 		while (is_small && run < 8*3)
         {
 			tmpsum=0;
-			for(j=0;j<3;j++) 
+			for(j=0;j<3;j++)
             {
 				tmp=thiscoord[j] - prevcoord[j];
 				tmpsum+=tmp*tmp;
@@ -1221,15 +1232,15 @@ xdrfile_compress_coord_float(float   *ptr,
             {
 				is_smaller = 0;
 			}
-      
+
 			tmpcoord[run++] = thiscoord[0] - prevcoord[0] + smallnum;
 			tmpcoord[run++] = thiscoord[1] - prevcoord[1] + smallnum;
 			tmpcoord[run++] = thiscoord[2] - prevcoord[2] + smallnum;
-      
+
 			prevcoord[0] = thiscoord[0];
 			prevcoord[1] = thiscoord[1];
 			prevcoord[2] = thiscoord[2];
-      
+
 			i++;
 			thiscoord = thiscoord + 3;
 			is_small = 0;
@@ -1241,35 +1252,35 @@ xdrfile_compress_coord_float(float   *ptr,
 				is_small = 1;
 			}
 		}
-		if (run != prevrun || is_smaller != 0) 
+		if (run != prevrun || is_smaller != 0)
         {
 			prevrun = run;
 			encodebits(buf2, 1, 1); /* flag the change in run-length */
 			encodebits(buf2, 5, run+is_smaller+1);
-		} 
-        else 
+		}
+        else
         {
 			encodebits(buf2, 1, 0); /* flag the fact that runlength did not change */
 		}
-		for (k=0; k < run; k+=3) 
+		for (k=0; k < run; k+=3)
         {
-			encodeints(buf2, 3, smallidx, sizesmall, &tmpcoord[k]);	
+			encodeints(buf2, 3, smallidx, sizesmall, &tmpcoord[k]);
 		}
-		if (is_smaller != 0) 
+		if (is_smaller != 0)
         {
 			smallidx += is_smaller;
-			if (is_smaller < 0) 
+			if (is_smaller < 0)
             {
 				smallnum = smaller;
 				smaller = magicints[smallidx-1] / 2;
-			} 
-            else 
+			}
+            else
             {
 				smaller = smallnum;
 				smallnum = magicints[smallidx] / 2;
 			}
 			sizesmall[0] = sizesmall[1] = sizesmall[2] = magicints[smallidx];
-		}   
+		}
 	}
 	if (buf2[1] != 0) buf2[0]++;
 	xdrfile_write_int(buf2,1,xfp); /* buf2[0] holds the length in bytes */
@@ -1282,21 +1293,21 @@ xdrfile_compress_coord_float(float   *ptr,
 
 
 int
-xdrfile_decompress_coord_double(double     *ptr, 
+xdrfile_decompress_coord_double(double     *ptr,
 								int        *size,
 								double     *precision,
 								XDRFILE*   xfp)
 {
 	int minint[3], maxint[3], *lip;
-	int smallidx, maxidx;
+	int smallidx, minidx, maxidx;
 	unsigned sizeint[3], sizesmall[3], bitsizeint[3], size3;
 	int k, *buf1, *buf2, lsize, flag;
-	int smallnum, smaller, i, is_smaller, run;
+	int smallnum, smaller, larger, i, is_smaller, run;
 	double *lfp, inv_precision;
 	float float_prec, tmpdata[30];
 	int tmp, *thiscoord,  prevcoord[3];
 	unsigned int bitsize;
-  
+
     bitsizeint[0] = 0;
     bitsizeint[1] = 0;
     bitsizeint[2] = 0;
@@ -1306,7 +1317,7 @@ xdrfile_decompress_coord_double(double     *ptr,
 	tmp=xdrfile_read_int(&lsize,1,xfp);
 	if(tmp==0)
 		return -1; /* return if we could not read size */
-	if (*size < lsize) 
+	if (*size < lsize)
     {
 		fprintf(stderr, "(xdrfile error) Requested to decompress %d coords, file contains %d\n",
 				*size, lsize);
@@ -1314,12 +1325,12 @@ xdrfile_decompress_coord_double(double     *ptr,
 	}
 	*size = lsize;
 	size3 = *size * 3;
-	if(size3>xfp->buf1size) 
+	if(size3>xfp->buf1size)
     {
-		if((xfp->buf1=(int *)malloc(sizeof(int)*size3))==NULL) 
+		if((xfp->buf1=(int *)malloc(sizeof(int)*size3))==NULL)
         {
 			fprintf(stderr, "(xdrfile error) Cannot allocate memory for decompression coordinates.\n");
-			return -1; 
+			return -1;
 		}
 		xfp->buf1size=size3;
 		xfp->buf2size=size3*1.2;
@@ -1342,17 +1353,17 @@ xdrfile_decompress_coord_double(double     *ptr,
 	xdrfile_read_float(&float_prec,1,xfp);
 	*precision=float_prec;
 	/* avoid repeated pointer dereferencing. */
-	buf1=xfp->buf1; 
+	buf1=xfp->buf1;
 	buf2=xfp->buf2;
 	/* buf2[0-2] are special and do not contain actual data */
 	buf2[0] = buf2[1] = buf2[2] = 0;
 	xdrfile_read_int(minint,3,xfp);
 	xdrfile_read_int(maxint,3,xfp);
-  
+
 	sizeint[0] = maxint[0] - minint[0]+1;
 	sizeint[1] = maxint[1] - minint[1]+1;
 	sizeint[2] = maxint[2] - minint[2]+1;
-	
+
 	/* check if one of the sizes is to big to be multiplied */
 	if ((sizeint[0] | sizeint[1] | sizeint[2] ) > 0xffffff)
     {
@@ -1361,39 +1372,41 @@ xdrfile_decompress_coord_double(double     *ptr,
 		bitsizeint[2] = sizeofint(sizeint[2]);
 		bitsize = 0; /* flag the use of large sizes */
 	}
-    else 
+    else
     {
 		bitsize = sizeofints(3, sizeint);
 	}
-	
-	if (xdrfile_read_int(&smallidx,1,xfp) == 0)	
+
+	if (xdrfile_read_int(&smallidx,1,xfp) == 0)
 		return 0;
 	tmp=smallidx+8;
 	maxidx = (LASTIDX<tmp) ? LASTIDX : tmp;
+	minidx = maxidx - 8; /* often this equal smallidx */
 	tmp = smallidx-1;
 	tmp = (FIRSTIDX>tmp) ? FIRSTIDX : tmp;
 	smaller = magicints[tmp] / 2;
 	smallnum = magicints[smallidx] / 2;
 	sizesmall[0] = sizesmall[1] = sizesmall[2] = magicints[smallidx] ;
+	larger = magicints[maxidx];
 
 	/* buf2[0] holds the length in bytes */
-  
+
 	if (xdrfile_read_int(buf2,1,xfp) == 0)
 		return 0;
 	if (xdrfile_read_opaque((char *)&(buf2[3]),(unsigned int)buf2[0],xfp) == 0)
 		return 0;
 	buf2[0] = buf2[1] = buf2[2] = 0;
-  
+
 	lfp = ptr;
 	inv_precision = 1.0 / * precision;
 	run = 0;
 	i = 0;
 	lip = buf1;
-	while ( i < lsize ) 
+	while ( i < lsize )
     {
 		thiscoord = (int *)(lip) + i * 3;
-    
-		if (bitsize == 0) 
+
+		if (bitsize == 0)
         {
 			thiscoord[0] = decodebits(buf2, bitsizeint[0]);
 			thiscoord[1] = decodebits(buf2, bitsizeint[1]);
@@ -1401,29 +1414,29 @@ xdrfile_decompress_coord_double(double     *ptr,
 		} else {
 			decodeints(buf2, 3, bitsize, sizeint, thiscoord);
 		}
-    
+
 		i++;
 		thiscoord[0] += minint[0];
 		thiscoord[1] += minint[1];
 		thiscoord[2] += minint[2];
-    
+
 		prevcoord[0] = thiscoord[0];
 		prevcoord[1] = thiscoord[1];
 		prevcoord[2] = thiscoord[2];
-    
+
 		flag = decodebits(buf2, 1);
 		is_smaller = 0;
-		if (flag == 1) 
+		if (flag == 1)
         {
 			run = decodebits(buf2, 5);
 			is_smaller = run % 3;
 			run -= is_smaller;
 			is_smaller--;
 		}
-		if (run > 0) 
+		if (run > 0)
         {
 			thiscoord += 3;
-			for (k = 0; k < run; k+=3) 
+			for (k = 0; k < run; k+=3)
             {
 				decodeints(buf2, 3, smallidx, sizesmall, thiscoord);
 				i++;
@@ -1445,7 +1458,7 @@ xdrfile_decompress_coord_double(double     *ptr,
 					*lfp++ = prevcoord[1] * inv_precision;
 					*lfp++ = prevcoord[2] * inv_precision;
 				}
-                else 
+                else
                 {
 					prevcoord[0] = thiscoord[0];
 					prevcoord[1] = thiscoord[1];
@@ -1458,7 +1471,7 @@ xdrfile_decompress_coord_double(double     *ptr,
 		} else {
 			*lfp++ = thiscoord[0] * inv_precision;
 			*lfp++ = thiscoord[1] * inv_precision;
-			*lfp++ = thiscoord[2] * inv_precision;		
+			*lfp++ = thiscoord[2] * inv_precision;
 		}
 		smallidx += is_smaller;
 		if (is_smaller < 0) {
@@ -1493,8 +1506,9 @@ xdrfile_compress_coord_double(double   *ptr,
 	float float_prec, lf,tmpdata[30];
 	int tmp, tmpsum, *thiscoord,  prevcoord[3];
 	unsigned int tmpcoord[30];
+	int errval=1;
 	unsigned int bitsize;
-  
+
     bitsizeint[0] = 0;
     bitsizeint[1] = 0;
     bitsizeint[2] = 0;
@@ -1529,7 +1543,7 @@ xdrfile_compress_coord_double(double   *ptr,
 	float_prec=precision;
 	xdrfile_write_float(&float_prec,1,xfp);
 	/* avoid repeated pointer dereferencing. */
-	buf1=xfp->buf1; 
+	buf1=xfp->buf1;
 	buf2=xfp->buf2;
 	/* buf2[0-2] are special and do not contain actual data */
 	buf2[0] = buf2[1] = buf2[2] = 0;
@@ -1549,6 +1563,7 @@ xdrfile_compress_coord_double(double   *ptr,
 		if (fabs(lf) > INT_MAX-2) {
 			/* scaling would cause overflow */
 			fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
+			errval=0;
 		}
 		lint1 = lf;
 		if (lint1 < minint[0]) minint[0] = lint1;
@@ -1562,6 +1577,7 @@ xdrfile_compress_coord_double(double   *ptr,
 		if (fabs(lf) > INT_MAX-2) {
 			/* scaling would cause overflow */
 			fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
+			errval=0;
 		}
 		lint2 = lf;
 		if (lint2 < minint[1]) minint[1] = lint2;
@@ -1572,6 +1588,9 @@ xdrfile_compress_coord_double(double   *ptr,
 			lf = (float)*lfp * float_prec + 0.5;
 		else
 			lf = (float)*lfp * float_prec - 0.5;
+		if (fabs(lf) > INT_MAX-2) {
+			errval=0;
+		}
 		lint3 = lf;
 		if (lint3 < minint[2]) minint[2] = lint3;
 		if (lint3 > maxint[2]) maxint[2] = lint3;
@@ -1583,10 +1602,10 @@ xdrfile_compress_coord_double(double   *ptr,
 		oldlint1 = lint1;
 		oldlint2 = lint2;
 		oldlint3 = lint3;
-	}  
+	}
 	xdrfile_write_int(minint,3,xfp);
 	xdrfile_write_int(maxint,3,xfp);
-  
+
 	if ((float)maxint[0] - (float)minint[0] >= INT_MAX-2 ||
 		(float)maxint[1] - (float)minint[1] >= INT_MAX-2 ||
 		(float)maxint[2] - (float)minint[2] >= INT_MAX-2) {
@@ -1594,11 +1613,12 @@ xdrfile_compress_coord_double(double   *ptr,
 		 * would cause overflow
 		 */
 		fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
+		errval=0;
 	}
 	sizeint[0] = maxint[0] - minint[0]+1;
 	sizeint[1] = maxint[1] - minint[1]+1;
 	sizeint[2] = maxint[2] - minint[2]+1;
-  
+
 	/* check if one of the sizes is to big to be multiplied */
 	if ((sizeint[0] | sizeint[1] | sizeint[2] ) > 0xffffff) {
 		bitsizeint[0] = sizeofint(sizeint[0]);
@@ -1652,7 +1672,7 @@ xdrfile_compress_coord_double(double   *ptr,
 				tmp = thiscoord[2]; thiscoord[2] = thiscoord[5];
 				thiscoord[5] = tmp;
 				is_small = 1;
-			} 
+			}
 		}
 		tmpcoord[0] = thiscoord[0] - minint[0];
 		tmpcoord[1] = thiscoord[1] - minint[1];
@@ -1682,15 +1702,15 @@ xdrfile_compress_coord_double(double   *ptr,
 			if (is_smaller == -1 && tmpsum >= smaller * smaller) {
 				is_smaller = 0;
 			}
-      
+
 			tmpcoord[run++] = thiscoord[0] - prevcoord[0] + smallnum;
 			tmpcoord[run++] = thiscoord[1] - prevcoord[1] + smallnum;
 			tmpcoord[run++] = thiscoord[2] - prevcoord[2] + smallnum;
-      
+
 			prevcoord[0] = thiscoord[0];
 			prevcoord[1] = thiscoord[1];
 			prevcoord[2] = thiscoord[2];
-      
+
 			i++;
 			thiscoord = thiscoord + 3;
 			is_small = 0;
@@ -1709,7 +1729,7 @@ xdrfile_compress_coord_double(double   *ptr,
 			encodebits(buf2, 1, 0); /* flag the fact that runlength did not change */
 		}
 		for (k=0; k < run; k+=3) {
-			encodeints(buf2, 3, smallidx, sizesmall, &tmpcoord[k]);	
+			encodeints(buf2, 3, smallidx, sizesmall, &tmpcoord[k]);
 		}
 		if (is_smaller != 0) {
 			smallidx += is_smaller;
@@ -1721,7 +1741,7 @@ xdrfile_compress_coord_double(double   *ptr,
 				smallnum = magicints[smallidx] / 2;
 			}
 			sizesmall[0] = sizesmall[1] = sizesmall[2] = magicints[smallidx];
-		}   
+		}
 	}
 	if (buf2[1] != 0) buf2[0]++;
 	xdrfile_write_int(buf2,1,xfp); /* buf2[0] holds the length in bytes */
@@ -1729,21 +1749,21 @@ xdrfile_compress_coord_double(double   *ptr,
 	if(tmp==(unsigned int)buf2[0])
 		return size;
 	else
-		return -1; 
+		return -1;
 }
 
 
 /* Dont try do document Fortran interface, since
- * Doxygen barfs at the F77_FUNC macro 
+ * Doxygen barfs at the F77_FUNC macro
  */
-#ifndef DOXYGEN 
+#ifndef DOXYGEN
 
 /*************************************************************
  * Fortran77 interface for reading/writing portable data     *
  * The routine are not threadsafe when called from Fortran   *
  * (as they are when called from C) unless you compile with  *
  * this file with posix thread support.                      *
- * Note that these are not multithread-safe.                 * 
+ * Note that these are not multithread-safe.                 *
  *************************************************************/
 #define MAX_FORTRAN_XDR 1024
 static XDRFILE *f77xdr[MAX_FORTRAN_XDR]; /* array of file handles */
@@ -1761,7 +1781,7 @@ F77_FUNC(xdropen,XDROPEN)(int *fid, char *filename, char *mode,
 	char cfilename[512];
 	char cmode[5];
 	int i;
-  
+
 	/* zero array at first invocation */
 	if(f77init) {
 		for(i=0;i<MAX_FORTRAN_XDR;i++)
@@ -1769,7 +1789,7 @@ F77_FUNC(xdropen,XDROPEN)(int *fid, char *filename, char *mode,
 		f77init=0;
 	}
 	i=0;
-  
+
 	/* nf77xdr is always smaller or equal to MAX_FORTRAN_XDR */
 	while(i<MAX_FORTRAN_XDR && f77xdr[i]!=NULL)
 		i++;
@@ -1782,7 +1802,7 @@ F77_FUNC(xdropen,XDROPEN)(int *fid, char *filename, char *mode,
 	} else {
 		f77xdr[i]=xdrfile_open(cfilename,cmode);
 		/* return the index in the array as a fortran file handle */
-		*fid=i; 
+		*fid=i;
 	}
 }
 
@@ -1926,7 +1946,7 @@ void
 F77_FUNC(xdrrstring,XDRRSTRING)(int *fid, char *str, int *ret, int len)
 {
 	char *cstr;
-  
+
 	if((cstr=(char*)malloc((len+1)*sizeof(char)))==NULL) {
 		*ret = 0;
 		return;
@@ -1936,7 +1956,7 @@ F77_FUNC(xdrrstring,XDRRSTRING)(int *fid, char *str, int *ret, int len)
 		free(cstr);
 		return;
 	}
-  
+
 	*ret = xdrfile_read_string(cstr, len+1,f77xdr[*fid]);
 	ctofstr( str, len , cstr);
 	free(cstr);
@@ -1946,7 +1966,7 @@ void
 F77_FUNC(xdrwstring,XDRWSTRING)(int *fid, char *str, int *ret, int len)
 {
 	char *cstr;
-  
+
 	if((cstr=(char*)malloc((len+1)*sizeof(char)))==NULL) {
 		*ret = 0;
 		return;
@@ -1956,7 +1976,7 @@ F77_FUNC(xdrwstring,XDRWSTRING)(int *fid, char *str, int *ret, int len)
 		free(cstr);
 		return;
 	}
-  
+
 	*ret = xdrfile_write_string(cstr, f77xdr[*fid]);
 	ctofstr( str, len , cstr);
 	free(cstr);
@@ -1977,7 +1997,7 @@ F77_FUNC(xdrwopaque,XDRWOPAQUE)(int *fid, char *data, int *ndata, int *ret)
 
 /* Write single-precision compressed 3d coordinates */
 void
-F77_FUNC(xdrccs,XDRCCS)(int *fid, float *data, int *ncoord, 
+F77_FUNC(xdrccs,XDRCCS)(int *fid, float *data, int *ncoord,
 						float *precision, int *ret)
 {
     *ret = xdrfile_compress_coord_float(data,*ncoord,*precision,f77xdr[*fid]);
@@ -1986,7 +2006,7 @@ F77_FUNC(xdrccs,XDRCCS)(int *fid, float *data, int *ncoord,
 
 /* Read single-precision compressed 3d coordinates */
 void
-F77_FUNC(xdrdcs,XDRDCS)(int *fid, float *data, int *ncoord, 
+F77_FUNC(xdrdcs,XDRDCS)(int *fid, float *data, int *ncoord,
 						float *precision, int *ret)
 {
 	*ret = xdrfile_decompress_coord_float(data,ncoord,precision,f77xdr[*fid]);
@@ -1995,7 +2015,7 @@ F77_FUNC(xdrdcs,XDRDCS)(int *fid, float *data, int *ncoord,
 
 /* Write compressed 3d coordinates from double precision data */
 void
-F77_FUNC(xdrccd,XDRCCD)(int *fid, double *data, int *ncoord, 
+F77_FUNC(xdrccd,XDRCCD)(int *fid, double *data, int *ncoord,
 						double *precision, int *ret)
 {
 	*ret = xdrfile_compress_coord_double(data,*ncoord,*precision,f77xdr[*fid]);
@@ -2003,7 +2023,7 @@ F77_FUNC(xdrccd,XDRCCD)(int *fid, double *data, int *ncoord,
 
 /* Read compressed 3d coordinates into double precision data */
 void
-F77_FUNC(xddcd,XDRDCD)(int *fid, double *data, int *ncoord, 
+F77_FUNC(xddcd,XDRDCD)(int *fid, double *data, int *ncoord,
 					   double *precision, int *ret)
 {
     *ret = xdrfile_decompress_coord_double(data,ncoord,precision,f77xdr[*fid]);
@@ -2051,7 +2071,7 @@ F77_FUNC(xddcd,XDRDCD)(int *fid, double *data, int *ncoord,
 /*
  * What follows is a modified version of the Sun XDR code. For reference
  * we include their copyright and license:
- * 
+ *
  * Sun RPC is a product of Sun Microsystems, Inc. and is provided for
  * unrestricted use provided that this legend is included on all tape
  * media and as a part of the software program in whole or part.  Users
@@ -2083,7 +2103,7 @@ F77_FUNC(xddcd,XDRDCD)(int *fid, double *data, int *ncoord,
 /* INT_MAX is defined in limits.h according to ANSI C */
 #if (INT_MAX > 2147483647)
 #    error Error: Cannot use builtin XDR support when size of int
-#    error is larger than 4 bytes. Use your system XDR libraries 
+#    error is larger than 4 bytes. Use your system XDR libraries
 #    error instead, or modify the source code in xdrfile.c
 #endif /* Check for 4 byte int type */
 
@@ -2102,7 +2122,7 @@ typedef int (*xdrproc_t) (XDR *, void *,...);
 #define xdr_putbytes(xdrs, addr, len)			\
 	(*(xdrs)->x_ops->x_putbytes)(xdrs, addr, len)
 
-#define BYTES_PER_XDR_UNIT 4 
+#define BYTES_PER_XDR_UNIT 4
 static char xdr_zero[BYTES_PER_XDR_UNIT] = {0, 0, 0, 0};
 
 static int32_t
@@ -2111,10 +2131,10 @@ xdr_swapbytes(int32_t x)
 	int32_t y,i;
 	char *px=(char *)&x;
 	char *py=(char *)&y;
-  
+
 	for(i=0;i<4;i++)
 		py[i]=px[3-i];
-  
+
 	return y;
 }
 
@@ -2432,31 +2452,31 @@ xdr_double(XDR *xdrs, double *dp)
 {
     /* Gromacs detects floating-point stuff at compile time, which is faster */
 #ifdef GROMACS
-#  ifndef FLOAT_FORMAT_IEEE754 
+#  ifndef FLOAT_FORMAT_IEEE754
 #    error non-IEEE floating point system, or you defined GROMACS yourself...
 #  endif
     int LSW;
-#  ifdef IEEE754_BIG_ENDIAN_WORD_ORDER 
+#  ifdef IEEE754_BIG_ENDIAN_WORD_ORDER
     int LSW=1;
 #  else
     int LSW=0;
 #  endif /* Big endian word order */
-#else 
+#else
     /* Outside Gromacs we rely on dynamic detection of FP order. */
     int LSW; /* Least significant fp word */
 
     double x=0.987654321; /* Just a number */
     unsigned char ix = *((char *)&x);
-    
-    /* Possible representations in IEEE double precision: 
+
+    /* Possible representations in IEEE double precision:
      * (S=small endian, B=big endian)
-     *  
+     *
      * Byte order, Word order, Hex
-     *     S           S       b8 56 0e 3c dd 9a ef 3f    
+     *     S           S       b8 56 0e 3c dd 9a ef 3f
      *     B           S       3c 0e 56 b8 3f ef 9a dd
      *     S           B       dd 9a ef 3f b8 56 0e 3c
      *     B           B       3f ef 9a dd 3c 0e 56 b8
-     */ 
+     */
     if(ix==0xdd || ix==0x3f)
 		LSW=1;  /* Big endian word order */
     else if(ix==0xb8 || ix==0x3c)
@@ -2470,7 +2490,7 @@ xdr_double(XDR *xdrs, double *dp)
 #endif /* end of dynamic detection of fp word order */
 
 	switch (xdrs->x_op) {
-    
+
 	case XDR_ENCODE:
 		if (2*sizeof(int32_t) == sizeof(double)) {
 			int32_t *lp = (int32_t *)dp;
@@ -2485,7 +2505,7 @@ xdr_double(XDR *xdrs, double *dp)
 					xdr_putlong(xdrs, tmp+1));
 		}
 		break;
-    
+
 	case XDR_DECODE:
 		if (2*sizeof(int32_t) == sizeof(double)) {
 			int32_t *lp = (int32_t *)dp;
@@ -2502,7 +2522,7 @@ xdr_double(XDR *xdrs, double *dp)
 			}
 		}
 		break;
-    
+
 	case XDR_FREE:
 		return (1);
 	}
@@ -2591,7 +2611,7 @@ static int
 xdrstdio_putbytes (XDR *xdrs, char *addr, unsigned int len)
 {
 	if ((len != 0) && (fwrite (addr, (int) len, 1,
-							   (FILE *) xdrs->x_private) != 1)) 
+							   (FILE *) xdrs->x_private) != 1))
 		return 0;
 	return 1;
 }

--- a/MDANSE/Extensions/xtc/src/xdrfile_trr.c
+++ b/MDANSE/Extensions/xtc/src/xdrfile_trr.c
@@ -67,7 +67,7 @@ typedef struct		/* This struct describes the order and the	*/
 static int nFloatSize(t_trnheader *sh,int *nflsz)
 {
     int nflsize=0;
-  
+
     if (sh->box_size)
         nflsize = sh->box_size/(DIM*DIM);
     else if (sh->x_size)
@@ -76,14 +76,14 @@ static int nFloatSize(t_trnheader *sh,int *nflsz)
         nflsize = sh->v_size/(sh->natoms*DIM);
     else if (sh->f_size)
         nflsize = sh->f_size/(sh->natoms*DIM);
-    else 
+    else
         return exdrHEADER;
-  
+
     if (((nflsize != sizeof(float)) && (nflsize != sizeof(double))))
         return exdrHEADER;
-      
+
     *nflsz = nflsize;
-  
+
     return exdrOK;
 }
 
@@ -93,7 +93,7 @@ extern int do_trnheader(XDRFILE *xd,mybool bRead,t_trnheader *sh)
 	int nflsz,slen,result;
 	char *version = "GMX_trn_file";
 	char buf[BUFSIZE];
-  
+
 	if (xdrfile_read_int(&magic,1,xd) != 1) {
 	    /* modification by RTM to return the right EOF code
 	    this is what's happening in the XTC code */
@@ -104,7 +104,7 @@ extern int do_trnheader(XDRFILE *xd,mybool bRead,t_trnheader *sh)
     }
 	if (magic != GROMACS_MAGIC)
 		return exdrMAGIC;
-	if (bRead) 
+	if (bRead)
     {
         if (xdrfile_read_int(&slen,1,xd) != 1)
             return exdrINT;
@@ -113,7 +113,7 @@ extern int do_trnheader(XDRFILE *xd,mybool bRead,t_trnheader *sh)
         if (xdrfile_read_string(buf,BUFSIZE,xd) <= 0)
             return exdrSTRING;
     }
-	else 
+	else
     {
         slen = strlen(version)+1;
         if (xdrfile_read_int(&slen,1,xd) != 1)
@@ -143,16 +143,16 @@ extern int do_trnheader(XDRFILE *xd,mybool bRead,t_trnheader *sh)
 		return exdrINT;
 	if (xdrfile_read_int(&sh->natoms,1,xd) != 1)
 		return exdrINT;
-	
+
 	if ((result = nFloatSize(sh,&nflsz)) != exdrOK)
 		return result;
 	sh->bDouble = (nflsz == sizeof(double));
-	
+
 	if (xdrfile_read_int(&sh->step,1,xd) != 1)
 		return exdrINT;
 	if (xdrfile_read_int(&sh->nre,1,xd) != 1)
 		return exdrINT;
-	if (sh->bDouble) 
+	if (sh->bDouble)
     {
         if (xdrfile_read_double(&sh->td,1,xd) != 1)
             return exdrDOUBLE;
@@ -161,7 +161,7 @@ extern int do_trnheader(XDRFILE *xd,mybool bRead,t_trnheader *sh)
             return exdrDOUBLE;
         sh->lambdaf = sh->lambdad;
     }
-	else 
+	else
     {
         if (xdrfile_read_float(&sh->tf,1,xd) != 1)
             return exdrFLOAT;
@@ -170,7 +170,7 @@ extern int do_trnheader(XDRFILE *xd,mybool bRead,t_trnheader *sh)
             return exdrFLOAT;
         sh->lambdad = sh->lambdaf;
     }
-  
+
     return exdrOK;
 }
 
@@ -182,12 +182,12 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
 	float  pvf[DIM*DIM];
 	float  *fx=NULL;
 	int    i,j;
-	
-	if (sh->bDouble) 
+
+	if (sh->bDouble)
 	{
-		if (sh->box_size != 0) 
+		if (sh->box_size != 0)
         {
-            if (!bRead) 
+            if (!bRead)
             {
                 for(i=0; (i<DIM); i++)
                     for(j=0; (j<DIM); j++)
@@ -196,7 +196,7 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
                             pvd[i*DIM+j] = box[i][j];
                         }
             }
-            if (xdrfile_read_double(pvd,DIM*DIM,xd) == DIM*DIM) 
+            if (xdrfile_read_double(pvd,DIM*DIM,xd) == DIM*DIM)
             {
                 for(i=0; (i<DIM); i++)
                     for(j=0; (j<DIM); j++)
@@ -208,27 +208,27 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
             else
                 return exdrDOUBLE;
         }
-			
-		if (sh->vir_size != 0) 
+
+		if (sh->vir_size != 0)
         {
-            if (xdrfile_read_double(pvd,DIM*DIM,xd) != DIM*DIM) 
+            if (xdrfile_read_double(pvd,DIM*DIM,xd) != DIM*DIM)
                 return exdrDOUBLE;
         }
-		
-		if (sh->pres_size!= 0) 
+
+		if (sh->pres_size!= 0)
         {
-            if (xdrfile_read_double(pvd,DIM*DIM,xd) != DIM*DIM) 
+            if (xdrfile_read_double(pvd,DIM*DIM,xd) != DIM*DIM)
                 return exdrDOUBLE;
         }
-		
+
 		if ((sh->x_size != 0) || (sh->v_size != 0) || (sh->f_size != 0)) {
 			dx = (double *)calloc(sh->natoms*DIM,sizeof(dx[0]));
 			if (NULL == dx)
 				return exdrNOMEM;
 		}
-		if (sh->x_size   != 0) 
+		if (sh->x_size   != 0)
         {
-            if (!bRead) 
+            if (!bRead)
             {
                 for(i=0; (i<sh->natoms); i++)
                     for(j=0; (j<DIM); j++)
@@ -239,7 +239,7 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
             }
             if (xdrfile_read_double(dx,sh->natoms*DIM,xd) == sh->natoms*DIM)
             {
-                if (bRead) 
+                if (bRead)
                 {
                     for(i=0; (i<sh->natoms); i++)
                         for(j=0; (j<DIM); j++)
@@ -252,9 +252,9 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
             else
                 return exdrDOUBLE;
         }
-		if (sh->v_size   != 0) 
+		if (sh->v_size   != 0)
         {
-            if (!bRead) 
+            if (!bRead)
             {
                 for(i=0; (i<sh->natoms); i++)
                     for(j=0; (j<DIM); j++)
@@ -275,9 +275,9 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
             else
                 return exdrDOUBLE;
         }
-		if (sh->f_size   != 0) 
+		if (sh->f_size   != 0)
         {
-            if (!bRead) 
+            if (!bRead)
             {
                 for(i=0; (i<sh->natoms); i++)
                     for(j=0; (j<DIM); j++)
@@ -309,9 +309,9 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
 	else
 		/* Float */
 	{
-		if (sh->box_size != 0) 
+		if (sh->box_size != 0)
         {
-            if (!bRead) 
+            if (!bRead)
             {
                 for(i=0; (i<DIM); i++)
                     for(j=0; (j<DIM); j++)
@@ -320,7 +320,7 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
                             pvf[i*DIM+j] = box[i][j];
                         }
             }
-            if (xdrfile_read_float(pvf,DIM*DIM,xd) == DIM*DIM) 
+            if (xdrfile_read_float(pvf,DIM*DIM,xd) == DIM*DIM)
             {
                 for(i=0; (i<DIM); i++)
                 {
@@ -336,27 +336,27 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
             else
                 return exdrFLOAT;
         }
-			
-		if (sh->vir_size != 0) 
+
+		if (sh->vir_size != 0)
         {
-            if (xdrfile_read_float(pvf,DIM*DIM,xd) != DIM*DIM) 
+            if (xdrfile_read_float(pvf,DIM*DIM,xd) != DIM*DIM)
                 return exdrFLOAT;
         }
-		
-		if (sh->pres_size!= 0) 
+
+		if (sh->pres_size!= 0)
         {
-            if (xdrfile_read_float(pvf,DIM*DIM,xd) != DIM*DIM) 
+            if (xdrfile_read_float(pvf,DIM*DIM,xd) != DIM*DIM)
                 return exdrFLOAT;
         }
-		
+
 		if ((sh->x_size != 0) || (sh->v_size != 0) || (sh->f_size != 0)) {
 			fx = (float *)calloc(sh->natoms*DIM,sizeof(fx[0]));
 			if (NULL == fx)
 				return exdrNOMEM;
 		}
-		if (sh->x_size   != 0) 
+		if (sh->x_size   != 0)
         {
-            if (!bRead) 
+            if (!bRead)
             {
                 for(i=0; (i<sh->natoms); i++)
                     for(j=0; (j<DIM); j++)
@@ -367,7 +367,7 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
             }
             if (xdrfile_read_float(fx,sh->natoms*DIM,xd) == sh->natoms*DIM)
             {
-                if (bRead) 
+                if (bRead)
                 {
                     for(i=0; (i<sh->natoms); i++)
                         for(j=0; (j<DIM); j++)
@@ -378,9 +378,9 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
             else
                 return exdrFLOAT;
         }
-		if (sh->v_size   != 0) 
+		if (sh->v_size   != 0)
         {
-            if (!bRead) 
+            if (!bRead)
             {
                 for(i=0; (i<sh->natoms); i++)
                     for(j=0; (j<DIM); j++)
@@ -399,9 +399,9 @@ static int do_htrn(XDRFILE *xd,mybool bRead,t_trnheader *sh,
             else
                 return exdrFLOAT;
         }
-		if (sh->f_size   != 0) 
+		if (sh->f_size   != 0)
         {
-           if (!bRead) 
+           if (!bRead)
             {
                 for(i=0; (i<sh->natoms); i++)
                     for(j=0; (j<DIM); j++)
@@ -432,9 +432,9 @@ static int do_trn(XDRFILE *xd,mybool bRead,int *step,float *t,float *lambda,
 {
     t_trnheader *sh;
     int result;
-  
+
     sh = (t_trnheader *)calloc(1,sizeof(*sh));
-  
+
     if (!bRead) {
         sh->box_size = (NULL != box) ? sizeof(matrix):0;
         sh->x_size   = ((NULL != x) ? (*natoms*sizeof(x[0])):0);
@@ -461,7 +461,7 @@ static int do_trn(XDRFILE *xd,mybool bRead,int *step,float *t,float *lambda,
         return result;
 
     free(sh);
-  
+
     return exdrOK;
 }
 
@@ -470,21 +470,23 @@ static int do_trn(XDRFILE *xd,mybool bRead,int *step,float *t,float *lambda,
  *  The following routines are the exported ones
  *
  ************************************************************/
- 
+
 int read_trr_natoms(char *fn,int *natoms)
 {
 	XDRFILE *xd;
 	t_trnheader sh;
 	int  result;
-	
+
 	xd = xdrfile_open(fn,"r");
 	if (NULL == xd)
 		return exdrFILENOTFOUND;
-	if ((result = do_trnheader(xd,1,&sh)) != exdrOK)
+	if ((result = do_trnheader(xd,1,&sh)) != exdrOK) {
+                xdrfile_close(xd);
 		return result;
+        }
 	xdrfile_close(xd);
 	*natoms = sh.natoms;
-	
+
 	return exdrOK;
 }
 
@@ -504,16 +506,16 @@ int read_trr_nframes(char *fn, unsigned long *nframes) {
     if (NULL == xd)
         return exdrFILENOTFOUND;
 
-	do {
-		result = read_trr(xd, natoms, &step, &time, &lambda,
-						  box, x, NULL, NULL);
-		if (exdrENDOFFILE != result) {
-			(*nframes)++;
-		}
-	} while (result == exdrOK);
+    do {
+            result = read_trr(xd, natoms, &step, &time, &lambda,
+                                              box, x, NULL, NULL);
+            if (exdrENDOFFILE != result) {
+                    (*nframes)++;
+            }
+    } while (result == exdrOK);
 
-	xdrfile_close(xd);
-	free(x);
+    xdrfile_close(xd);
+    free(x);
     return exdrOK;
 }
 
@@ -528,4 +530,3 @@ int read_trr(XDRFILE *xd,int natoms,int *step,float *t,float *lambda,
 {
 	return do_trn(xd,1,step,t,lambda,box,&natoms,x,v,f);
 }
-

--- a/MDANSE/Extensions/xtc/src/xdrfile_xtc.c
+++ b/MDANSE/Extensions/xtc/src/xdrfile_xtc.c
@@ -1,4 +1,4 @@
-/* -*- mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4 -*- 
+/* -*- mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4 -*-
  *
  * $Id$
  *
@@ -26,11 +26,11 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #include <stdlib.h>
 #include "xdrfile.h"
 #include "xdrfile_xtc.h"
-	
+
 #define MAGIC 1995
 
 enum { FALSE, TRUE };
@@ -38,7 +38,7 @@ enum { FALSE, TRUE };
 static int xtc_header(XDRFILE *xd,int *natoms,int *step,float *time,mybool bRead)
 {
 	int result,magic,n=1;
-	
+
 	/* Note: read is same as write. He he he */
 	magic  = MAGIC;
 	if ((result = xdrfile_write_int(&magic,n,xd)) != n)
@@ -56,30 +56,30 @@ static int xtc_header(XDRFILE *xd,int *natoms,int *step,float *time,mybool bRead
 		return exdrINT;
 	if ((result = xdrfile_write_float(time,n,xd)) != n)
 		return exdrFLOAT;
-	
+
 	return exdrOK;
 }
 
 static int xtc_coord(XDRFILE *xd,int *natoms,matrix box,rvec *x,float *prec,
 					 mybool bRead)
 {
-	int result;
-    
+	int i,j,result;
+
 	/* box */
 	result = xdrfile_read_float(box[0],DIM*DIM,xd);
 	if (DIM*DIM != result)
 		return exdrFLOAT;
-	else 
+	else
 		{
 			if (bRead)
 				{
-					result = xdrfile_decompress_coord_float(x[0],natoms,prec,xd); 
+					result = xdrfile_decompress_coord_float(x[0],natoms,prec,xd);
 					if (result != *natoms)
 						return exdr3DX;
 				}
 			else
 				{
-					result = xdrfile_compress_coord_float(x[0],*natoms,*prec,xd); 
+					result = xdrfile_compress_coord_float(x[0],*natoms,*prec,xd);
 					if (result != *natoms)
 						return exdr3DX;
 				}
@@ -92,13 +92,13 @@ int read_xtc_natoms(char *fn,int *natoms)
 	XDRFILE *xd;
 	int step,result;
 	float time;
-	
+
 	xd = xdrfile_open(fn,"r");
 	if (NULL == xd)
 		return exdrFILENOTFOUND;
 	result = xtc_header(xd,natoms,&step,&time,TRUE);
 	xdrfile_close(xd);
-	
+
 	return result;
 }
 
@@ -137,10 +137,10 @@ int read_xtc(XDRFILE *xd,
 /* Read subsequent frames */
 {
 	int result;
-  
+
 	if ((result = xtc_header(xd,&natoms,step,time,TRUE)) != exdrOK)
 		return result;
-	  
+
 	if ((result = xtc_coord(xd,&natoms,box,x,prec,1)) != exdrOK)
 		return result;
 
@@ -153,12 +153,12 @@ int write_xtc(XDRFILE *xd,
 /* Write a frame to xtc file */
 {
 	int result;
-  
+
 	if ((result = xtc_header(xd,&natoms,&step,&time,FALSE)) != exdrOK)
 		return result;
 
 	if ((result = xtc_coord(xd,&natoms,box,x,&prec,0)) != exdrOK)
 		return result;
-  
+
 	return exdrOK;
 }

--- a/MDANSE/Extensions/xtc/xdrlib.pxd
+++ b/MDANSE/Extensions/xtc/xdrlib.pxd
@@ -16,8 +16,10 @@ cdef extern from "include/xdrfile_xtc.h":
 
 
 cimport numpy as np
+
 ctypedef np.npy_int64 int64_t
 
 cdef extern from "include/xdr_seek.h":
     int64_t xdr_tell(XDRFILE *xd)
     int xdr_seek(XDRFILE *xd, int64_t pos, int whence)
+    int xdr_flush(XDRFILE* xd)

--- a/MDANSE/Src/MDANSE/Framework/Converters/DCD.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DCD.py
@@ -21,7 +21,7 @@ import numpy as np
 from MDANSE.Core.Error import Error
 from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Units import measure
-from MDANSE.IO.PDBReader import PDBReader
+from MDANSE.IO.MinimalPDBReader import MinimalPDBReader
 from MDANSE.Mathematics.Geometry import get_basis_vectors_from_cell_parameters
 from MDANSE.MolecularDynamics.Configuration import PeriodicRealConfiguration
 from MDANSE.MolecularDynamics.Trajectory import (
@@ -323,8 +323,8 @@ class DCD(Converter):
         self.numberOfSteps = self.configuration["dcd_file"]["instance"]["n_frames"]
 
         # Create all chemical entities from the PDB file.
-        pdb_reader = PDBReader(self.configuration["pdb_file"]["filename"])
-        self._chemical_system = pdb_reader.build_chemical_system()
+        pdb_reader = MinimalPDBReader(self.configuration["pdb_file"]["filename"])
+        self._chemical_system = pdb_reader._chemical_system
 
         resolve_undefined_molecules_name(self._chemical_system)
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
@@ -21,7 +21,7 @@ import numpy as np
 from MDANSE.Core.Error import Error
 from MDANSE.Extensions import xtc, trr
 from MDANSE.Framework.Converters.Converter import Converter
-from MDANSE.IO.PDBReader import PDBReader
+from MDANSE.IO.MinimalPDBReader import MinimalPDBReader
 from MDANSE.MolecularDynamics.Configuration import PeriodicRealConfiguration
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
@@ -121,8 +121,8 @@ class Gromacs(Converter):
         self.numberOfSteps = len(self._xdr_file)
 
         # Create all chemical entities from the PDB file.
-        pdb_reader = PDBReader(self.configuration["pdb_file"]["filename"])
-        chemical_system = pdb_reader.build_chemical_system()
+        pdb_reader = MinimalPDBReader(self.configuration["pdb_file"]["filename"])
+        chemical_system = pdb_reader._chemical_system
 
         # A trajectory is opened for writing.
         self._trajectory = TrajectoryWriter(

--- a/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
@@ -148,8 +148,11 @@ class Gromacs(Converter):
         if self._xtc:
             coords, times, steps, box = self._xdr_file.read(1)
         else:
-            coords, times, steps, box, __, velocities, forces = self._xdr_file.read(
-                1, get_velocities=self._read_velocities, get_forces=self._read_forces
+            coords, times, steps, box, __, velocities, forces = self._xdr_file._read(
+                1,
+                None,
+                get_velocities=self._read_velocities,
+                get_forces=self._read_forces,
             )
 
             if self._read_velocities:

--- a/MDANSE/Src/MDANSE/IO/MinimalPDBReader.py
+++ b/MDANSE/Src/MDANSE/IO/MinimalPDBReader.py
@@ -131,12 +131,26 @@ class MinimalPDBReader:
 
         for atom_line in atom_lines:
             chemical_element = atom_line[element_slice].strip()
-            atom_name = atom_line[name_slice].strip()
-            if chemical_element in ATOMS_DATABASE.atoms:
+            atom_name = atom_line[name_slice]
+            backup_element = atom_line.split()[-1]
+            backup_element2 = atom_line.split()[-2]
+            if atom_name[-2:].isnumeric():
+                backup_element3 = atom_name[0]
+            if backup_element in ATOMS_DATABASE.atoms:
+                atom = Atom(symbol=backup_element, name=atom_name)
+            elif atom_name[:2].strip() in ATOMS_DATABASE.atoms:
+                atom = Atom(symbol=atom_name[:2].strip(), name=atom_name)
+            elif backup_element2 in ATOMS_DATABASE.atoms:
+                atom = Atom(symbol=backup_element2, name=atom_name)
+            elif backup_element3 in ATOMS_DATABASE.atoms:
+                atom = Atom(symbol=backup_element3, name=atom_name)
+            elif chemical_element in ATOMS_DATABASE.atoms:
                 atom = Atom(symbol=chemical_element, name=atom_name)
-            elif atom_name[:2] in ATOMS_DATABASE.atoms:
-                atom = Atom(symbol=atom_name[:2], name=atom_name)
             else:
+                print(atom_line)
+                print(f"Chemical symbol = {chemical_element}")
+                print(f"backup symbol = {backup_element}")
+                raise ValueError()
                 atom = Atom(symbol="Du", name=atom_name)
             self._chemical_system.add_chemical_entity(atom)
             x, y, z = (

--- a/MDANSE/Src/MDANSE/IO/MinimalPDBReader.py
+++ b/MDANSE/Src/MDANSE/IO/MinimalPDBReader.py
@@ -1,0 +1,159 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from typing import List
+
+import numpy as np
+from ase.io import read as ase_read
+
+from MDANSE.Framework.Units import measure
+from MDANSE.Chemistry import ATOMS_DATABASE
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem, Atom
+from MDANSE.MolecularDynamics.Configuration import (
+    RealConfiguration,
+    PeriodicRealConfiguration,
+)
+from MDANSE.MolecularDynamics.UnitCell import UnitCell
+
+atom_line_records = {
+    "record_name": (0, 6),
+    "atom_number": (6, 11),
+    "atom_name": (12, 16),
+    "location": (16, 17),
+    "residue_name": (17, 20),
+    "chain_id": (21, 22),
+    "residue_number": (22, 26),
+    "insertion_code": (26, 27),
+    "pos_x": (30, 38),
+    "pos_y": (38, 46),
+    "pos_z": (46, 54),
+    "occupancy": (54, 60),
+    "temperature_factor": (60, 66),
+    "element_symbol": (76, 78),
+    "charge": (78, 80),
+}
+
+
+def atom_line_slice(keyword: str) -> slice:
+    try:
+        limits = atom_line_records[keyword]
+    except KeyError:
+        return slice()
+    else:
+        return slice(limits[0], limits[1])
+
+
+class MinimalPDBReader:
+
+    def __init__(self, filename: str):
+
+        self._unit_cell = None
+        cell_params = self.find_unit_cell(filename)
+        if len(cell_params) == 0:
+            self.periodic = False
+        else:
+            try:
+                ase_atoms = ase_read(filename, format="pdb", index=0)
+                cell = ase_atoms.get_cell()
+            except:
+                self.periodic = False
+            else:
+                self.periodic = True
+                self._unit_cell = np.vstack(cell)
+        self._chemical_system = ChemicalSystem(filename)
+        atom_lines = self.find_atoms(filename)
+        self.build_chemical_system(atom_lines)
+
+    def find_unit_cell(self, filename: str, frame_number: int = 0):
+        cell_found = False
+        cell_params = []
+        cell_line = ""
+        fail_count = 0
+        with open(filename, "r") as source:
+            for line in source:
+                if "CRYST" in line[0:5]:
+                    cell_found = True
+                    cell_line += line
+                    break
+                if "ENDMDL" in line[0:6]:
+                    fail_count += 1
+                if fail_count > 2:
+                    cell_line = ""
+                    cell_found = False
+                    break
+        if not cell_found:
+            return cell_params
+        cell_params = [float(x) for x in cell_line.split()[1:7]]
+        return cell_params
+
+    def find_atoms(self, filename: str, frame_number: int = 0):
+        fail_count = 0
+        result = []
+        with open(filename, "r") as source:
+            for line in source:
+                if "ATOM" in line[0:5]:
+                    result.append(line)
+                elif "HETATM" in line[0:6]:
+                    result.append(line)
+                if "ENDMDL" in line[0:6]:
+                    fail_count += 1
+                if fail_count > 0:
+                    break
+        return result
+
+    def build_chemical_system(self, atom_lines: List[str]):
+        """Build the chemical system.
+
+        Returns:
+            MDANSE.Chemistry.ChemicalEntity.ChemicalSystem: the chemical system
+        """
+
+        coordinates = []
+        element_slice = atom_line_slice("element_symbol")
+        name_slice = atom_line_slice("atom_name")
+        posx_slice = atom_line_slice("pos_x")
+        posy_slice = atom_line_slice("pos_y")
+        posz_slice = atom_line_slice("pos_z")
+        pos_scaling = measure(1.0, "ang").toval("nm")
+
+        for atom_line in atom_lines:
+            chemical_element = atom_line[element_slice].strip()
+            atom_name = atom_line[name_slice].strip()
+            if chemical_element in ATOMS_DATABASE.atoms:
+                atom = Atom(symbol=chemical_element, name=atom_name)
+            elif atom_name[:2] in ATOMS_DATABASE.atoms:
+                atom = Atom(symbol=atom_name[:2], name=atom_name)
+            else:
+                atom = Atom(symbol="Du", name=atom_name)
+            self._chemical_system.add_chemical_entity(atom)
+            x, y, z = (
+                atom_line[posx_slice],
+                atom_line[posy_slice],
+                atom_line[posz_slice],
+            )
+            coordinates.append([float(aaa) for aaa in [x, y, z]])
+
+        coordinates = np.array(coordinates)
+        coordinates *= pos_scaling
+
+        if self._unit_cell is None:
+            self._chemical_system.configuration = RealConfiguration(
+                self._chemical_system, coordinates
+            )
+        else:
+            self._chemical_system.configuration = PeriodicRealConfiguration(
+                self._chemical_system, coordinates, UnitCell(self._unit_cell)
+            )

--- a/MDANSE/Src/MDANSE/mdtraj/utils.py
+++ b/MDANSE/Src/MDANSE/mdtraj/utils.py
@@ -1,0 +1,188 @@
+##############################################################################
+# MDTraj: A Python Library for Loading, Saving, and Manipulating
+#         Molecular Dynamics Trajectories.
+# Copyright 2012-2013 Stanford University and the Authors
+#
+# Authors: Robert McGibbon
+# Contributors:
+#
+# MDTraj is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with MDTraj. If not, see <http://www.gnu.org/licenses/>.
+##############################################################################
+
+
+##############################################################################
+# imports
+##############################################################################
+
+import collections
+import numbers
+import warnings
+from itertools import zip_longest
+
+import numpy as np
+
+
+class TypeCastPerformanceWarning(RuntimeWarning):
+    pass
+
+
+def ensure_type(
+    val,
+    dtype,
+    ndim,
+    name,
+    length=None,
+    can_be_none=False,
+    shape=None,
+    warn_on_cast=True,
+    add_newaxis_on_deficient_ndim=False,
+):
+    """Typecheck the size, shape and dtype of a numpy array, with optional
+    casting.
+
+    Parameters
+    ----------
+    val : {np.ndaraay, None}
+        The array to check
+    dtype : {nd.dtype, str}
+        The dtype you'd like the array to have
+    ndim : int
+        The number of dimensions you'd like the array to have
+    name : str
+        name of the array. This is used when throwing exceptions, so that
+        we can describe to the user which array is messed up.
+    length : int, optional
+        How long should the array be?
+    can_be_none : bool
+        Is ``val == None`` acceptable?
+    shape : tuple, optional
+        What should be shape of the array be? If the provided tuple has
+        Nones in it, those will be semantically interpreted as matching
+        any length in that dimension. So, for example, using the shape
+        spec ``(None, None, 3)`` will ensure that the last dimension is of
+        length three without constraining the first two dimensions
+    warn_on_cast : bool, default=True
+        Raise a warning when the dtypes don't match and a cast is done.
+    add_newaxis_on_deficient_ndim : bool, default=True
+        Add a new axis to the beginining of the array if the number of
+        dimensions is deficient by one compared to your specification. For
+        instance, if you're trying to get out an array of ``ndim == 3``,
+        but the user provides an array of ``shape == (10, 10)``, a new axis will
+        be created with length 1 in front, so that the return value is of
+        shape ``(1, 10, 10)``.
+
+    Notes
+    -----
+    The returned value will always be C-contiguous.
+
+    Returns
+    -------
+    typechecked_val : np.ndarray, None
+        If `val=None` and `can_be_none=True`, then this will return None.
+        Otherwise, it will return val (or a copy of val). If the dtype wasn't right,
+        it'll be casted to the right shape. If the array was not C-contiguous, it'll
+        be copied as well.
+
+    """
+    if can_be_none and val is None:
+        return None
+
+    if not isinstance(val, np.ndarray):
+        if isinstance(val, collections.abc.Iterable):
+            # If they give us an iterator, let's try...
+            if isinstance(val, collections.abc.Sequence):
+                # sequences are easy. these are like lists and stuff
+                val = np.array(val, dtype=dtype)
+            else:
+                # this is a generator...
+                val = np.array(list(val), dtype=dtype)
+        elif np.isscalar(val) and add_newaxis_on_deficient_ndim and ndim == 1:
+            # special case: if the user is looking for a 1d array, and
+            # they request newaxis upconversion, and provided a scalar
+            # then we should reshape the scalar to be a 1d length-1 array
+            val = np.array([val])
+        else:
+            raise TypeError(
+                f"{name} must be numpy array. You supplied type {type(val)}"
+            )
+
+    if warn_on_cast and val.dtype != dtype:
+        warnings.warn(
+            f"Casting {name} dtype={val.dtype} to {dtype} ",
+            TypeCastPerformanceWarning,
+        )
+
+    if not val.ndim == ndim:
+        if add_newaxis_on_deficient_ndim and val.ndim + 1 == ndim:
+            val = val[np.newaxis, ...]
+        else:
+            raise ValueError(f"{name} must be ndim {ndim}. You supplied {val.ndim}")
+
+    val = np.ascontiguousarray(val, dtype=dtype)
+
+    if length is not None and len(val) != length:
+        raise ValueError(f"{name} must be length {length}. You supplied {len(val)}")
+
+    if shape is not None:
+        # the shape specified given by the user can look like (None, None 3)
+        # which indicates that ANY length is accepted in dimension 0 or
+        # dimension 1
+        sentenel = object()
+        error = ValueError(
+            "{} must be shape {}. You supplied  "
+            "{}".format(name, str(shape).replace("None", "Any"), val.shape),
+        )
+        for a, b in zip_longest(val.shape, shape, fillvalue=sentenel):
+            if a is sentenel or b is sentenel:
+                # if the sentenel was reached, it means that the ndim didn't
+                # match or something. this really shouldn't happen
+                raise error
+            if b is None:
+                # if the user's shape spec has a None in it, it matches anything
+                continue
+            if a != b:
+                # check for equality
+                raise error
+
+    return val
+
+
+def cast_indices(indices):
+    """Check that ``indices`` are appropriate for indexing an array
+
+    Parameters
+    ----------
+    indices : {None, array_like, slice}
+        If indices is None or slice, it'll just pass through. Otherwise, it'll
+        be converted to a numpy array and checked to make sure it contains
+        unique integers.
+
+    Returns
+    -------
+    value : {slice, np.ndarray}
+        Either a slice or an array of integers, depending on the input type
+    """
+    if indices is None or isinstance(indices, slice):
+        return indices
+
+    if not len(indices) == len(set(indices)):
+        raise ValueError("indices must be unique.")
+
+    out = np.asarray(indices)
+    if not issubclass(out.dtype.type, np.integer):
+        raise ValueError(
+            "indices must be of an integer type. %s is not an integer type" % out.dtype
+        )
+
+    return out


### PR DESCRIPTION
**Description of work**
Recent work has shown that the current Gromacs converter in MDANSE could not read complicated trajectories correctly. Both the PDB reader and the XTC/TRR Cython extensions were triggering errors when converting a trajectory.

NOTE: `gmx editconf` has been shown to produce _wrong formatting_ in PDB files. When such a file is used, the chemical elements will not be recognised correctly. The most reliable tool for creating the input PDB file so far has been `gmx trjconv`.

**Fixes**
1. Cython extension code (originally copied from mdtraj) has been replaced with a newer version, also from mdtraj.
2. MDANSE Gromacs converter has been adapted to deal with the changed API of the Cython extensions.
3. PDBReader has been replaced with a new MinimalPDBReader.

**To test**
All tests must pass.
A Gromacs trajectory should be converted to the MDANSE format from both .xtc and .trr files. The resulting trajectory should be the same in both cases, except that the .trr file may also contain velocities.
