### PR TITLE
3d viewer fix when switching trajectories

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -601,12 +601,11 @@ class MolecularViewer(QtWidgets.QWidget):
         # Update the view.
         self.update_renderer()
 
-    def set_reader(self, reader, frame=0):
+    def set_reader(self, reader):
         """Set the trajectory at a given frame
 
         Args:
             reader (IReader): the trajectory object
-            frame (int): the selected frame
         """
 
         if (self._reader is not None) and (reader.filename == self._reader.filename):
@@ -619,8 +618,7 @@ class MolecularViewer(QtWidgets.QWidget):
 
         self._n_atoms = self._reader.n_atoms
         self._n_frames = self._reader.n_frames
-
-        self.new_max_frames.emit(self._n_frames - 1)
+        self._current_frame = min(self._current_frame, self._n_frames - 1)
 
         self._atoms = self._reader.atom_types
 
@@ -648,8 +646,8 @@ class MolecularViewer(QtWidgets.QWidget):
         self.reset_all_polydata()
         self._polydata.GetPointData().SetScalars(scalars)
 
-        self._current_frame = frame
         self._colour_manager.onNewValues()
+        self.new_max_frames.emit(self._n_frames - 1)
 
     @Slot(object)
     def take_atom_properties(self, data):
@@ -657,8 +655,8 @@ class MolecularViewer(QtWidgets.QWidget):
         scalars = ndarray_to_vtkarray(colours, radii, numbers)
         self._polydata = vtk.vtkPolyData()
         self._polydata.GetPointData().SetScalars(scalars)
-        self.set_coordinates(self._current_frame)
-
+        self.update_all_polydata()
+        self.update_renderer()
         # self._datamodel.setReader(reader)
 
     def update_renderer(self):


### PR DESCRIPTION
**Description of work**
PR to fix issues with the 3D viewer when switching between trajectories.

**Fixes**
Fixes #575.

**To test**
Load up two trajectories with a different number of frames. Switch to the trajectory with the largest number of frames and set the 3d view to its last frame then switch to the other trajectory. The trajectory of the system you switched to should be visible.

Load up two trajectories and set the frame to something other than zero. Switch between the trajectories. The frame in the 3D viewer should not be in the zeroth frame; see #575.
