### PR TITLE
Correct dlpoly and instruments

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
@@ -307,8 +307,12 @@ class DL_POLY(Converter):
         )
 
         self._velocities = None
-
         self._gradients = None
+
+        if self._historyFile["keytrj"] > 0:
+            self._velocities = True
+        if self._historyFile["keytrj"] > 1:
+            self._gradients = True
 
     def run_step(self, index):
         """Runs a single step of the job.

--- a/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
@@ -28,45 +28,6 @@ from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 
-_HISTORY_FORMAT = {}
-_HISTORY_FORMAT["2"] = {
-    "rec1": 81,
-    "rec2": 31,
-    "reci": 61,
-    "recii": 37,
-    "reciii": 37,
-    "reciv": 37,
-    "reca": 43,
-    "recb": 37,
-    "recc": 37,
-    "recd": 37,
-}
-_HISTORY_FORMAT["3"] = {
-    "rec1": 73,
-    "rec2": 73,
-    "reci": 73,
-    "recii": 73,
-    "reciii": 73,
-    "reciv": 73,
-    "reca": 73,
-    "recb": 73,
-    "recc": 73,
-    "recd": 73,
-}
-_HISTORY_FORMAT["4"] = {
-    "rec1": 73,
-    "rec2": 73,
-    "reci": 73,
-    "recii": 73,
-    "reciii": 73,
-    "reciv": 73,
-    "reca": 73,
-    "recb": 73,
-    "recc": 73,
-    "recd": 73,
-}
-
-
 class HistoryFileError(Error):
     pass
 
@@ -79,157 +40,83 @@ class HistoryFile(dict):
 
     def __init__(self, filename):
         super().__init__()
-        self["instance"] = open(filename, "rb")
-
-        version = self.determine_version()
-        self["version"] = version
-
-        lenTestLine = len(self["instance"].readline())
-
-        self["instance"].seek(0, 0)
-
-        offset = lenTestLine - _HISTORY_FORMAT[self["version"]]["rec1"]
-
-        self._headerSize = (
-            _HISTORY_FORMAT[self["version"]]["rec1"]
-            + _HISTORY_FORMAT[self["version"]]["rec2"]
-            + 2 * offset
-        )
-
-        self["instance"].read(_HISTORY_FORMAT[self["version"]]["rec1"] + offset)
-
-        data = self["instance"].read(_HISTORY_FORMAT[self["version"]]["rec2"] + offset)
-
-        self["keytrj"], self["imcon"], self["natms"] = [
-            int(v) for v in data.split()[0:3]
-        ]
-
-        if self["keytrj"] not in list(range(3)):
-            raise HistoryFileError("Invalid value for trajectory output key.")
-
-        if self["imcon"] not in list(range(4)):
-            raise HistoryFileError(
-                "Invalid value for periodic boundary conditions key."
-            )
-
-        if self["imcon"] == 0:
-            self._configHeaderSize = _HISTORY_FORMAT[self["version"]]["reci"]
-        else:
-            self._configHeaderSize = (
-                _HISTORY_FORMAT[self["version"]]["reci"]
-                + 3 * _HISTORY_FORMAT[self["version"]]["recii"]
-                + 4 * offset
-            )
-
-        self._configSize = (
-            _HISTORY_FORMAT[self["version"]]["reca"]
-            + offset
-            + (self["keytrj"] + 1) * (_HISTORY_FORMAT[self["version"]]["recb"] + offset)
-        ) * self["natms"]
-
-        self._frameSize = self._configHeaderSize + self._configSize
-
-        self["instance"].seek(0, 2)
-
-        self["n_frames"] = (
-            self["instance"].tell() - self._headerSize
-        ) / self._frameSize
-
-        self["instance"].seek(self._headerSize)
-
-        data = self["instance"].read(self._configHeaderSize).splitlines()
-
-        line = data[0].split()
-
-        self._firstStep = int(line[1])
-
-        self._timeStep = float(line[5])
-
-        self._maskStep = 3 + 3 * (self["keytrj"] + 1) + 1
-
-        if (self["version"] == "3") or (self["version"] == "4"):
-            self._maskStep += 1
-
-        self["instance"].seek(0)
+        self._dist_conversion = measure(1.0, "ang").toval("nm")
+        self._vel_conversion = measure(1.0, "ang/ps").toval("nm/ps")
+        self._grad_conversion = measure(1.0, "uma ang / ps2").toval("uma nm / ps2")
+        with open(filename, "r") as source:
+            _ = source.readline()
+            tagline = source.readline()
+            toks = tagline.split()
+            self["keytrj"], self["imcon"], self["natms"] = [int(v) for v in toks[:3]]
+            timeline = source.readline()
+            toks = timeline.split()
+            self._timeStep = float(toks[5])
+            self._firstStep = int(toks[1])
+        n_frames = 0
+        with open(filename, "r") as source:
+            for line in source:
+                if "timestep" in line:
+                    n_frames += 1
+        self["n_frames"] = n_frames
+        self["instance"] = open(filename, "r")
+        for _ in range(2):
+            self["instance"].readline()
 
     def read_step(self, step):
-        self["instance"].seek(self._headerSize + step * self._frameSize)
-
-        data = self["instance"].read(self._configHeaderSize).splitlines()
-
-        line = data[0].split()
-        currentStep = int(line[1])
+        headerline = self["instance"].readline()
+        currentStep = int(headerline.split()[1])
 
         timeStep = (currentStep - self._firstStep) * self._timeStep
         if self["imcon"] > 0:
-            cell = " ".join([i.decode("UTF-8") for i in data[1:]]).split()
-            cell = np.array(cell, dtype=np.float64)
+            cell_nums = []
+            for _ in range(3):
+                cell_nums.append(
+                    [float(x) for x in self["instance"].readline().split()]
+                )
+            cell = np.array(cell_nums, dtype=np.float64)
             cell = np.reshape(cell, (3, 3)).T
-            cell *= measure(1.0, "ang").toval("nm")
+            cell *= self._dist_conversion
         else:
             cell = None
 
-        data = np.array(self["instance"].read(self._configSize).split())
+        charges = np.empty(self["natms"])
+        positions = np.empty((self["natms"], 3))
+        lines_per_atom = 2
+        if self["keytrj"] > 0:
+            velocities = np.empty((self["natms"], 3))
+            lines_per_atom = 3
+        if self["keytrj"] > 1:
+            gradients = np.empty((self["natms"], 3))
+            lines_per_atom = 4
 
-        mask = np.ones((len(data),), dtype=bool)
-        mask[0 :: self._maskStep] = False  # atom label
-        mask[1 :: self._maskStep] = False  # atom index
-        mask[2 :: self._maskStep] = False  # atom mass
-        mask[3 :: self._maskStep] = False  # charge on atom
-        if (self["version"] == "3") or (self["version"] == "4"):
-            mask[4 :: self._maskStep] = False
+        for atom_num in range(self["natms"]):
+            for line_num in range(lines_per_atom):
+                toks = self["instance"].readline().split()
+                if line_num == 0:
+                    charges[atom_num] = float(toks[3])
+                elif line_num == 1:
+                    positions[atom_num] = [float(x) for x in toks]
+                elif line_num == 2:
+                    velocities[atom_num] = [float(x) for x in toks]
+                elif line_num == 3:
+                    gradients[atom_num] = [float(x) for x in toks]
 
-        charge_mask = np.zeros((len(data),), dtype=bool)
-        charge_mask[3 :: self._maskStep] = True
-        charge = np.array(np.compress(charge_mask, data), dtype=np.float64)
-
-        config = np.array(np.compress(mask, data), dtype=np.float64)
-
-        config = np.reshape(config, (self["natms"], 3 * (self["keytrj"] + 1)))
-
-        config[:, 0:3] *= measure(1.0, "ang").toval("nm")
-
+        positions *= self._dist_conversion
+        config = [positions]
         # Case of the velocities
-        if self["keytrj"] == 1:
-            config[:, 3:6] *= measure(1.0, "ang/ps").toval("nm/ps")
+        if self["keytrj"] > 0:
+            velocities *= self._vel_conversion
+            config.append(velocities)
 
         # Case of the velocities + gradients
-        elif self["keytrj"] == 2:
-            config[:, 3:6] *= measure(1.0, "ang/ps").toval("nm/ps")
-            config[:, 6:9] *= measure(1.0, "uma ang / ps2").toval("uma nm / ps2")
+        elif self["keytrj"] > 1:
+            gradients *= self._grad_conversion
+            config.append(gradients)
 
-        return timeStep, cell, config, charge
+        return timeStep, cell, config, charges
 
     def close(self):
         self["instance"].close()
-
-    def determine_version(self):
-        """Determine the DL_POLY version from the history file based
-        on record 1 and 2. See the DL_POLY 2, 3 and 4 manuals.
-
-        Returns
-        -------
-        str
-            The DL_POLY version.
-
-        Raises
-        ------
-        HistoryFileError
-            When the history file does not appear valid.
-        """
-        lines = self["instance"].readlines()
-        self["instance"].seek(0, 0)
-        record_1 = lines[0]
-        record_2 = lines[1]
-        if len(record_1) in [73, 74]:
-            if len(record_2.split()) == 5:
-                return "4"
-            elif len(record_2.split()) == 3:
-                return "3"
-        elif len(record_1) in [81, 82]:
-            return "2"
-
-        raise HistoryFileError("Invalid DLPOLY history file")
 
 
 class DL_POLY(Converter):
@@ -330,19 +217,19 @@ class DL_POLY(Converter):
 
         if self._historyFile["imcon"] > 0:
             conf = PeriodicRealConfiguration(
-                self._trajectory.chemical_system, config[:, 0:3], unitCell
+                self._trajectory.chemical_system, config[0], unitCell
             )
         else:
-            conf = RealConfiguration(self._trajectory.chemical_system, config[:, 0:3])
+            conf = RealConfiguration(self._trajectory.chemical_system, config[0])
 
         if self.configuration["fold"]["value"]:
             conf.fold_coordinates()
 
         if self._velocities is not None:
-            conf["velocities"] = config[:, 3:6]
+            conf["velocities"] = config[1]
 
         if self._gradients is not None:
-            conf["gradients"] = config[:, 6:9]
+            conf["gradients"] = config[2]
 
         self._trajectory.chemical_system.configuration = conf
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -230,7 +230,7 @@ class DynamicIncoherentStructureFactor(IJob):
 
             rho = np.exp(1j * np.dot(series, qVectors))
             res = correlate(rho, rho[:n_configs], mode="valid").T[0] / (
-                n_configs * qVectors.shape[1]
+                n_configs * rho.shape[1]
             )
 
             disf_per_q_shell[q] += res.real

--- a/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
@@ -32,6 +32,8 @@ class NeutronDynamicTotalStructureFactor(IJob):
     Computes the dynamic total structure factor for a set of atoms as the sum of the incoherent and coherent structure factors
     """
 
+    enabled = False
+
     label = "Neutron Dynamic Total Structure Factor"
 
     category = (

--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "MDANSE"
-version = "2.0.0b1"
+version = "2.0.0b2"
 description = 'MDANSE Core package - Molecular Dynamics trajectory handling and analysis code'
 readme = "README.md"
 requires-python = ">=3.9"

--- a/MDANSE_GUI/MANIFEST.in
+++ b/MDANSE_GUI/MANIFEST.in
@@ -2,6 +2,6 @@ include LICENSE
 
 recursive-include Src/MDANSE_GUI/Icons *.png *.ico
 recursive-include Src/MDANSE_GUI/MolecularViewer/database *.yml
-recursive-include Src/MDANSE_GUI/Resources *.png
+recursive-include Src/MDANSE_GUI/Resources *.png *.toml
 
 recursive-include Tests *.py

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "MDANSE_GUI"
-version = "0.1.0b2"
+version = "0.1.0b3"
 description = 'MDANSE GUI package - the graphical interface for MDANSE'
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
**Description of work**
This PR fixes some problems which became apparent when testing on the visa platform.

**Fixes**
- DL_POLY converter does not ignore velocities and forces if they are present in HISTORY,
- MANIFEST.in has been updated to include InstrumentDefinitions.toml
- version numbers have been incremented, so this build can be used on PyPI
- disabled the 'Neutron Dynamic Total Structure Factor' since it does not check if weights had already been applied,
- changed the normalisation factor in Dynamic Incoherent Structure Factor.

**To test**
Install MDANSE on a fresh machine. Check that initial list of instruments is present.
Convert a DL_POLY trajectory with velocities, see that they get written to the output file.
Try to reproduce the argon results from CCPBioSim tutorial 3, using atoms with effective scattering lengths of b_coh=0.0025 and b_inc=1e-10, based on the sigma values reported in the Skold paper. The ratio of DISF to DCSF should be close to the one presented in the paper.
