### PR TITLE
GUI optimisation - qvector and instrument resolution type change

### DIFF
--- a/MDANSE/Tests/UnitTests/TrajectoryEditor/test_editor.py
+++ b/MDANSE/Tests/UnitTests/TrajectoryEditor/test_editor.py
@@ -167,7 +167,7 @@ def test_editor_transmute():
 def test_editor_set_charges():
     temp_name = tempfile.mktemp()
     parameters = {}
-    parameters["output_files"] = (temp_name, 64, "gzip", "INFO")
+    parameters["output_files"] = (temp_name, 64, 128, "gzip", "INFO")
     parameters["trajectory"] = short_traj
     parameters["atom_charges"] = (
         '{"0": 1.2, "1": 1.2, "2": 1.2, "3": 1.2, "4": 1.2, "5": 1.2, "6": -0.5, "7": -0.5, "8": -0.5, "9": -0.5, "10": -0.5, "11": -0.5, "12": -0.5, "13": -0.5, "14": -0.5, "15": -0.5, "16": -0.5, "17": -0.5, "18": -0.5, "19": -0.5}'
@@ -194,7 +194,7 @@ def test_editor_set_charges():
 def test_editor_find_molecules():
     temp_name = tempfile.mktemp()
     parameters = {}
-    parameters["output_files"] = (temp_name, 64, "gzip", "INFO")
+    parameters["output_files"] = (temp_name, 64, 128, "gzip", "INFO")
     parameters["trajectory"] = short_traj
     parameters["molecule_tolerance"] = [True, 0.25]
     parameters["frames"] = (0, 501, 1)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InstrumentResolutionWidget.py
@@ -125,6 +125,10 @@ class InstrumentResolutionWidget(WidgetBase):
 
     @Slot(str)
     def change_function(self, function: str, optional_parameters: dict = None):
+        # need to disconnect textChanged otherwise updateValue will
+        # be called multiple times as the field data will be changed
+        # during the function change
+        [field.textChanged.disconnect() for field in self._fields]
         if optional_parameters is None:
             if function in init_parameters.keys():
                 new_params = init_parameters[function]
@@ -141,6 +145,8 @@ class InstrumentResolutionWidget(WidgetBase):
             self._type_combo.setCurrentText(function)
         self._type_combo.blockSignals(False)
         self.set_field_values(new_params)
+        self.updateValue()
+        [field.textChanged.connect(self.updateValue) for field in self._fields]
 
     def get_widget_value(self):
         function = widget_text_map[self._type_combo.currentText()]

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
@@ -124,7 +124,7 @@ class QVectorsWidget(WidgetBase):
         self._selector.currentTextChanged.connect(self._model.switch_qvector_type)
         self._selector.setCurrentIndex(1)
         self._model.itemChanged.connect(self.updateValue)
-        self._model.type_changed.connect(self.updateValue)
+        self._model.type_changed.connect(self.type_change_update)
         self.updateValue()
         if self._tooltip:
             tooltip_text = self._tooltip
@@ -139,6 +139,14 @@ class QVectorsWidget(WidgetBase):
         policy.setVerticalPolicy(QSizePolicy.Policy.Minimum)
         self._view.setSizePolicy(policy)
         self._view.horizontalHeader().hide()
+
+    def type_change_update(self):
+        # need to disconnect itemChanged otherwise updateValue will
+        # be called multiple times as the item data has been changed
+        # during the type update
+        self._model.itemChanged.disconnect()
+        self.updateValue()
+        self._model.itemChanged.connect(self.updateValue)
 
     @Slot(bool)
     def validate_model_parameters(self, all_are_correct: bool):


### PR DESCRIPTION
**Description of work**
Optimized some more parts of the GUI. When the instrument resolution or qvector types are changed their fields are changed so updateValue and the output prediction will be recalculated. I've updated the code so this does not happen. With large trajectories, changing the instrument resolution or qvector type should be a lot faster.

Fixed units tests.

**To test**
Load up a large trajectory and select an action job, change the qvector or instrument resolution type. The change should be a lot faster than before. Check that the prediction output changes with the same values as before.