### PR TITLE
Make iterable unpacking backwards compatible

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -212,7 +212,7 @@ class SingleDataset:
                 if plane_number in self._data_limits:
                     fixed_argument = perpendicular_axis[plane_number]
                     slice_def[axis_number] = plane_number
-                    data = self._data[*slice_def]
+                    data = self._data[tuple(slice_def)]
                     self._planes[plane_number] = data
                     self._plane_labels[plane_number] = (
                         f"{perpendicular_axis_name}={fixed_argument}"
@@ -220,7 +220,7 @@ class SingleDataset:
             else:
                 fixed_argument = perpendicular_axis[plane_number]
                 slice_def[axis_number] = plane_number
-                data = self._data[*slice_def]
+                data = self._data[tuple(slice_def)]
                 self._planes[plane_number] = data
                 self._plane_labels[plane_number] = (
                     f"{perpendicular_axis_name}={fixed_argument}"

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "MDANSE_GUI"
-version = "0.1.0b1"
+version = "0.1.0b2"
 description = 'MDANSE GUI package - the graphical interface for MDANSE'
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
**Description of work**
The syntax of PlottingContext for n-dimensional arrays was not handled correctly by Python versions before 3.11.

**Fixes**
- replaced the `*` unpacking operator with a conversion to tuple.

**To test**
Create and load a 3D data array (Molecular Trace will do it). Using Python 3.9, make sure that you can start the GUI, load the data and plot a 2D slice using the Heatmap plotter.
