### PR TITLE
Indicate job start and completion

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -269,6 +269,7 @@ class TabbedWindow(QMainWindow):
         self.tabs.addTab(trajectory_tab._core, name)
         self._tabs[name] = trajectory_tab
         self._job_holder.trajectory_for_loading.connect(trajectory_tab.load_trajectory)
+        self._job_holder.trajectory_for_loading.connect(trajectory_tab.tab_notification)
 
     def createInstrumentSelector(self):
         name = "Instruments"
@@ -335,6 +336,7 @@ class TabbedWindow(QMainWindow):
         self.tabs.addTab(plot_tab._core, name)
         self._tabs[name] = plot_tab
         self._job_holder.results_for_loading.connect(plot_tab.load_results)
+        self._job_holder.results_for_loading.connect(plot_tab.tab_notification)
 
     def createPlotHolder(self):
         name = "Plot Holder"

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -115,6 +115,7 @@ class TabbedWindow(QMainWindow):
         self._tabs["Instruments"]._visualiser.instrument_details_changed.connect(
             self._tabs["Actions"].update_action_after_instrument_change
         )
+        self.tabs.currentChanged.connect(self.tabs.reset_current_color)
 
     def createCommonModels(self):
         self._trajectory_model = GeneralModel()

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -22,7 +22,6 @@ from qtpy.QtWidgets import (
     QMainWindow,
     QFileDialog,
     QToolBar,
-    QTabWidget,
     QMenuBar,
     QMessageBox,
     QApplication,
@@ -48,6 +47,7 @@ from MDANSE_GUI.Tabs.PlotSelectionTab import PlotSelectionTab
 from MDANSE_GUI.Tabs.PlotTab import PlotTab
 from MDANSE_GUI.Tabs.InstrumentTab import InstrumentTab
 from MDANSE_GUI.Widgets.StyleDialog import StyleDialog, StyleDatabase
+from MDANSE_GUI.Widgets.NotificationTabWidget import NotificationTabWidget
 
 
 class TabbedWindow(QMainWindow):
@@ -71,7 +71,7 @@ class TabbedWindow(QMainWindow):
         **kwargs,
     ):
         super().__init__(parent, *args, **kwargs)
-        self.tabs = QTabWidget(self)
+        self.tabs = NotificationTabWidget(self)
         self.setCentralWidget(self.tabs)
         self._views = defaultdict(list)
         self._actions = []

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/GeneralTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/GeneralTab.py
@@ -17,7 +17,7 @@
 
 from typing import Dict, Tuple
 
-from qtpy.QtCore import QObject, Slot, QMessageLogger
+from qtpy.QtCore import QObject, Slot, Signal, QMessageLogger
 from qtpy.QtWidgets import QListView
 
 from MDANSE.MLogging import LOG
@@ -41,7 +41,10 @@ class GeneralTab(QObject):
     for accessing them from the outside.
     """
 
+    notify_user = Signal(int)
+
     def __init__(self, *args, **kwargs):
+        self._my_tab_id = -1
         self._name = kwargs.pop("name", "Unnamed GUI part")
         self._session = kwargs.pop("session", LocalSession())
         _ = kwargs.pop("settings", None)
@@ -68,6 +71,13 @@ class GeneralTab(QObject):
             self._core.set_model(self._model)
         self._core.set_label_text(label_text)
         self.propagate_session()
+
+    def set_my_id(self, tab_id: int):
+        self._my_tab_id = tab_id
+
+    @Slot()
+    def tab_notification(self):
+        self.notify_user.emit(self._my_tab_id)
 
     def grouped_settings(self):
         """This method tells the Session object what settings

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -238,6 +238,7 @@ class JobHolder(QStandardItemModel):
 
     trajectory_for_loading = Signal(str)
     results_for_loading = Signal(str)
+    new_job_started = Signal()
 
     def __init__(self, parent: QObject = None):
         super().__init__(parent=parent)
@@ -330,6 +331,7 @@ class JobHolder(QStandardItemModel):
                 item_th._stat_item,
             ]
         )
+        self.new_job_started.emit()
         # nrows = self.rowCount()
         # index = self.indexFromItem(item_th._item)
         # print(f"Index: {index}")

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
@@ -95,6 +95,7 @@ class PlotTab(GeneralTab):
             label_text=label_text,
         )
         the_tab._visualiser._unit_lookup = the_tab
+        the_tab._visualiser.new_entry.connect(the_tab.tab_notification)
         return the_tab
 
     @property
@@ -113,6 +114,8 @@ class PlotTab(GeneralTab):
                 self._visualiser.plotter.plot_data()
             except Exception as e2:
                 LOG.error(f"Visualiser failed to plot data: {e2}")
+            else:
+                self.tab_notification()
 
     @Slot(int)
     def switch_model(self, tab_id):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/RunTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/RunTab.py
@@ -90,6 +90,7 @@ class RunTab(GeneralTab):
             ),
             label_text=run_tab_label,
         )
+        the_tab._model.new_job_started.connect(the_tab.tab_notification)
         return the_tab
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -31,6 +31,7 @@ from qtpy.QtCore import Signal, Slot
 from MDANSE.MLogging import LOG
 from MDANSE.Framework.Jobs.IJob import IJob
 
+from MDANSE_GUI.Widgets.DelayedButton import DelayedButton
 from MDANSE_GUI.InputWidgets import *
 from MDANSE_GUI.Tabs.Visualisers.InstrumentInfo import SimpleInstrument
 
@@ -245,7 +246,7 @@ class Action(QWidget):
         buttonlayout = QHBoxLayout(buttonbase)
         buttonbase.setLayout(buttonlayout)
         self.save_button = QPushButton("Save as script", buttonbase)
-        self.execute_button = QPushButton("RUN!", buttonbase)
+        self.execute_button = DelayedButton("RUN!", buttonbase, delay=3000)
         self.execute_button.setStyleSheet("font-weight: bold")
         self.post_execute_checkbox = QCheckBox("Auto-load results", buttonbase)
         try:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -261,6 +261,7 @@ class Action(QWidget):
 
         self.save_button.clicked.connect(self.save_dialog)
         self.execute_button.clicked.connect(self.execute_converter)
+        self.execute_button.needs_updating.connect(self.allow_execution)
 
         buttonlayout.addWidget(self.save_button)
         buttonlayout.addWidget(self.execute_button)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
@@ -29,6 +29,7 @@ class PlotHolder(QTabWidget):
     """
 
     error = Signal(str)
+    new_entry = Signal()
 
     def __init__(self, *args, unit_lookup=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -67,6 +68,7 @@ class PlotHolder(QTabWidget):
         self._context.append(plotting_context)
         self._plotter.append(plotter)
         self.setCurrentIndex(tab_id)
+        self.new_entry.emit()
         return tab_id
 
     @Slot(str)
@@ -82,6 +84,7 @@ class PlotHolder(QTabWidget):
         self._context.append(plotting_context)
         self._plotter.append(plotter)
         self.setCurrentIndex(tab_id)
+        self.new_entry.emit()
         return tab_id
 
     @Slot(int)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/DelayedButton.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/DelayedButton.py
@@ -20,6 +20,8 @@ from qtpy.QtWidgets import QPushButton
 
 class DelayedButton(QPushButton):
 
+    needs_updating = Signal()
+
     def __init__(self, *args, **kwargs):
         delay_time = kwargs.pop("delay", 1000)
         inactive_message = kwargs.pop("inactive_text", "Starting...")
@@ -27,16 +29,23 @@ class DelayedButton(QPushButton):
 
         self._delay_time = delay_time
         self._inactive_message = inactive_message
+        self._freeze_updates = False
         self._active_message = self.text()
         self.clicked.connect(self.start_delay)
+
+    def setEnabled(self, a0: bool) -> None:
+        if not self._freeze_updates:
+            return super().setEnabled(a0)
 
     @Slot()
     def start_delay(self):
         self.setText(self._inactive_message)
         self.setEnabled(False)
+        self._freeze_updates = True
         QTimer.singleShot(self._delay_time, self.end_delay)
 
     @Slot()
     def end_delay(self):
         self.setText(self._active_message)
-        self.setEnabled(True)
+        self._freeze_updates = False
+        self.needs_updating.emit()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/DelayedButton.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/DelayedButton.py
@@ -1,0 +1,42 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from qtpy.QtCore import Slot, Signal, QObject, QTimer
+from qtpy.QtWidgets import QPushButton
+
+
+class DelayedButton(QPushButton):
+
+    def __init__(self, *args, **kwargs):
+        delay_time = kwargs.pop("delay", 1000)
+        inactive_message = kwargs.pop("inactive_text", "Starting...")
+        super().__init__(*args, **kwargs)
+
+        self._delay_time = delay_time
+        self._inactive_message = inactive_message
+        self._active_message = self.text()
+        self.clicked.connect(self.start_delay)
+
+    @Slot()
+    def start_delay(self):
+        self.setText(self._inactive_message)
+        self.setEnabled(False)
+        QTimer.singleShot(self._delay_time, self.end_delay)
+
+    @Slot()
+    def end_delay(self):
+        self.setText(self._active_message)
+        self.setEnabled(True)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/NotificationTabWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/NotificationTabWidget.py
@@ -16,7 +16,7 @@
 
 from qtpy.QtCore import Slot, Signal, QObject, QTimer
 from qtpy.QtWidgets import QTabWidget
-from qtpy.QtGui import QColor
+from qtpy.QtGui import QColor, QIcon
 
 
 class NotificationTabWidget(QTabWidget):
@@ -25,7 +25,6 @@ class NotificationTabWidget(QTabWidget):
         super().__init__(*args, **kwargs)
         self._normal_colours = {}
         self._special_color = QColor(250, 10, 50)
-        self.tabBarClicked.connect(self.reset_current_color)
 
     def addTab(self, widget: "QObject", name: str) -> int:
         object_id = super().addTab(widget, name)
@@ -37,12 +36,17 @@ class NotificationTabWidget(QTabWidget):
     @Slot(int)
     def set_special_color(self, tab_index: int):
         self.tabBar().setTabTextColor(tab_index, self._special_color)
+        self.tabBar().setTabIcon(
+            tab_index, QIcon.fromTheme(QIcon.ThemeIcon.DialogInformation)
+        )
 
     @Slot(int)
     def reset_current_color(self):
         tab_index = self.tabBar().currentIndex()
         self.tabBar().setTabTextColor(tab_index, self._normal_colours[tab_index])
+        self.tabBar().setTabIcon(tab_index, QIcon())
 
     @Slot(int)
     def reset_color(self, tab_index: int):
         self.tabBar().setTabTextColor(tab_index, self._normal_colours[tab_index])
+        self.tabBar().setTabIcon(tab_index, QIcon())

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/NotificationTabWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/NotificationTabWidget.py
@@ -1,0 +1,48 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from qtpy.QtCore import Slot, Signal, QObject, QTimer
+from qtpy.QtWidgets import QTabWidget
+from qtpy.QtGui import QColor
+
+
+class NotificationTabWidget(QTabWidget):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._normal_colours = {}
+        self._special_color = QColor(250, 10, 50)
+        self.tabBarClicked.connect(self.reset_current_color)
+
+    def addTab(self, widget: "QObject", name: str) -> int:
+        object_id = super().addTab(widget, name)
+        self._normal_colours[object_id] = self.tabBar().tabTextColor(object_id)
+        widget._tab_reference.set_my_id(object_id)
+        widget._tab_reference.notify_user.connect(self.set_special_color)
+        return object_id
+
+    @Slot(int)
+    def set_special_color(self, tab_index: int):
+        self.tabBar().setTabTextColor(tab_index, self._special_color)
+
+    @Slot(int)
+    def reset_current_color(self):
+        tab_index = self.tabBar().currentIndex()
+        self.tabBar().setTabTextColor(tab_index, self._normal_colours[tab_index])
+
+    @Slot(int)
+    def reset_color(self, tab_index: int):
+        self.tabBar().setTabTextColor(tab_index, self._normal_colours[tab_index])


### PR DESCRIPTION
**Description of work**
Basic mechanism has been added to inform users about job start and objects appearing in other tabs.

closes #593

**Fixes**
1. "RUN!" button becomes inactive after job start, and the text changes to "starting" for 3 seconds.
2. Tabs which received new input now change the text colour and show an info icon.

**To test**
Run a converter. It should highlight the running job tab on start, and trajectory tab on job completion.
Run an analysis. It should highlight the running job tab on start, and plot creator tab on job completion.
Plot the results. Both creating a new plot and sending data to the plot should highlight the plot holder tab.
Check that the tab text and icon get reset correctly when clicked on.
