### PR TITLE
Explicitly set the QLocale in the GUI

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -53,6 +53,10 @@ def startGUI(some_args):
     path = os.path.dirname(os.path.abspath(__file__))
     app.setWindowIcon(QIcon(os.path.join(path, "Icons/MDANSE.ico")))
     fixed_locale = QLocale(QLocale.Language.English, QLocale.Country.UnitedKingdom)
+    fixed_locale.setNumberOptions(
+        QLocale.NumberOption.RejectGroupSeparator
+        | QLocale.NumberOption.OmitGroupSeparator
+    )
     QLocale.setDefault(fixed_locale)
 
     settings = QSettings(

--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -19,7 +19,7 @@ import os
 import time
 
 from qtpy.QtWidgets import QApplication, QSplashScreen, QStyleFactory
-from qtpy.QtCore import QSettings, Qt, QTimer
+from qtpy.QtCore import QSettings, Qt, QTimer, QLocale
 from qtpy.QtGui import QPixmap, QIcon
 
 from MDANSE.MLogging import LOG, FMT
@@ -52,6 +52,8 @@ def startGUI(some_args):
 
     path = os.path.dirname(os.path.abspath(__file__))
     app.setWindowIcon(QIcon(os.path.join(path, "Icons/MDANSE.ico")))
+    fixed_locale = QLocale(QLocale.Language.English, QLocale.Country.UnitedKingdom)
+    QLocale.setDefault(fixed_locale)
 
     settings = QSettings(
         "ISIS Neutron and Muon Source", "MDANSE for Python 3", parent=app


### PR DESCRIPTION
**Description of work**
The number format will always follow the British convention, where "1 point 0" is 1.0 and not 1,0 or anything else.

closes #595 

**Fixes**
1. Created a QLocale instance set to English, UK, before starting the GUI.

**To test**
On a platform already set to English, there should be no difference.
On platforms using different symbols for the decimal point, the MDANSE GUI should now accept the '.' character instead.
