### PR TITLE
Update the normalization of the van hove functions

### DIFF
--- a/MDANSE/Extensions/van_hove.pyx
+++ b/MDANSE/Extensions/van_hove.pyx
@@ -116,6 +116,7 @@ def van_hove_distinct(
 def van_hove_self(
     double[:,:] xyz,
     double[:,:] histograms,
+    double[:] cell_vols,
     double rmin,
     double dr,
     int n_configs,
@@ -131,6 +132,8 @@ def van_hove_self(
         The trajectory of an atom.
     histograms : np.ndarray
         The histograms to be updated.
+    cell_vols : np.ndarray
+        The cell volumes.
     rmin : float
         The minimum distance of the histogram.
     dr : float
@@ -159,4 +162,4 @@ def van_hove_self(
             if ((bin < 0) or (bin >= nbins)):
                 continue
 
-            histograms[bin, j] += 1.0
+            histograms[bin, j] += cell_vols[i+j]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
@@ -185,21 +185,12 @@ class VanHoveFunctionDistinct(IJob):
             dtype=np.int32,
         )
 
-        # usually the normalization is 4 * pi * r^2 * dr which is
-        # correct for small values of dr or large values of r.
-        # unlike the PDF, g(r, t) may not be zero around r=0 we will use
-        # the actual shell volume instead.
-        self.shell_volumes = []
-        for i in range(self.n_mid_points):
-            self.shell_volumes.append(
-                (
-                    self.configuration["r_values"]["value"][i]
-                    + self.configuration["r_values"]["step"]
-                )
-                ** 3
-                - self.configuration["r_values"]["value"][i] ** 3
-            )
-        self.shell_volumes = (4 / 3) * np.pi * np.array(self.shell_volumes)
+        self.shell_volumes = (
+            4
+            * np.pi
+            * np.array(self.configuration["r_values"]["mid_points"]) ** 2
+            * self.configuration["r_values"]["step"]
+        )
 
         self.h_intra = np.zeros(
             (self.nElements, self.nElements, self.n_mid_points, self.numberOfSteps)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
@@ -185,12 +185,21 @@ class VanHoveFunctionDistinct(IJob):
             dtype=np.int32,
         )
 
-        self.shell_volumes = (
-            4
-            * np.pi
-            * np.array(self.configuration["r_values"]["mid_points"]) ** 2
-            * self.configuration["r_values"]["step"]
-        )
+        # usually the normalization is 4 * pi * r^2 * dr which is
+        # correct for small values of dr or large values of r.
+        # unlike the PDF, g(r, t) may not be zero around r=0 we will use
+        # the actual shell volume instead.
+        self.shell_volumes = []
+        for i in range(self.n_mid_points):
+            self.shell_volumes.append(
+                (
+                    self.configuration["r_values"]["value"][i]
+                    + self.configuration["r_values"]["step"]
+                )
+                ** 3
+                - self.configuration["r_values"]["value"][i] ** 3
+            )
+        self.shell_volumes = (4 / 3) * np.pi * np.array(self.shell_volumes)
 
         self.h_intra = np.zeros(
             (self.nElements, self.nElements, self.n_mid_points, self.numberOfSteps)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
@@ -172,11 +172,14 @@ class VanHoveFunctionSelf(IJob):
             last=last,
             step=step,
         )
-        cell_vols = np.array([
-            self.configuration["trajectory"]["instance"].configuration(
-                i
-            ).unit_cell.volume for i in range(first, last, step)
-        ])
+        cell_vols = np.array(
+            [
+                self.configuration["trajectory"]["instance"]
+                .configuration(i)
+                .unit_cell.volume
+                for i in range(first, last, step)
+            ]
+        )
 
         van_hove.van_hove_self(
             series,


### PR DESCRIPTION
**Description of work**
Updated the self-part of the van Hove function so that both $4 \pi r^2 G_s(r,t)$ and $G_s(r,t)$ are saved. Changed the normalization so that it is now consistent with the distinct part. The normalization of $4 \pi r^2 G_s(r,t)$ has been corrected.

Here I have plotted both the self and distinct part of the van Hove function on the same plot for the 0th and 20th time steps.
![image](https://github.com/user-attachments/assets/ec3bbe08-9804-4955-a3b3-15947c021629)
![image](https://github.com/user-attachments/assets/1d684a9b-2ce7-4fbb-94f0-81dcf0f10dbe)

**To test**
Run the self-part of van Hove function and check the results, rebuild MDANSE as some cython was changed. Check the self-part van Hove function, there should now be two outputs with different normalizations.  The $4 \pi r^2 G_s(r,t)$ output should be similar to the output from before. A new $G_s(r,t)$ should be available, normalized in the same way as the distinct part.
