### PR TITLE
General GUI optimisations and atom selection inversion button

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/selector.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/selector.py
@@ -110,7 +110,7 @@ class Selector:
         }
 
         # figure out if a match exists for the selector function
-        self.match_exists = self.full_settings
+        self.match_exists = self.create_default_settings()
         for k0, v0 in self.match_exists.items():
             if isinstance(v0, dict):
                 for k1 in v0.keys():
@@ -118,9 +118,25 @@ class Selector:
             else:
                 self.match_exists[k0] = self._funcs[k0](self.system, check_exists=True)
 
+        self.settings = self.create_default_settings()
+
+    def create_default_settings(self) -> dict[str, Union[bool, dict]]:
+        """Create a new settings dictionary with default settings.
+
+        Returns
+        -------
+        dict[str, Union[bool, dict]]
+            A settings dictionary.
+        """
+        settings = copy.deepcopy(self._default)
+        for k, vs in self._kwarg_vals.items():
+            for v in sorted(vs):
+                settings[k][v] = False
+        return settings
+
     def reset_settings(self) -> None:
         """Resets the settings back to the defaults."""
-        self.settings = copy.deepcopy(self._default)
+        self.settings = self.create_default_settings()
 
     def update_settings(
         self, settings: dict[str, Union[bool, dict]], reset_first: bool = False
@@ -192,10 +208,14 @@ class Selector:
         idxs : set[int]
             With the indexes of the atom selection.
         """
-        new_settings = copy.deepcopy(self.settings)
+        new_settings = self.create_default_settings()
+        new_settings["all"] = False
+
         added = set([])
-        prev_selected = set([])
         for k, v in self.settings.items():
+
+            if k == "index":
+                continue
 
             if isinstance(v, dict):
                 args = [{self._kwarg_keys[k]: i} for i in v.keys()]
@@ -209,20 +229,17 @@ class Selector:
                     continue
 
                 selection = self._funcs[k](self.system, **arg)
-                if idxs.issuperset(selection):
-                    added.update(selection)
+                if not idxs.issuperset(selection):
                     continue
 
-                prev_selected.update(selection)
+                added.update(selection)
                 if isinstance(v, dict):
-                    new_settings[k][arg[self._kwarg_keys[k]]] = False
+                    new_settings[k][arg[self._kwarg_keys[k]]] = True
                 else:
-                    new_settings[k] = False
+                    new_settings[k] = True
 
         for idx in idxs - added:
             new_settings["index"][idx] = True
-        for idx in prev_selected - idxs:
-            new_settings["index"][idx] = False
 
         self.settings = new_settings
 
@@ -245,7 +262,7 @@ class Selector:
                     if v1:
                         sub_list.append(k1)
                 if sub_list:
-                    minimal_dict[k0] = sub_list
+                    minimal_dict[k0] = sorted(sub_list)
         return json.dumps(minimal_dict)
 
     def json_to_settings(self, json_string: str) -> dict[str, Union[bool, dict]]:
@@ -337,18 +354,3 @@ class Selector:
         except ValueError:
             return False
         return self.check_valid_setting(settings)
-
-    @property
-    def full_settings(self) -> dict[str, Union[bool, dict]]:
-        """
-        Returns
-        -------
-        dict[str, Union[bool, dict]]
-            The full settings for the initialised chemical system.
-        """
-        settings = copy.deepcopy(self.settings)
-        for k, vs in self._kwarg_vals.items():
-            for v in sorted(vs):
-                if v not in settings[k]:
-                    settings[k][v] = False
-        return settings

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
@@ -274,9 +274,6 @@ class IConfigurator(dict, metaclass=SubclassFactory):
     def set_configurable(self, configurable):
         self._configurable = configurable
 
-    def preview_output_axis(self):
-        return None, None
-
     def check_dependencies(self, configured=None):
         """
         Check that the configurators on which this configurator depends on have already been configured.

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -178,10 +178,11 @@ class IJob(Configurable, metaclass=SubclassFactory):
     def preview_output_axis(self):
         axes = {}
         for configurator in self._configuration.values():
-            axis, unit = configurator.preview_output_axis()
-            if axis is None:
-                continue
-            axes[unit] = axis
+            preview_method = getattr(configurator, "preview_output_axis", None)
+            if callable(preview_method):
+                axis, unit = preview_method()
+                if axis is not None:
+                    axes[unit] = axis
         return axes
 
     @classmethod

--- a/MDANSE/Tests/UnitTests/AtomSelector/test_selector.py
+++ b/MDANSE/Tests/UnitTests/AtomSelector/test_selector.py
@@ -124,7 +124,7 @@ def test_selector_json_dump_3(protein_chemical_system):
         {"all": False, "element": {"S": True, "H": True}, "water": True}
     )
     json_dump = selector.settings_to_json()
-    assert json_dump == '{"all": false, "water": true, "element": ["S", "H"]}'
+    assert json_dump == '{"all": false, "water": true, "element": ["H", "S"]}'
 
 
 def test_selector_json_dump_4(protein_chemical_system):
@@ -140,7 +140,7 @@ def test_selector_json_dump_4(protein_chemical_system):
     json_dump = selector.settings_to_json()
     assert (
         json_dump
-        == '{"all": false, "water": true, "element": ["S", "H"], "index": [0, 1]}'
+        == '{"all": false, "water": true, "element": ["H", "S"], "index": [0, 1]}'
     )
 
 
@@ -149,7 +149,7 @@ def test_selector_json_dump_with_second_update(protein_chemical_system):
     selector.update_settings({"all": False})
     selector.update_settings({"element": {"S": True, "O": True}, "water": True})
     json_dump = selector.settings_to_json()
-    assert json_dump == '{"all": false, "water": true, "element": ["S", "O"]}'
+    assert json_dump == '{"all": false, "water": true, "element": ["O", "S"]}'
 
 
 def test_selector_json_dump_with_third_update(protein_chemical_system):

--- a/MDANSE/Tests/UnitTests/AtomSelector/test_selector.py
+++ b/MDANSE/Tests/UnitTests/AtomSelector/test_selector.py
@@ -275,7 +275,7 @@ def test_selector_returns_true_with_correct_json_setting_0(protein_chemical_syst
 def test_selector_returns_true_with_correct_json_setting_1(protein_chemical_system):
     selector = Selector(protein_chemical_system)
     assert selector.check_valid_json_settings(
-        '{"all": false, "index": {"0": true, "1": true}}'
+        '{"all": false, "index": [0, 1]}'
     )
 
 
@@ -289,14 +289,14 @@ def test_selector_returns_false_with_incorrect_json_setting_0(protein_chemical_s
 def test_selector_returns_false_with_incorrect_json_setting_1(protein_chemical_system):
     selector = Selector(protein_chemical_system)
     assert not selector.check_valid_json_settings(
-        '{"all": false, "index": {0: true, "1": true}}'
+        '{"all": false, "index": [0, "1"]}'
     )
 
 
 def test_selector_returns_false_with_incorrect_json_setting_2(protein_chemical_system):
     selector = Selector(protein_chemical_system)
     assert not selector.check_valid_json_settings(
-        '{"all": False, "index": {"0": true, "1": true}}'
+        '{"all": False, "index": ["0", "1"]}'
     )
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -23,7 +23,7 @@ from qtpy.QtWidgets import (
     QHBoxLayout,
     QGroupBox,
     QLabel,
-    QTextEdit,
+    QPlainTextEdit,
     QWidget,
 )
 from MDANSE.Framework.AtomSelector import Selector
@@ -92,8 +92,9 @@ class SelectionHelper(QDialog):
         self.selector = selector
         self._field = field
         self.settings = self.selector.settings
+        self.atm_full_names = [atm.full_name for atm in self.selector.system.atom_list]
 
-        self.selection_textbox = QTextEdit()
+        self.selection_textbox = QPlainTextEdit()
         self.selection_textbox.setReadOnly(True)
 
         mol_view = MolecularViewerWithPicking()
@@ -299,10 +300,9 @@ class SelectionHelper(QDialog):
         """
         num_sel = len(idxs)
         text = [f"Number of atoms selected:\n{num_sel}\n\nSelected atoms:\n"]
-        atoms = self.selector.system.atom_list
         for idx in idxs:
-            text.append(f"{idx}  ({atoms[idx].full_name})\n")
-        self.selection_textbox.setText("".join(text))
+            text.append(f"{idx}  ({self.atm_full_names[idx]})\n")
+        self.selection_textbox.setPlainText("".join(text))
 
     def apply(self) -> None:
         """Set the field of the AtomSelectionWidget to the currently

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -118,6 +118,7 @@ class SelectionHelper(QDialog):
         self.update_others()
 
         self.all_selection = True
+        self.selected = set([])
 
     def closeEvent(self, a0):
         """Hide the window instead of closing. Some issues occur in the
@@ -226,6 +227,14 @@ class SelectionHelper(QDialog):
                 combo_layout.addWidget(combo)
                 select_layout.addLayout(combo_layout)
 
+        invert_layout = QHBoxLayout()
+        label = QLabel("Invert selection:")
+        apply = QPushButton("Apply")
+        apply.clicked.connect(self.invert_selection)
+        invert_layout.addWidget(label)
+        invert_layout.addWidget(apply)
+        select_layout.addLayout(invert_layout)
+
         select.setLayout(select_layout)
         return [select]
 
@@ -246,9 +255,9 @@ class SelectionHelper(QDialog):
                 self.settings[combo_box.objectName()][key] = combo_box.checked[i]
 
         self.selector.update_settings(self.settings)
-        idxs = self.selector.get_idxs()
-        self.view_3d._viewer.change_picked(idxs)
-        self.update_selection_textbox(idxs)
+        self.selected = self.selector.get_idxs()
+        self.view_3d._viewer.change_picked(self.selected)
+        self.update_selection_textbox()
 
     def update_from_3d_view(self, selection: set[int]) -> None:
         """A selection/deselection was made in the 3d view, update the
@@ -262,7 +271,17 @@ class SelectionHelper(QDialog):
         self.selector.update_with_idxs(selection)
         self.settings = self.selector.settings
         self.update_selection_widgets()
-        self.update_selection_textbox(self.selector.get_idxs())
+        self.selected = self.selector.get_idxs()
+        self.update_selection_textbox()
+
+    def invert_selection(self):
+        """Inverts the selection."""
+        self.selected = self.selector.all_idxs - self.selected
+        self.selector.update_with_idxs(self.selected)
+        self.settings = self.selector.settings
+        self.update_selection_widgets()
+        self.view_3d._viewer.change_picked(self.selected)
+        self.update_selection_textbox()
 
     def update_selection_widgets(self) -> None:
         """Updates the selection widgets so that it matches the full
@@ -290,17 +309,11 @@ class SelectionHelper(QDialog):
             combo_box.update_line_edit()
             combo_box.model().blockSignals(False)
 
-    def update_selection_textbox(self, idxs: set[int]) -> None:
-        """Update the selection textbox.
-
-        Parameters
-        ----------
-        idxs : set[int]
-            The selected indexes.
-        """
-        num_sel = len(idxs)
+    def update_selection_textbox(self) -> None:
+        """Update the selection textbox."""
+        num_sel = len(self.selected)
         text = [f"Number of atoms selected:\n{num_sel}\n\nSelected atoms:\n"]
-        for idx in idxs:
+        for idx in self.selected:
             text.append(f"{idx}  ({self.atm_full_names[idx]})\n")
         self.selection_textbox.setPlainText("".join(text))
 
@@ -317,9 +330,9 @@ class SelectionHelper(QDialog):
         self.selector.settings["all"] = self.all_selection
         self.settings = self.selector.settings
         self.update_selection_widgets()
-        idxs = self.selector.get_idxs()
-        self.view_3d._viewer.change_picked(idxs)
-        self.update_selection_textbox(idxs)
+        self.selected = self.selector.get_idxs()
+        self.view_3d._viewer.change_picked(self.selected)
+        self.update_selection_textbox()
 
 
 class AtomSelectionWidget(WidgetBase):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -236,15 +236,13 @@ class SelectionHelper(QDialog):
         for check_box in self.check_boxes:
             self.settings[check_box.objectName()] = check_box.isChecked()
         for combo_box in self.combo_boxes:
-            for item in combo_box.getItems():
-                txt = item.text()
+            for i in range(combo_box.n_items):
+                txt = combo_box.text[i]
                 if combo_box.objectName() == "index":
                     key = int(txt)
                 else:
                     key = txt
-                self.settings[combo_box.objectName()][key] = (
-                    item.checkState() == Qt.Checked
-                )
+                self.settings[combo_box.objectName()][key] = combo_box.checked[i]
 
         self.selector.update_settings(self.settings)
         idxs = self.selector.get_idxs()
@@ -278,16 +276,15 @@ class SelectionHelper(QDialog):
             check_box.blockSignals(False)
         for combo_box in self.combo_boxes:
             combo_box.model().blockSignals(True)
-            for item in combo_box.getItems():
-                txt = item.text()
+            for i in range(combo_box.n_items):
+                txt = combo_box.text[i]
                 if combo_box.objectName() == "index":
                     key = int(txt)
                 else:
                     key = txt
-                if self.settings[combo_box.objectName()][key]:
-                    item.setCheckState(Qt.Checked)
-                else:
-                    item.setCheckState(Qt.Unchecked)
+                combo_box.set_item_checked_state(
+                    i, self.settings[combo_box.objectName()][key]
+                )
             combo_box.update_all_selected()
             combo_box.update_line_edit()
             combo_box.model().blockSignals(False)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -91,7 +91,7 @@ class SelectionHelper(QDialog):
 
         self.selector = selector
         self._field = field
-        self.full_settings = self.selector.full_settings
+        self.settings = self.selector.settings
 
         self.selection_textbox = QTextEdit()
         self.selection_textbox.setReadOnly(True)
@@ -187,7 +187,7 @@ class SelectionHelper(QDialog):
         self.check_boxes = []
         self.combo_boxes = []
 
-        for k, v in self.full_settings.items():
+        for k, v in self.settings.items():
 
             if isinstance(v, bool):
                 check_layout = QHBoxLayout()
@@ -234,7 +234,7 @@ class SelectionHelper(QDialog):
         the current selection and the 3d view to match the selection.
         """
         for check_box in self.check_boxes:
-            self.full_settings[check_box.objectName()] = check_box.isChecked()
+            self.settings[check_box.objectName()] = check_box.isChecked()
         for combo_box in self.combo_boxes:
             for item in combo_box.getItems():
                 txt = item.text()
@@ -242,11 +242,11 @@ class SelectionHelper(QDialog):
                     key = int(txt)
                 else:
                     key = txt
-                self.full_settings[combo_box.objectName()][key] = (
+                self.settings[combo_box.objectName()][key] = (
                     item.checkState() == Qt.Checked
                 )
 
-        self.selector.update_settings(self.full_settings)
+        self.selector.update_settings(self.settings)
         idxs = self.selector.get_idxs()
         self.view_3d._viewer.change_picked(idxs)
         self.update_selection_textbox(idxs)
@@ -261,7 +261,7 @@ class SelectionHelper(QDialog):
             Selection indexes from the 3d view.
         """
         self.selector.update_with_idxs(selection)
-        self.full_settings = self.selector.full_settings
+        self.settings = self.selector.settings
         self.update_selection_widgets()
         self.update_selection_textbox(self.selector.get_idxs())
 
@@ -271,7 +271,7 @@ class SelectionHelper(QDialog):
         """
         for check_box in self.check_boxes:
             check_box.blockSignals(True)
-            if self.full_settings[check_box.objectName()]:
+            if self.settings[check_box.objectName()]:
                 check_box.setCheckState(Qt.Checked)
             else:
                 check_box.setCheckState(Qt.Unchecked)
@@ -284,7 +284,7 @@ class SelectionHelper(QDialog):
                     key = int(txt)
                 else:
                     key = txt
-                if self.full_settings[combo_box.objectName()][key]:
+                if self.settings[combo_box.objectName()][key]:
                     item.setCheckState(Qt.Checked)
                 else:
                     item.setCheckState(Qt.Unchecked)
@@ -311,14 +311,14 @@ class SelectionHelper(QDialog):
         """Set the field of the AtomSelectionWidget to the currently
         chosen setting in this widget.
         """
-        self.selector.update_settings(self.full_settings)
+        self.selector.update_settings(self.settings)
         self._field.setText(self.selector.settings_to_json())
 
     def reset(self) -> None:
         """Resets the helper to the default state."""
         self.selector.reset_settings()
         self.selector.settings["all"] = self.all_selection
-        self.full_settings = self.selector.full_settings
+        self.settings = self.selector.settings
         self.update_selection_widgets()
         idxs = self.selector.get_idxs()
         self.view_3d._viewer.change_picked(idxs)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomTransmutationWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomTransmutationWidget.py
@@ -126,7 +126,7 @@ class TransmutationHelper(SelectionHelper):
         transmutation setting.
         """
         self.transmuter.apply_transmutation(
-            self.full_settings, self.transmutation_combo.currentText()
+            self.settings, self.transmutation_combo.currentText()
         )
         self.update_transmutation_textbox()
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/CheckableComboBox.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/CheckableComboBox.py
@@ -97,7 +97,7 @@ class CheckableComboBox(QComboBox):
         Parameters
         ----------
         idx : int
-            Index of the items in the self.items list.
+            Index of the item in the self.items list.
         set_checked : bool
             Checks the item if true.
         """

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/CheckableComboBox.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/CheckableComboBox.py
@@ -29,6 +29,7 @@ class CheckableComboBox(QComboBox):
         self.lineEdit().setReadOnly(True)
         self.view().viewport().installEventFilter(self)
         self.view().setAutoScroll(False)
+        self.item_text_castable_to_int = True
         # it's faster to access the items through this python list than
         # through self.model().item(idx)
         self._items = []
@@ -99,6 +100,11 @@ class CheckableComboBox(QComboBox):
         text : str
             The text of the item to add.
         """
+        if text != "select all" and self.item_text_castable_to_int:
+            try:
+                int(text)
+            except ValueError:
+                self.item_text_castable_to_int = False
         item = QStandardItem()
         item.setText(text)
         item.setEnabled(True)
@@ -128,26 +134,13 @@ class CheckableComboBox(QComboBox):
                 continue
             yield self._items[i]
 
-    def check_items_castable_to_int(self) -> bool:
-        """
-        Returns
-        -------
-        bool
-            Returns true if the text of all items can be cast to int.
-        """
-        try:
-            [int(i.text()) for i in self.getItems()]
-            return True
-        except ValueError:
-            return False
-
     def update_line_edit(self) -> None:
         """Updates the lineEdit text of the combobox."""
         vals = []
         for item in self.getItems():
             if item.checkState() == Qt.Checked:
                 vals.append(item.text())
-        if self.check_items_castable_to_int():
+        if self.item_text_castable_to_int:
             vals = [int(i) for i in vals]
             # changes for example 1,2,3,5,6,7,9,10 -> 1-3,5-7,9-10
             gr = (list(x) for _, x in groupby(vals, lambda x, c=count(): next(c) - x))

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/CheckableComboBox.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/CheckableComboBox.py
@@ -13,7 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-from typing import Union, Iterator
+from typing import Union
 from itertools import count, groupby
 from qtpy.QtCore import Qt, QEvent, QObject
 from qtpy.QtGui import QStandardItem
@@ -32,7 +32,13 @@ class CheckableComboBox(QComboBox):
         self.item_text_castable_to_int = True
         # it's faster to access the items through this python list than
         # through self.model().item(idx)
-        self._items = []
+        self.items = []
+        # for a large number of items accessing the checked status and
+        # text seems quite slow. We mirror the data in these lists for
+        # improved performances.
+        self.checked = []
+        self.text = []
+        self.select_all_item = None
         self.addItem("select all", underline=True)
         self.lineEdit().setText("")
 
@@ -47,25 +53,27 @@ class CheckableComboBox(QComboBox):
             A QT event.
         """
         if a0 == self.view().viewport() and a1.type() == QEvent.MouseButtonRelease:
-            idx = self.view().indexAt(a1.pos())
-            item = self.model().item(idx.row())
+            idx = self.view().indexAt(a1.pos()).row()
+            item = self.model().item(idx)
 
             if item.checkState() == Qt.Checked:
-                check_uncheck = Qt.Unchecked
+                set_checked = False
             else:
-                check_uncheck = Qt.Checked
+                set_checked = True
 
-            if idx.row() == 0:
+            if idx == 0:
                 # need to block signals temporarily otherwise as we
                 # need to make a change on all the items which could
                 # cause alot of signals to be emitted
                 self.model().blockSignals(True)
-                for i in self.getItems():
-                    i.setCheckState(check_uncheck)
+                for i in range(self.n_items):
+                    self.set_item_checked_state(i, set_checked)
                 self.model().blockSignals(False)
-                item.setCheckState(check_uncheck)
+                self.select_all_item.setCheckState(
+                    Qt.Checked if set_checked else Qt.Unchecked
+                )
             else:
-                item.setCheckState(check_uncheck)
+                self.set_item_checked_state(idx - 1, set_checked)
                 self.update_all_selected()
 
             self.update_line_edit()
@@ -73,12 +81,39 @@ class CheckableComboBox(QComboBox):
 
         return super().eventFilter(a0, a1)
 
+    @property
+    def n_items(self) -> int:
+        """
+        Returns
+        -------
+        int
+            Number of items not including the select all item.
+        """
+        return len(self.items)
+
+    def set_item_checked_state(self, idx: int, set_checked: bool):
+        """Checks the item and updates the checked list.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the items in the self.items list.
+        set_checked : bool
+            Checks the item if true.
+        """
+        self.checked[idx] = set_checked
+        if set_checked:
+            check_uncheck = Qt.Checked
+        else:
+            check_uncheck = Qt.Unchecked
+        self.items[idx].setCheckState(check_uncheck)
+
     def update_all_selected(self):
         """check/uncheck select all since everything is/isn't selected."""
-        if all([i.checkState() == Qt.Checked for i in self.getItems()]):
-            self.model().item(0).setCheckState(Qt.Checked)
+        if all(self.checked):
+            self.select_all_item.setCheckState(Qt.Checked)
         else:
-            self.model().item(0).setCheckState(Qt.Unchecked)
+            self.select_all_item.setCheckState(Qt.Unchecked)
 
     def addItems(self, texts: list[str]) -> None:
         """
@@ -100,11 +135,6 @@ class CheckableComboBox(QComboBox):
         text : str
             The text of the item to add.
         """
-        if text != "select all" and self.item_text_castable_to_int:
-            try:
-                int(text)
-            except ValueError:
-                self.item_text_castable_to_int = False
         item = QStandardItem()
         item.setText(text)
         item.setEnabled(True)
@@ -119,35 +149,30 @@ class CheckableComboBox(QComboBox):
                 font.setUnderline(underline)
             item.setFont(font)
         self.model().appendRow(item)
-        self._items.append(item)
 
-    def getItems(self) -> Iterator[QStandardItem]:
-        """
-        Yields
-        ------
-        QStandardItem
-            Yields the items in the combobox except for the zeroth
-            item because that is the select all item.
-        """
-        for i in range(self.model().rowCount()):
-            if i == 0:  # skips the select all item
-                continue
-            yield self._items[i]
+        if text == "select all":
+            self.select_all_item = item
+        else:
+            self.items.append(item)
+            self.checked.append(False)
+            self.text.append(text)
+            if self.item_text_castable_to_int:
+                try:
+                    int(text)
+                except ValueError:
+                    self.item_text_castable_to_int = False
 
     def update_line_edit(self) -> None:
         """Updates the lineEdit text of the combobox."""
-        vals = []
-        for item in self.getItems():
-            if item.checkState() == Qt.Checked:
-                vals.append(item.text())
+        text = [i for i, j in zip(self.text, self.checked) if j]
         if self.item_text_castable_to_int:
-            vals = [int(i) for i in vals]
+            vals = [int(i) for i in text]
             # changes for example 1,2,3,5,6,7,9,10 -> 1-3,5-7,9-10
             gr = (list(x) for _, x in groupby(vals, lambda x, c=count(): next(c) - x))
             text = ",".join("-".join(map(str, (g[0], g[-1])[: len(g)])) for g in gr)
             self.lineEdit().setText(text)
         else:
-            self.lineEdit().setText(",".join(vals))
+            self.lineEdit().setText(",".join(text))
 
     def set_default(self, default: str) -> None:
         """Checks the item with the text equal to the default parameter.
@@ -157,15 +182,12 @@ class CheckableComboBox(QComboBox):
         default : str
             Parameter used to check items in the combobox.
         """
-        model = self.model()
-        for row_number in range(model.rowCount()):
-            index = model.index(row_number, 0)
-            item = model.itemFromIndex(index)
-            text = model.data(index)
+        for i in range(self.n_items):
+            text = self.text[i]
             if text == default:
-                item.setCheckState(Qt.Checked)
+                self.set_item_checked_state(i, True)
             else:
-                item.setCheckState(Qt.Unchecked)
+                self.set_item_checked_state(i, False)
         self.update_line_edit()
 
     def checked_values(self) -> list[str]:
@@ -176,13 +198,7 @@ class CheckableComboBox(QComboBox):
             List of items texts that are checked.
         """
         result = []
-        model = self.model()
-        for row_number in range(model.rowCount()):
-            if row_number == 0:
-                continue
-            index = model.index(row_number, 0)
-            item = model.itemFromIndex(index)
-            if item.checkState() == Qt.Checked:
-                text = model.data(index)
-                result.append(text)
+        for i in range(self.n_items):
+            if self.checked[i]:
+                result.append(self.text[i])
         return result

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/CheckableComboBox.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/CheckableComboBox.py
@@ -101,11 +101,15 @@ class CheckableComboBox(QComboBox):
         set_checked : bool
             Checks the item if true.
         """
-        self.checked[idx] = set_checked
+        if self.checked[idx] == set_checked:
+            return
+
         if set_checked:
             check_uncheck = Qt.Checked
         else:
             check_uncheck = Qt.Unchecked
+
+        self.checked[idx] = set_checked
         self.items[idx].setCheckState(check_uncheck)
 
     def update_all_selected(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/PartialChargeWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/PartialChargeWidget.py
@@ -122,7 +122,7 @@ class ChargeHelper(SelectionHelper):
         except ValueError:
             # probably an empty QLineEdit box
             return
-        self.mapper.update_charges(self.full_settings, charge)
+        self.mapper.update_charges(self.settings, charge)
         self.update_charge_textbox()
 
     def update_charge_textbox(self) -> None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -212,7 +212,7 @@ class ViewerControls(QWidget):
         layout2 = QHBoxLayout(wrapper2)
         frame_time_selector = QSpinBox(base)
         frame_time_selector.setToolTip("Larger number means slower animation")
-        frame_time_selector.setValue(5)
+        frame_time_selector.setValue(80)
         frame_time_selector.setMinimum(1)
         frame_time_selector.setMaximum(5000)
         frame_time_selector.valueChanged.connect(self.setTimeStep)

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -384,7 +384,8 @@ class MolecularViewer(QtWidgets.QWidget):
             # do not bond atoms to dummy atoms
             rs = coords[self.not_du]
             bonds, bonds_exist = self.create_bond_cell_array(
-                rs, self.covs[self.not_du], self.not_du)
+                rs, self.covs[self.not_du], self.not_du
+            )
             if bonds_exist:
                 self._polydata.SetLines(bonds)
                 self._polydata_bonds_exist = True
@@ -639,10 +640,12 @@ class MolecularViewer(QtWidgets.QWidget):
                 for at in self._atoms
             ]
         ).astype(np.float32)
-        self.du_log = np.array([
-            CHEMICAL_ELEMENTS.get_atom_property(at, "element") != "dummy"
-            for at in self._reader.atom_types
-        ])
+        self.du_log = np.array(
+            [
+                CHEMICAL_ELEMENTS.get_atom_property(at, "element") != "dummy"
+                for at in self._reader.atom_types
+            ]
+        )
         self.not_du = np.array(
             [
                 i

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -383,7 +383,8 @@ class MolecularViewer(QtWidgets.QWidget):
         if self._bonds_visible:
             # do not bond atoms to dummy atoms
             rs = coords[self.not_du]
-            bonds, bonds_exist = self.create_bond_cell_array(rs, self.covs, self.not_du)
+            bonds, bonds_exist = self.create_bond_cell_array(
+                rs, self.covs[self.not_du], self.not_du)
             if bonds_exist:
                 self._polydata.SetLines(bonds)
                 self._polydata_bonds_exist = True
@@ -638,6 +639,10 @@ class MolecularViewer(QtWidgets.QWidget):
                 for at in self._atoms
             ]
         ).astype(np.float32)
+        self.du_log = np.array([
+            CHEMICAL_ELEMENTS.get_atom_property(at, "element") != "dummy"
+            for at in self._reader.atom_types
+        ])
         self.not_du = np.array(
             [
                 i
@@ -650,7 +655,7 @@ class MolecularViewer(QtWidgets.QWidget):
                 CHEMICAL_ELEMENTS.get_atom_property(at, "covalent_radius")
                 for at in self._reader.atom_types
             ]
-        )[self.not_du]
+        )
 
         scalars = ndarray_to_vtkarray(
             self._atom_colours, self._atom_scales, self._n_atoms
@@ -765,50 +770,29 @@ class MolecularViewerWithPicking(MolecularViewer):
         self.update_renderer()
 
     def update_picked_polydata(self):
+        atoms = vtk.vtkPoints()
+
+        if len(self.picked_atoms) == 0:
+            self._picked_polydata.SetPoints(atoms)
+            return
+
         picked = np.array(sorted(list(self.picked_atoms)))
         coords = self._reader.read_frame(self._current_frame)
-
-        atoms = vtk.vtkPoints()
-        atoms.SetNumberOfPoints(len(self.picked_atoms))
-        for i, j in enumerate(picked):
-            x, y, z = coords[j, :]
-            atoms.SetPoint(i, x, y, z)
+        atoms.SetData(numpy_support.numpy_to_vtk(coords[picked]))
         self._picked_polydata.SetPoints(atoms)
 
-        picked_colours = []
-        picked_radii = []
-        for i in sorted(list(self.picked_atoms)):
-            picked_colours.append(self._colour_manager.colours[i])
-            picked_radii.append(self._colour_manager.radii[i])
         scalars = ndarray_to_vtkarray(
-            np.array(picked_colours),
-            np.array(picked_radii),
+            self._colour_manager.colours[picked],
+            self._colour_manager.radii[picked],
             np.arange(len(self.picked_atoms)),
         )
         self._picked_polydata.GetPointData().SetScalars(scalars)
 
-        not_du = np.array(
-            [
-                i
-                for i, j in enumerate(picked)
-                if CHEMICAL_ELEMENTS.get_atom_property(
-                    self._reader.atom_types[j], "element"
-                )
-                != "dummy"
-            ]
-        )
-
+        not_du = np.arange(len(self.picked_atoms))[self.du_log[picked]]
         if self._bonds_visible and len(not_du) >= 1:
             # do not bond atoms to dummy atoms
             rs = coords[picked][not_du]
-            covs = np.array(
-                [
-                    CHEMICAL_ELEMENTS.get_atom_property(
-                        self._reader.atom_types[i], "covalent_radius"
-                    )
-                    for i in picked
-                ]
-            )[not_du]
+            covs = self.covs[picked][not_du]
 
             bonds, bonds_exist = self.create_bond_cell_array(rs, covs, not_du)
             if bonds_exist:

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -410,13 +410,16 @@ class MolecularViewer(QtWidgets.QWidget):
             ks[start : start + n_idxs] = idxs
             start += n_idxs
 
+        mask = js < ks
+        js = js[mask]
+        ks = ks[mask]
         diff = rs[js] - rs[ks]
         dist = np.sum(diff * diff, axis=1)
         sum_radii = (covs[js] + covs[ks] + tolerance) ** 2
         js = js[(0 < dist) & (dist < sum_radii)]
         ks = ks[(0 < dist) & (dist < sum_radii)]
-        ls = not_du[js[js < ks]]
-        ms = not_du[ks[js < ks]]
+        ls = not_du[js]
+        ms = not_du[ks]
 
         n_points = len(ls)
         idxs = np.zeros((len(ls), 3), dtype=np.int64)

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -23,6 +23,7 @@ from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QSizePolicy
 
 import vtk
+from vtk.util import numpy_support
 from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 from vtkmodules.vtkRenderingAnnotation import vtkAxesActor
 
@@ -376,31 +377,13 @@ class MolecularViewer(QtWidgets.QWidget):
 
         if self._atoms_visible or self._bonds_visible:
             atoms = vtk.vtkPoints()
-            atoms.SetNumberOfPoints(self._n_atoms)
-            for i in range(self._n_atoms):
-                x, y, z = coords[i, :]
-                atoms.SetPoint(i, x, y, z)
-
+            atoms.SetData(numpy_support.numpy_to_vtk(coords))
             self._polydata.SetPoints(atoms)
 
         if self._bonds_visible:
             # do not bond atoms to dummy atoms
-            not_du = np.array(
-                [
-                    i
-                    for i, at in enumerate(self._reader.atom_types)
-                    if CHEMICAL_ELEMENTS.get_atom_property(at, "element") != "dummy"
-                ]
-            )
-            rs = coords[not_du]
-            covs = np.array(
-                [
-                    CHEMICAL_ELEMENTS.get_atom_property(at, "covalent_radius")
-                    for at in self._reader.atom_types
-                ]
-            )[not_du]
-
-            bonds, bonds_exist = self.create_bond_cell_array(rs, covs, not_du)
+            rs = coords[self.not_du]
+            bonds, bonds_exist = self.create_bond_cell_array(rs, self.covs, self.not_du)
             if bonds_exist:
                 self._polydata.SetLines(bonds)
                 self._polydata_bonds_exist = True
@@ -410,25 +393,42 @@ class MolecularViewer(QtWidgets.QWidget):
 
     def create_bond_cell_array(self, rs, covs, not_du, tolerance=0.04):
         # determine and set bonds without PBC applied
-        tree = KDTree(rs)
         bonds = vtk.vtkCellArray()
+
+        tree = KDTree(rs)
         contacts = tree.query_ball_tree(tree, 2 * np.max(covs) + tolerance)
-        n_bonds = 0
+        n_dists = sum([len(i) for i in contacts])
+
+        js = np.zeros(n_dists, dtype=int)
+        ks = np.zeros(n_dists, dtype=int)
+        start = 0
         for i, idxs in enumerate(contacts):
-            if len(idxs) == 0:
+            n_idxs = len(idxs)
+            if n_idxs == 0:
                 continue
-            diff = rs[i] - rs[idxs]
-            dist = np.sum(diff * diff, axis=1)
-            sum_radii = (covs[i] + covs[idxs] + tolerance) ** 2
-            js = np.array(idxs)[(0 < dist) & (dist < sum_radii)]
-            js = not_du[js[i < js]]
-            n_bonds += len(js)
-            for j in js:
-                line = vtk.vtkLine()
-                line.GetPointIds().SetId(0, not_du[i])
-                line.GetPointIds().SetId(1, j)
-                bonds.InsertNextCell(line)
-        return bonds, n_bonds > 0
+            js[start: start + n_idxs] = i
+            ks[start: start + n_idxs] = idxs
+            start += n_idxs
+
+        diff = rs[js] - rs[ks]
+        dist = np.sum(diff * diff, axis=1)
+        sum_radii = (covs[js] + covs[ks] + tolerance) ** 2
+        js = js[(0 < dist) & (dist < sum_radii)]
+        ks = ks[(0 < dist) & (dist < sum_radii)]
+        ls = not_du[js[js < ks]]
+        ms = not_du[ks[js < ks]]
+
+        n_points = len(ls)
+        idxs = np.zeros((len(ls), 3), dtype=np.int64)
+        idxs[:,0] = 2
+        idxs[:,1] = ls
+        idxs[:,2] = ms
+        bonds.SetCells(
+            n_points,
+            numpy_support.numpy_to_vtkIdTypeArray(idxs.flatten())
+        )
+
+        return bonds, len(ls) > 0
 
     def update_uc_polydata(self):
         uc = self._reader.read_pbc(self._current_frame)
@@ -630,7 +630,7 @@ class MolecularViewer(QtWidgets.QWidget):
         self._atom_colours = self._colour_manager.reinitialise_from_database(
             self._atoms, CHEMICAL_ELEMENTS, self.dummy_size
         )
-        # this returs a list of indices, mapping colours to atoms
+        # this returns a list of indices, mapping colours to atoms
 
         self._atom_scales = np.array(
             [
@@ -638,6 +638,20 @@ class MolecularViewer(QtWidgets.QWidget):
                 for at in self._atoms
             ]
         ).astype(np.float32)
+        self.not_du = np.array(
+            [
+                i
+                for i, at in enumerate(self._reader.atom_types)
+                if
+                CHEMICAL_ELEMENTS.get_atom_property(at, "element") != "dummy"
+            ]
+        )
+        self.covs = np.array(
+            [
+                CHEMICAL_ELEMENTS.get_atom_property(at, "covalent_radius")
+                for at in self._reader.atom_types
+            ]
+        )[self.not_du]
 
         scalars = ndarray_to_vtkarray(
             self._atom_colours, self._atom_scales, self._n_atoms

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -406,8 +406,8 @@ class MolecularViewer(QtWidgets.QWidget):
             n_idxs = len(idxs)
             if n_idxs == 0:
                 continue
-            js[start: start + n_idxs] = i
-            ks[start: start + n_idxs] = idxs
+            js[start : start + n_idxs] = i
+            ks[start : start + n_idxs] = idxs
             start += n_idxs
 
         diff = rs[js] - rs[ks]
@@ -420,13 +420,10 @@ class MolecularViewer(QtWidgets.QWidget):
 
         n_points = len(ls)
         idxs = np.zeros((len(ls), 3), dtype=np.int64)
-        idxs[:,0] = 2
-        idxs[:,1] = ls
-        idxs[:,2] = ms
-        bonds.SetCells(
-            n_points,
-            numpy_support.numpy_to_vtkIdTypeArray(idxs.flatten())
-        )
+        idxs[:, 0] = 2
+        idxs[:, 1] = ls
+        idxs[:, 2] = ms
+        bonds.SetCells(n_points, numpy_support.numpy_to_vtkIdTypeArray(idxs.flatten()))
 
         return bonds, len(ls) > 0
 
@@ -642,8 +639,7 @@ class MolecularViewer(QtWidgets.QWidget):
             [
                 i
                 for i, at in enumerate(self._reader.atom_types)
-                if
-                CHEMICAL_ELEMENTS.get_atom_property(at, "element") != "dummy"
+                if CHEMICAL_ELEMENTS.get_atom_property(at, "element") != "dummy"
             ]
         )
         self.covs = np.array(

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -396,7 +396,7 @@ class MolecularViewer(QtWidgets.QWidget):
         bonds = vtk.vtkCellArray()
 
         tree = KDTree(rs)
-        contacts = tree.query_ball_tree(tree, 2 * np.max(covs) + tolerance)
+        contacts = tree.query_ball_point(rs, 2 * np.max(covs) + tolerance, workers=-1)
         n_dists = sum([len(i) for i in contacts])
 
         js = np.zeros(n_dists, dtype=int)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -225,7 +225,10 @@ class Action(QWidget):
                 self._widgets_in_layout.append(widget)
                 self._widgets.append(input_widget)
                 input_widget.valid_changed.connect(self.allow_execution)
-                if self._use_preview:
+                has_preview = callable(
+                    getattr(input_widget._configurator, "preview_output_axis", False)
+                )
+                if self._use_preview and has_preview:
                     input_widget.value_updated.connect(self.show_output_prediction)
                 LOG.info(f"Set up the right widget for {key}")
             # self.handlers[key] = data_handler
@@ -279,6 +282,18 @@ class Action(QWidget):
             q_vector_tuple = self._current_instrument.create_q_vector_params()
             resolution_tuple = self._current_instrument.create_resolution_params()
             for widget in self._widgets:
+                has_preview = callable(
+                    getattr(widget._configurator, "preview_output_axis", False)
+                )
+                if not has_preview:
+                    continue
+                # These widgets will emit a signal and call
+                # show_output_prediction this means that this function
+                # can be called multiple times. We need to block the
+                # signals from these widgets to stop this from happening
+                # show_output_prediction will be called at the end of
+                # this function.
+                widget.blockSignals(True)
                 if isinstance(widget, InstrumentResolutionWidget):
                     if resolution_tuple is None:
                         continue
@@ -290,6 +305,7 @@ class Action(QWidget):
                     widget._model.switch_qvector_type(
                         q_vector_tuple[0], q_vector_tuple[1]
                     )
+                widget.blockSignals(False)
         self.allow_execution()
         self.show_output_prediction()
 


### PR DESCRIPTION
**Description of work**
- An invert selection button was added to the atom selection.
- Atom selection functions were optimized.
- Checkablecombo box has been optimized.
- Bond calculation in the 3D view has been optimized.
- apply_instrument has been updated so that the prediction output is only determined once.
- Changing certain settings that do not affect the output prediction will be faster as they will skip the output determination step.
- Fixed the time per frame so that the spin box is set to the same value as the value it is set to in the objects __init__. This means it doesn't suddenly change from 80 to 6 when it is changed.

According to my profiling tools, most of the time is taken up by the literal_eval calls in the ChemicalEntity objects. I think we should see a performance improvement with #616. We can make another PR to see what else can be optimized once #616 has been merged.

**To test**
- Load up a large trajectory and go to the 3D view, the trajectory animation with the bond calculation should be faster.
- Go to the actions tab and load up the atom selection helper, atom selections should be slightly more responsive. Check that the inversion button works as expected.
- Check that in a job like DISF, applying an instrument should be much faster as the prediction is only determined once.

