### PR TITLE
Add MDTraj converter and update to atom mapping code

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
@@ -39,6 +39,9 @@ class AtomLabel:
         if self.grp_label == other.grp_label and self.atm_label == other.atm_label:
             return True
 
+    def __hash__(self):
+        return hash((self.atm_label, self.grp_label, self.mass))
+
 
 def guess_element(atm_label: str, mass: Union[float, int, None] = None) -> str:
     """From an input atom label find a match to an element in the atom
@@ -179,6 +182,29 @@ def fill_remaining_labels(
             mapping[grp_label][atm_label] = guess_element(atm_label, label.mass)
 
 
+def mapping_to_labels(mapping: dict[str, dict[str, str]]) -> list[AtomLabel]:
+    """Converts the mapping back into a list of labels.
+
+    Parameters
+    ----------
+    mapping : dict[str, dict[str, str]]
+        The atom mapping dictionary.
+
+    Returns
+    -------
+    list[AtomLabel]
+        List of atom labels from the mapping.
+    """
+    labels = []
+    for grp_label, atm_map in mapping.items():
+        kwargs = {}
+        for k, v in [i.split("=") for i in grp_label.split(";")]:
+            kwargs[k] = v
+        for atm_label in atm_map.keys():
+            labels.append(AtomLabel(atm_label, **kwargs))
+    return labels
+
+
 def check_mapping_valid(mapping: dict[str, dict[str, str]], labels: list[AtomLabel]):
     """Given a list of labels check that the mapping is valid.
 
@@ -194,11 +220,17 @@ def check_mapping_valid(mapping: dict[str, dict[str, str]], labels: list[AtomLab
     bool
         True if the mapping is valid.
     """
+    pattern = re.compile("[A-Za-z]\w*=\w+(;[A-Za-z]\w*=\w+)*$")
+    if not all([pattern.match(grp_label) for grp_label in mapping.keys()]):
+        return False
+
+    if set(mapping_to_labels(mapping)) != set(labels):
+        return False
+
     for label in labels:
         grp_label = label.grp_label
         atm_label = label.atm_label
-        if grp_label not in mapping or atm_label not in mapping[grp_label]:
-            return False
         if mapping[grp_label][atm_label] not in ATOMS_DATABASE:
             return False
+
     return True

--- a/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
@@ -23,6 +23,18 @@ from MDANSE.Chemistry import ATOMS_DATABASE
 class AtomLabel:
 
     def __init__(self, atm_label: str, **kwargs):
+        """Creates an atom label object which is used for atom mapping
+        and atom type guessing.
+
+        Parameters
+        ----------
+        atm_label : str
+            The main atom label.
+        kwargs : dict
+            The other atom label.
+        """
+        # use translations since it's faster than the alternative
+        # methods as of writing e.g. re.replace
         translation = str.maketrans("", "", ";=")
         self.atm_label = atm_label.translate(translation)
         self.grp_label = f""
@@ -35,12 +47,39 @@ class AtomLabel:
             self.mass = float(self.mass)
 
     def __eq__(self, other: object) -> bool:
+        """Used to check if atom labels are equal.
+
+        Parameters
+        ----------
+        other : AtomLabel
+            The other atom label to compare against.
+
+        Returns
+        -------
+        bool
+            True if all attributes are equal.
+
+        Raises
+        ------
+        AssertionError
+            If the other object is not an AtomLabel.
+        """
         if not isinstance(other, AtomLabel):
             AssertionError(f"{other} should be an instance of AtomLabel.")
-        if self.grp_label == other.grp_label and self.atm_label == other.atm_label:
+        if (
+            self.grp_label == other.grp_label
+            and self.atm_label == other.atm_label
+            and self.mass == other.mass
+        ):
             return True
 
-    def __hash__(self):
+    def __hash__(self) -> int:
+        """
+        Returns
+        -------
+        int
+            A hash of the object in its current state.
+        """
         return hash((self.atm_label, self.grp_label, self.mass))
 
 

--- a/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
@@ -30,7 +30,7 @@ class AtomLabel:
         ----------
         atm_label : str
             The main atom label.
-        kwargs : dict
+        kwargs
             The other atom label.
         """
         # use translations since it's faster than the alternative
@@ -240,8 +240,9 @@ def mapping_to_labels(mapping: dict[str, dict[str, str]]) -> list[AtomLabel]:
     labels = []
     for grp_label, atm_map in mapping.items():
         kwargs = {}
-        for k, v in [i.split("=") for i in grp_label.split(";")]:
-            kwargs[k] = v
+        if grp_label:
+            for k, v in [i.split("=") for i in grp_label.split(";")]:
+                kwargs[k] = v
         for atm_label in atm_map.keys():
             labels.append(AtomLabel(atm_label, **kwargs))
     return labels
@@ -262,7 +263,7 @@ def check_mapping_valid(mapping: dict[str, dict[str, str]], labels: list[AtomLab
     bool
         True if the mapping is valid.
     """
-    pattern = re.compile("[A-Za-z]\w*=[^=;]+(;[A-Za-z]\w*=[^=;]+)*$")
+    pattern = re.compile("^([A-Za-z]\w*=[^=;]+(;[A-Za-z]\w*=[^=;]+)*)*$")
     if not all([pattern.match(grp_label) for grp_label in mapping.keys()]):
         return False
 

--- a/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
@@ -220,7 +220,7 @@ def check_mapping_valid(mapping: dict[str, dict[str, str]], labels: list[AtomLab
     bool
         True if the mapping is valid.
     """
-    pattern = re.compile("[A-Za-z]\w*=\w+(;[A-Za-z]\w*=\w+)*$")
+    pattern = re.compile("[A-Za-z]\w*=.+(;[A-Za-z]\w*=.+)*$")
     if not all([pattern.match(grp_label) for grp_label in mapping.keys()]):
         return False
 

--- a/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
@@ -34,7 +34,7 @@ class AtomLabel:
             The other atom label.
         """
         # use translations since it's faster than the alternative
-        # methods as of writing e.g. re.replace
+        # methods as of writing e.g. re.sub
         translation = str.maketrans("", "", ";=")
         self.atm_label = atm_label.translate(translation)
         self.grp_label = f""

--- a/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
@@ -39,9 +39,6 @@ class AtomLabel:
         if self.grp_label == other.grp_label and self.atm_label == other.atm_label:
             return True
 
-    def __hash__(self):
-        return hash((self.atm_label, self.grp_label, self.mass))
-
 
 def guess_element(atm_label: str, mass: Union[float, int, None] = None) -> str:
     """From an input atom label find a match to an element in the atom
@@ -224,7 +221,9 @@ def check_mapping_valid(mapping: dict[str, dict[str, str]], labels: list[AtomLab
     if not all([pattern.match(grp_label) for grp_label in mapping.keys()]):
         return False
 
-    if set(mapping_to_labels(mapping)) != set(labels):
+    if set(
+        [(i.atm_label, i.grp_label, i.mass) for i in mapping_to_labels(mapping)]
+    ) != set([(i.atm_label, i.grp_label, i.mass) for i in labels]):
         return False
 
     for label in labels:

--- a/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
@@ -72,6 +72,8 @@ class AtomLabel:
             and self.mass == other.mass
         ):
             return True
+        else:
+            return False
 
     def __hash__(self) -> int:
         """

--- a/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
@@ -22,12 +22,12 @@ from MDANSE.Chemistry import ATOMS_DATABASE
 
 class AtomLabel:
 
-    def __init__(self, atm_label, **kwargs):
-        self.atm_label = atm_label
+    def __init__(self, atm_label: str, **kwargs):
+        self.atm_label = re.sub("[;=]", "", atm_label)
         self.grp_label = f""
         if kwargs:
             for k, v in kwargs.items():
-                self.grp_label += f"{k}={v};"
+                self.grp_label += f"{k}={re.sub("[;=]", "", str(v))};"
             self.grp_label = self.grp_label[:-1]
         self.mass = kwargs.get("mass", None)
         if self.mass is not None:
@@ -220,7 +220,7 @@ def check_mapping_valid(mapping: dict[str, dict[str, str]], labels: list[AtomLab
     bool
         True if the mapping is valid.
     """
-    pattern = re.compile("[A-Za-z]\w*=.+(;[A-Za-z]\w*=.+)*$")
+    pattern = re.compile("[A-Za-z]\w*=[^=;]+(;[A-Za-z]\w*=[^=;]+)*$")
     if not all([pattern.match(grp_label) for grp_label in mapping.keys()]):
         return False
 

--- a/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
@@ -23,11 +23,12 @@ from MDANSE.Chemistry import ATOMS_DATABASE
 class AtomLabel:
 
     def __init__(self, atm_label: str, **kwargs):
-        self.atm_label = re.sub("[;=]", "", atm_label)
+        translation = str.maketrans("", "", ";=")
+        self.atm_label = atm_label.translate(translation)
         self.grp_label = f""
         if kwargs:
             for k, v in kwargs.items():
-                self.grp_label += f"{k}={re.sub("[;=]", "", str(v))};"
+                self.grp_label += f"{k}={str(v).translate(translation)};"
             self.grp_label = self.grp_label[:-1]
         self.mass = kwargs.get("mass", None)
         if self.mass is not None:
@@ -38,6 +39,9 @@ class AtomLabel:
             AssertionError(f"{other} should be an instance of AtomLabel.")
         if self.grp_label == other.grp_label and self.atm_label == other.atm_label:
             return True
+
+    def __hash__(self):
+        return hash((self.atm_label, self.grp_label, self.mass))
 
 
 def guess_element(atm_label: str, mass: Union[float, int, None] = None) -> str:
@@ -221,9 +225,7 @@ def check_mapping_valid(mapping: dict[str, dict[str, str]], labels: list[AtomLab
     if not all([pattern.match(grp_label) for grp_label in mapping.keys()]):
         return False
 
-    if set(
-        [(i.atm_label, i.grp_label, i.mass) for i in mapping_to_labels(mapping)]
-    ) != set([(i.atm_label, i.grp_label, i.mass) for i in labels]):
+    if set(mapping_to_labels(mapping)) != set(labels):
         return False
 
     for label in labels:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/ASEFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/ASEFileConfigurator.py
@@ -13,6 +13,8 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from typing import Iterable
+
 from ase.io import iread, read
 from ase.io.trajectory import Trajectory as ASETrajectory
 
@@ -37,16 +39,12 @@ class ASEFileConfigurator(FileWithAtomDataConfigurator):
 
         self["element_list"] = first_frame.get_chemical_symbols()
 
-    def get_atom_labels(self) -> list[AtomLabel]:
+    def atom_labels(self) -> Iterable[AtomLabel]:
         """
-        Returns
-        -------
-        list[AtomLabel]
-            An ordered list of atom labels.
+        Yields
+        ------
+        AtomLabel
+            An atom label.
         """
-        labels = []
         for atm_label in self["element_list"]:
-            label = AtomLabel(atm_label)
-            if label not in labels:
-                labels.append(label)
-        return labels
+            yield AtomLabel(atm_label)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
@@ -56,7 +56,7 @@ class AtomMappingConfigurator(IConfigurator):
             self.error_status = "Input file not selected or valid."
             return
 
-        labels = file_configurator.generate_labels()
+        labels = file_configurator.unique_labels()
         try:
             fill_remaining_labels(value, labels)
         except AttributeError:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
@@ -56,7 +56,7 @@ class AtomMappingConfigurator(IConfigurator):
             self.error_status = "Input file not selected."
             return
 
-        labels = file_configurator.get_atom_labels()
+        labels = file_configurator.get_labels()
         try:
             fill_remaining_labels(value, labels)
         except AttributeError:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
@@ -56,7 +56,7 @@ class AtomMappingConfigurator(IConfigurator):
             self.error_status = "Input file not selected."
             return
 
-        labels = file_configurator.get_labels()
+        labels = file_configurator.labels
         try:
             fill_remaining_labels(value, labels)
         except AttributeError:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
@@ -53,10 +53,10 @@ class AtomMappingConfigurator(IConfigurator):
 
         file_configurator = self._configurable[self._dependencies["input_file"]]
         if not file_configurator._valid:
-            self.error_status = "Input file not selected."
+            self.error_status = "Input file not selected or valid."
             return
 
-        labels = file_configurator.labels
+        labels = file_configurator.generate_labels()
         try:
             fill_remaining_labels(value, labels)
         except AttributeError:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomMappingConfigurator.py
@@ -56,7 +56,7 @@ class AtomMappingConfigurator(IConfigurator):
             self.error_status = "Input file not selected or valid."
             return
 
-        labels = file_configurator.unique_labels()
+        labels = file_configurator.labels
         try:
             fill_remaining_labels(value, labels)
         except AttributeError:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/ConfigFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/ConfigFileConfigurator.py
@@ -13,12 +13,13 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from typing import Iterable
 import re
+
 import numpy as np
 
 from MDANSE.Core.Error import Error
 from MDANSE.Framework.AtomMapping import AtomLabel
-
 from .FileWithAtomDataConfigurator import FileWithAtomDataConfigurator
 from MDANSE.MLogging import LOG
 
@@ -186,16 +187,12 @@ class ConfigFileConfigurator(FileWithAtomDataConfigurator):
             except:
                 LOG.error(f"LAMMPS ConfigFileConfigurator failed to find a unit cell")
 
-    def get_atom_labels(self) -> list[AtomLabel]:
+    def atom_labels(self) -> Iterable[AtomLabel]:
         """
-        Returns
-        -------
-        list[AtomLabel]
-            An ordered list of atom labels.
+        Yields
+        ------
+        AtomLabel
+            An atom label.
         """
-        labels = []
         for idx, mass in self["elements"]:
-            label = AtomLabel(str(idx), mass=mass)
-            if label not in labels:
-                labels.append(label)
-        return labels
+            yield AtomLabel(str(idx), mass=mass)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FieldFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FieldFileConfigurator.py
@@ -13,6 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from typing import Iterable
 import re
 
 import numpy as np
@@ -23,7 +24,6 @@ from MDANSE.Chemistry.ChemicalEntity import (
 )
 from MDANSE.Core.Error import Error
 from MDANSE.Framework.AtomMapping import get_element_from_mapping, AtomLabel
-
 from .FileWithAtomDataConfigurator import FileWithAtomDataConfigurator
 
 
@@ -114,20 +114,16 @@ class FieldFileConfigurator(FileWithAtomDataConfigurator):
 
             first = last + 1
 
-    def get_atom_labels(self) -> list[AtomLabel]:
+    def atom_labels(self) -> Iterable[AtomLabel]:
         """
-        Returns
-        -------
-        list[AtomLabel]
-            An ordered list of atom labels.
+        Yields
+        ------
+        AtomLabel
+            An atom label.
         """
-        labels = []
         for mol_name, _, atomic_contents, masses, _ in self["molecules"]:
             for atm_label, mass in zip(atomic_contents, masses):
-                label = AtomLabel(atm_label, molecule=mol_name, mass=mass)
-                if label not in labels:
-                    labels.append(label)
-        return labels
+                yield AtomLabel(atm_label, molecule=mol_name, mass=mass)
 
     def get_atom_charges(self) -> np.ndarray:
         """Returns an array of partial electric charges

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
@@ -40,8 +40,7 @@ class FileWithAtomDataConfigurator(InputFileConfigurator):
             self.error_status = f"File parsing error {e}: {traceback.format_exc()}"
             return
 
-        self.labels = self.generate_labels()
-        if len(self.labels) == 0:
+        if len(self.generate_labels()) == 0:
             self.error_status = f"Unable to generate atom labels"
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
@@ -40,7 +40,8 @@ class FileWithAtomDataConfigurator(InputFileConfigurator):
             self.error_status = f"File parsing error {e}: {traceback.format_exc()}"
             return
 
-        if len(self.unique_labels()) == 0:
+        self.labels = self.unique_labels()
+        if len(self.labels) == 0:
             self.error_status = f"Unable to generate atom labels"
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
@@ -13,6 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from typing import Iterable
 from abc import abstractmethod
 import traceback
 
@@ -44,6 +45,18 @@ class FileWithAtomDataConfigurator(InputFileConfigurator):
         pass
 
     @abstractmethod
-    def get_atom_labels(self) -> list[AtomLabel]:
-        """Return the atoms labels in the file."""
-        pass
+    def atom_labels(self) -> Iterable[AtomLabel]:
+        """Yields atom labels"""
+
+    def get_labels(self) -> list[AtomLabel]:
+        """
+        Returns
+        -------
+        list[AtomLabel]
+            An ordered list of atom labels.
+        """
+        labels = set()
+        for label in self.atom_labels():
+            if label not in labels:
+                labels.add(label)
+        return list(labels)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
@@ -40,7 +40,7 @@ class FileWithAtomDataConfigurator(InputFileConfigurator):
             self.error_status = f"File parsing error {e}: {traceback.format_exc()}"
             return
 
-        if len(self.generate_labels()) == 0:
+        if len(self.unique_labels()) == 0:
             self.error_status = f"Unable to generate atom labels"
             return
 
@@ -53,7 +53,7 @@ class FileWithAtomDataConfigurator(InputFileConfigurator):
     def atom_labels(self) -> Iterable[AtomLabel]:
         """Yields atom labels"""
 
-    def generate_labels(self) -> list[AtomLabel]:
+    def unique_labels(self) -> list[AtomLabel]:
         """
         Returns
         -------

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
@@ -38,6 +38,12 @@ class FileWithAtomDataConfigurator(InputFileConfigurator):
             self.parse()
         except Exception as e:
             self.error_status = f"File parsing error {e}: {traceback.format_exc()}"
+            return
+
+        self.labels = self.generate_labels()
+        if len(self.labels) == 0:
+            self.error_status = f"Unable to generate atom labels"
+            return
 
     @abstractmethod
     def parse(self) -> None:
@@ -48,7 +54,7 @@ class FileWithAtomDataConfigurator(InputFileConfigurator):
     def atom_labels(self) -> Iterable[AtomLabel]:
         """Yields atom labels"""
 
-    def get_labels(self) -> list[AtomLabel]:
+    def generate_labels(self) -> list[AtomLabel]:
         """
         Returns
         -------

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
@@ -60,8 +60,4 @@ class FileWithAtomDataConfigurator(InputFileConfigurator):
         list[AtomLabel]
             An ordered list of atom labels.
         """
-        labels = set()
-        for label in self.atom_labels():
-            if label not in labels:
-                labels.add(label)
-        return list(labels)
+        return list(set(self.atom_labels()))

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisCoordinateFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisCoordinateFileConfigurator.py
@@ -13,17 +13,15 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-import ast
-import os
 from typing import Union
 
 import MDAnalysis as mda
 
-from MDANSE import PLATFORM
 from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
+from .MultiInputFileConfigurator import MultiInputFileConfigurator
 
 
-class MDAnalysisCoordinateFileConfigurator(IConfigurator):
+class MDAnalysisCoordinateFileConfigurator(MultiInputFileConfigurator):
 
     _default = ("", "AUTO")
 
@@ -41,50 +39,7 @@ class MDAnalysisCoordinateFileConfigurator(IConfigurator):
             string of the coordinate file format.
         """
         values, format = setting
-
-        self["values"] = self._default
-        self._original_input = values
-
-        if type(values) is str:
-            if values:
-                try:
-                    # some issues when \ is used in the path as this
-                    # can be interpreted as an escape character by
-                    # literal_eval, on windows we can use \ or / so lets
-                    # just swap them here
-                    values = ast.literal_eval(values.replace("\\", "/"))
-                except (SyntaxError, ValueError) as e:
-                    self.error_status = f"Unable to evaluate string: {e}"
-                    return
-                if type(values) is not list:
-                    self.error_status = (
-                        f"Input values should be able to be evaluated as a list"
-                    )
-                    return
-            else:
-                values = []
-
-        if type(values) is list:
-            if not all([type(value) is str for value in values]):
-                self.error_status = f"Input values should be a list of str"
-                return
-        else:
-            self.error_status = f"Input values should be able to be evaluated as a list"
-            return
-
-        values = [PLATFORM.get_path(value) for value in values]
-
-        none_exist = []
-        for value in values:
-            if not os.path.isfile(value):
-                none_exist.append(value)
-
-        if none_exist:
-            self.error_status = f"The files {', '.join(none_exist)} do not exist."
-            return
-
-        self["values"] = values
-        self["filenames"] = values
+        super().configure(values)
 
         if format == "AUTO" or not self["filenames"]:
             self["format"] = None
@@ -99,7 +54,7 @@ class MDAnalysisCoordinateFileConfigurator(IConfigurator):
         if topology_configurator._valid:
             try:
                 if len(self["filenames"]) <= 1 or self["format"] is None:
-                    traj = mda.Universe(
+                    _ = mda.Universe(
                         topology_configurator["filename"],
                         *self["filenames"],
                         format=self["format"],
@@ -107,7 +62,7 @@ class MDAnalysisCoordinateFileConfigurator(IConfigurator):
                     ).trajectory
                 else:
                     coord_files = [(i, self["format"]) for i in self["filenames"]]
-                    traj = mda.Universe(
+                    _ = mda.Universe(
                         topology_configurator["filename"],
                         coord_files,
                         topology_format=topology_configurator["format"],
@@ -119,8 +74,6 @@ class MDAnalysisCoordinateFileConfigurator(IConfigurator):
             if self["values"]:
                 self.error_status = "Requires valid topology file."
                 return
-
-        self.error_status = "OK"
 
     @property
     def wildcard(self):

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisCoordinateFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisCoordinateFileConfigurator.py
@@ -23,7 +23,7 @@ from MDANSE import PLATFORM
 from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
 
 
-class CoordinateFileConfigurator(IConfigurator):
+class MDAnalysisCoordinateFileConfigurator(IConfigurator):
 
     _default = ("", "AUTO")
 
@@ -48,7 +48,11 @@ class CoordinateFileConfigurator(IConfigurator):
         if type(values) is str:
             if values:
                 try:
-                    values = ast.literal_eval(values)
+                    # some issues when \ is used in the path as this
+                    # can be interpreted as an escape character by
+                    # literal_eval, on windows we can use \ or / so lets
+                    # just swap them here
+                    values = ast.literal_eval(values.replace("\\", "/"))
                 except (SyntaxError, ValueError) as e:
                     self.error_status = f"Unable to evaluate string: {e}"
                     return

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTopologyFileConfigurator.py
@@ -19,7 +19,7 @@ from MDANSE.Framework.AtomMapping import AtomLabel
 from .FileWithAtomDataConfigurator import FileWithAtomDataConfigurator
 
 
-class TopologyFileConfigurator(FileWithAtomDataConfigurator):
+class MDAnalysisTopologyFileConfigurator(FileWithAtomDataConfigurator):
 
     _default = ("", "AUTO")
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTopologyFileConfigurator.py
@@ -60,16 +60,19 @@ class MDAnalysisTopologyFileConfigurator(FileWithAtomDataConfigurator):
         AtomLabel
             An atom label.
         """
+        args = []
+        for arg in ["element", "name", "type", "resname", "mass"]:
+            if hasattr(self.atoms[0], arg):
+                args.append(arg)
+        if len(args) == 0:
+            yield from []
+            return
+
         for at in self.atoms:
             kwargs = {}
-            for arg in ["element", "name", "type", "resname", "mass"]:
-                if hasattr(at, arg):
-                    kwargs[arg] = getattr(at, arg)
+            for arg in args:
+                kwargs[arg] = getattr(at, arg)
             # the first out of the list above will be the main label
-            try:
-                (k, main_label) = next(iter(kwargs.items()))
-                kwargs.pop(k)
-                yield AtomLabel(main_label, **kwargs)
-            except StopIteration:
-                yield from []
-                return
+            (k, main_label) = next(iter(kwargs.items()))
+            kwargs.pop(k)
+            yield AtomLabel(main_label, **kwargs)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTopologyFileConfigurator.py
@@ -13,6 +13,8 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from typing import Iterable
+
 import MDAnalysis as mda
 
 from MDANSE.Framework.AtomMapping import AtomLabel
@@ -51,14 +53,13 @@ class MDAnalysisTopologyFileConfigurator(FileWithAtomDataConfigurator):
             self["filename"], topology_format=self["format"]
         ).atoms
 
-    def get_atom_labels(self) -> list[AtomLabel]:
+    def atom_labels(self) -> Iterable[AtomLabel]:
         """
-        Returns
-        -------
-        list[AtomLabel]
-            An ordered list of atom labels.
+        Yields
+        ------
+        AtomLabel
+            An atom label.
         """
-        labels = []
         for at in self.atoms:
             kwargs = {}
             for arg in ["element", "name", "type", "resname", "mass"]:
@@ -67,7 +68,4 @@ class MDAnalysisTopologyFileConfigurator(FileWithAtomDataConfigurator):
             # the first out of the list above will be the main label
             (k, main_label) = next(iter(kwargs.items()))
             kwargs.pop(k)
-            label = AtomLabel(main_label, **kwargs)
-            if label not in labels:
-                labels.append(label)
-        return labels
+            yield AtomLabel(main_label, **kwargs)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTopologyFileConfigurator.py
@@ -66,6 +66,10 @@ class MDAnalysisTopologyFileConfigurator(FileWithAtomDataConfigurator):
                 if hasattr(at, arg):
                     kwargs[arg] = getattr(at, arg)
             # the first out of the list above will be the main label
-            (k, main_label) = next(iter(kwargs.items()))
-            kwargs.pop(k)
-            yield AtomLabel(main_label, **kwargs)
+            try:
+                (k, main_label) = next(iter(kwargs.items()))
+                kwargs.pop(k)
+                yield AtomLabel(main_label, **kwargs)
+            except StopIteration:
+                yield from []
+                return

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDFileConfigurator.py
@@ -13,6 +13,8 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from typing import Iterable
+
 import itertools
 import re
 import numpy as np
@@ -191,16 +193,12 @@ class MDFileConfigurator(FileWithAtomDataConfigurator):
         """Closes the file."""
         self["instance"].close()
 
-    def get_atom_labels(self) -> list[AtomLabel]:
+    def atom_labels(self) -> Iterable[AtomLabel]:
         """
-        Returns
-        -------
-        list[AtomLabel]
-            An ordered list of atom labels.
+        Yields
+        ------
+        AtomLabel
+            An atom label.
         """
-        labels = []
         for atm_label, _ in self["atoms"]:
-            label = AtomLabel(atm_label)
-            if label not in labels:
-                labels.append(label)
-        return labels
+            yield AtomLabel(atm_label)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTimeStepConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTimeStepConfigurator.py
@@ -1,0 +1,58 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import mdtraj as md
+
+from MDANSE.Framework.Configurators.FloatConfigurator import FloatConfigurator
+
+
+class MDTrajTimeStepConfigurator(FloatConfigurator):
+
+    _default = 0.0
+
+    def configure(self, value):
+        # if the value is not valid then we use the MDTraj
+        # default values which maybe the time step in the inputted
+        # files or 1 ps
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            pass
+
+        if value is None or value == "" or value == 0.0:
+            coord_conf = self._configurable[self._dependencies["coordinate_files"]]
+            top_conf = self._configurable[self._dependencies["topology_file"]]
+            if coord_conf._valid and top_conf._valid:
+                traj_files = coord_conf["filenames"]
+                top_file = top_conf["filename"]
+                try:
+                    if top_file:
+                        traj = md.load(traj_files, top=top_file)
+                    else:
+                        traj = md.load(traj_files)
+                    if traj.n_frames == 1:
+                        value = self._default
+                    else:
+                        value = traj.timestep
+                except Exception as e:
+                    self.error_status = (
+                        f"Unable to determine a time step from MDTraj: {e}"
+                    )
+                    return
+            else:
+                self.error_status = f"Unable to determine a time step from MDTraj"
+                return
+
+        super().configure(value)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTimeStepConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTimeStepConfigurator.py
@@ -45,7 +45,7 @@ class MDTrajTimeStepConfigurator(FloatConfigurator):
                     if traj.n_frames == 1:
                         value = self._default
                     else:
-                        value = traj.timestep
+                        value = float(traj.timestep)
                 except Exception as e:
                     self.error_status = (
                         f"Unable to determine a time step from MDTraj: {e}"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -90,7 +90,7 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
         list[AtomLabel]
             An ordered list of atom labels.
         """
-        labels = []
+        labels = set()
         for at in self.atoms:
             label = AtomLabel(
                 at.name,
@@ -100,5 +100,5 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
                 mass=at.element.mass,
             )
             if label not in labels:
-                labels.append(label)
-        return labels
+                labels.add(label)
+        return list(labels)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -39,6 +39,7 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
             return
 
         if not value:
+            self.error_status = "OK"
             self["filename"] = value
 
             extension = self._configurable[
@@ -53,11 +54,15 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
                 )
                 return
 
-            self.error_status = "OK"
             try:
                 self.parse()
             except Exception as e:
                 self.error_status = f"File parsing error {e}: {traceback.format_exc()}"
+                return
+
+            self.labels = self.unique_labels()
+            if len(self.labels) == 0:
+                self.error_status = f"Unable to generate atom labels"
 
         else:
             extension = "".join(Path(value).suffixes)[1:]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -71,17 +71,17 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
             super().configure(value)
 
     def parse(self) -> None:
-        trajectory_file = self._configurable[self._dependencies["trajectory_files"]][
-            "filename"
+        trajectory_files = self._configurable[self._dependencies["trajectory_files"]][
+            "filenames"
         ]
         if self["filename"]:
             self.atoms = [
                 at
-                for at in md.load(trajectory_file, top=self["filename"]).topology.atoms
+                for at in md.load(trajectory_files, top=self["filename"]).topology.atoms
             ]
 
         else:
-            self.atoms = [at for at in md.load(trajectory_file).topology.atoms]
+            self.atoms = [at for at in md.load(trajectory_files).topology.atoms]
 
     def atom_labels(self) -> Iterable[AtomLabel]:
         """

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -13,6 +13,8 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from typing import Optional
+import traceback
 from pathlib import Path
 
 import mdtraj as md
@@ -24,18 +26,52 @@ from .FileWithAtomDataConfigurator import FileWithAtomDataConfigurator
 
 class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
 
+    def configure(self, value: Optional[str]):
+        """
+        Parameters
+        ----------
+        value : str or None
+            The path of the MDTraj topology file can be None if
+            topology information is contained in the trajectory files.
+        """
+        if not self._configurable[self._dependencies["trajectory_files"]].valid:
+            self.error_status = "Trajectory file not valid"
+            return
+
+        if not value:
+            self["filename"] = value
+
+            extension = "".join(
+                Path(
+                    self._configurable[self._dependencies["trajectory_files"]][
+                        "filename"
+                    ]
+                ).suffixes
+            )[1:]
+            supported = list(i[1:] for i in _TOPOLOGY_EXTS)
+            if extension not in supported:
+                self.error_status = (
+                    f"Trajectory file does not contain topology information. "
+                    f"File '{extension}' not support should be one of the following: {supported}"
+                )
+                return
+
+            self.error_status = "OK"
+            try:
+                self.parse()
+            except Exception as e:
+                self.error_status = f"File parsing error {e}: {traceback.format_exc()}"
+            return
+
+        else:
+            extension = "".join(Path(value).suffixes)[1:]
+            supported = list(i[1:] for i in _TOPOLOGY_EXTS)
+            if extension not in supported:
+                self.error_status = f"File '{extension}' not support should be one of the following: {supported}"
+                return
+            super().configure(value)
+
     def parse(self) -> None:
-        extension = "".join(Path(self["value"]).suffixes)[1:]
-
-        supported = list(i[1:] for i in _TOPOLOGY_EXTS)
-        if extension not in supported:
-            raise ValueError(
-                f"File '{extension}' not support should be one of the following: {supported}"
-            )
-
-        if not self._configurable[self._dependencies["trajectory_files"]]._valid:
-            raise RuntimeError(f"Trajectory file not valid")
-
         trajectory_file = self._configurable[self._dependencies["trajectory_files"]][
             "filename"
         ]
@@ -54,7 +90,11 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
         labels = []
         for at in self.atoms:
             label = AtomLabel(
-                at.name, symbol=at.element.symbol, residue=at.residue.name
+                at.name,
+                symbol=at.element.symbol,
+                residue=at.residue.name,
+                number=at.element.number,
+                mass=at.element.mass,
             )
             if label not in labels:
                 labels.append(label)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -13,7 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-from typing import Optional
+from typing import Optional, Iterable
 import traceback
 from pathlib import Path
 
@@ -83,22 +83,18 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
         else:
             self.atoms = [at for at in md.load(trajectory_file).topology.atoms]
 
-    def get_atom_labels(self) -> list[AtomLabel]:
+    def atom_labels(self) -> Iterable[AtomLabel]:
         """
-        Returns
-        -------
-        list[AtomLabel]
-            An ordered list of atom labels.
+        Yields
+        ------
+        AtomLabel
+            An atom label.
         """
-        labels = set()
         for at in self.atoms:
-            label = AtomLabel(
+            yield AtomLabel(
                 at.name,
                 symbol=at.element.symbol,
                 residue=at.residue.name,
                 number=at.element.number,
                 mass=at.element.mass,
             )
-            if label not in labels:
-                labels.add(label)
-        return list(labels)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -34,7 +34,7 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
             The path of the MDTraj topology file can be None if
             topology information is contained in the trajectory files.
         """
-        if not self._configurable[self._dependencies["trajectory_files"]].valid:
+        if not self._configurable[self._dependencies["coordinate_files"]].valid:
             self.error_status = "Trajectory file not valid"
             return
 
@@ -43,7 +43,7 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
             self["filename"] = value
 
             extension = self._configurable[
-                self._dependencies["trajectory_files"]
+                self._dependencies["coordinate_files"]
             ].extension
 
             supported = list(i[1:] for i in _TOPOLOGY_EXTS)
@@ -73,17 +73,17 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
             super().configure(value)
 
     def parse(self) -> None:
-        trajectory_files = self._configurable[self._dependencies["trajectory_files"]][
+        coord_files = self._configurable[self._dependencies["coordinate_files"]][
             "filenames"
         ]
         if self["filename"]:
             self.atoms = [
                 at
-                for at in md.load(trajectory_files, top=self["filename"]).topology.atoms
+                for at in md.load(coord_files, top=self["filename"]).topology.atoms
             ]
 
         else:
-            self.atoms = [at for at in md.load(trajectory_files).topology.atoms]
+            self.atoms = [at for at in md.load(coord_files).topology.atoms]
 
     def atom_labels(self) -> Iterable[AtomLabel]:
         """

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -41,13 +41,10 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
         if not value:
             self["filename"] = value
 
-            extension = "".join(
-                Path(
-                    self._configurable[self._dependencies["trajectory_files"]][
-                        "filename"
-                    ]
-                ).suffixes
-            )[1:]
+            extension = self._configurable[
+                self._dependencies["trajectory_files"]
+            ].extension
+
             supported = list(i[1:] for i in _TOPOLOGY_EXTS)
             if extension not in supported:
                 self.error_status = (

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -78,8 +78,7 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
         ]
         if self["filename"]:
             self.atoms = [
-                at
-                for at in md.load(coord_files, top=self["filename"]).topology.atoms
+                at for at in md.load(coord_files, top=self["filename"]).topology.atoms
             ]
 
         else:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -1,0 +1,61 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from pathlib import Path
+
+import mdtraj as md
+from mdtraj.core.trajectory import _TOPOLOGY_EXTS
+
+from MDANSE.Framework.AtomMapping import AtomLabel
+from .FileWithAtomDataConfigurator import FileWithAtomDataConfigurator
+
+
+class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
+
+    def parse(self) -> None:
+        extension = "".join(Path(self["value"]).suffixes)[1:]
+
+        supported = list(i[1:] for i in _TOPOLOGY_EXTS)
+        if extension not in supported:
+            raise ValueError(
+                f"File '{extension}' not support should be one of the following: {supported}"
+            )
+
+        if not self._configurable[self._dependencies["trajectory_files"]]._valid:
+            raise RuntimeError(f"Trajectory file not valid")
+
+        trajectory_file = self._configurable[self._dependencies["trajectory_files"]][
+            "filename"
+        ]
+        if self["filename"]:
+            self.atoms = md.load(trajectory_file, top=self["filename"]).topology.atoms
+        else:
+            self.atoms = md.load(trajectory_file).topology.atoms
+
+    def get_atom_labels(self) -> list[AtomLabel]:
+        """
+        Returns
+        -------
+        list[AtomLabel]
+            An ordered list of atom labels.
+        """
+        labels = []
+        for at in self.atoms:
+            label = AtomLabel(
+                at.name, symbol=at.element.symbol, residue=at.residue.name
+            )
+            if label not in labels:
+                labels.append(label)
+        return labels

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -61,7 +61,6 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
                 self.parse()
             except Exception as e:
                 self.error_status = f"File parsing error {e}: {traceback.format_exc()}"
-            return
 
         else:
             extension = "".join(Path(value).suffixes)[1:]
@@ -76,9 +75,13 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
             "filename"
         ]
         if self["filename"]:
-            self.atoms = md.load(trajectory_file, top=self["filename"]).topology.atoms
+            self.atoms = [
+                at
+                for at in md.load(trajectory_file, top=self["filename"]).topology.atoms
+            ]
+
         else:
-            self.atoms = md.load(trajectory_file).topology.atoms
+            self.atoms = [at for at in md.load(trajectory_file).topology.atoms]
 
     def get_atom_labels(self) -> list[AtomLabel]:
         """

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTrajectoryFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTrajectoryFileConfigurator.py
@@ -29,9 +29,9 @@ class MDTrajTrajectoryFileConfigurator(MultiInputFileConfigurator):
         if len(extensions) != 1:
             self.error_status = f"Files should be of a single format."
             return
-        extension = next(iter(extensions))
+        self.extension = next(iter(extensions))
 
         supported = list(i[1:] for i in FormatRegistry.loaders.keys())
-        if extension not in supported:
-            self.error_status = f"File '{extension}' not support should be one of the following: {supported}"
+        if self.extension not in supported:
+            self.error_status = f"File '{self.extension}' not support should be one of the following: {supported}"
             return

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTrajectoryFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTrajectoryFileConfigurator.py
@@ -17,16 +17,19 @@ from pathlib import Path
 
 from mdtraj.formats.registry import FormatRegistry
 
+from .MultiInputFileConfigurator import MultiInputFileConfigurator
 
-from .InputFileConfigurator import InputFileConfigurator
 
-
-class MDTrajTrajectoryFileConfigurator(InputFileConfigurator):
+class MDTrajTrajectoryFileConfigurator(MultiInputFileConfigurator):
 
     def configure(self, value):
         super().configure(value)
 
-        extension = "".join(Path(self["value"]).suffixes)[1:]
+        extensions = {"".join(Path(value).suffixes)[1:] for value in self["values"]}
+        if len(extensions) != 1:
+            self.error_status = f"Files should be of a single format."
+            return
+        extension = next(iter(extensions))
 
         supported = list(i[1:] for i in FormatRegistry.loaders.keys())
         if extension not in supported:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTrajectoryFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTrajectoryFileConfigurator.py
@@ -1,0 +1,34 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from pathlib import Path
+
+from mdtraj.formats.registry import FormatRegistry
+
+
+from .InputFileConfigurator import InputFileConfigurator
+
+
+class MDTrajTrajectoryFileConfigurator(InputFileConfigurator):
+
+    def configure(self, value):
+        super().configure(value)
+
+        extension = "".join(Path(self["value"]).suffixes)[1:]
+
+        supported = list(i[1:] for i in FormatRegistry.loaders.keys())
+        if extension not in supported:
+            self.error_status = f"File '{extension}' not support should be one of the following: {supported}"
+            return

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MultiInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MultiInputFileConfigurator.py
@@ -1,0 +1,102 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import ast
+import os
+from typing import Union
+
+from MDANSE import PLATFORM
+from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
+
+
+class MultiInputFileConfigurator(IConfigurator):
+
+    _default = ""
+
+    def __init__(self, name, wildcard="All files (*)", **kwargs):
+        IConfigurator.__init__(self, name, **kwargs)
+        self._wildcard = wildcard
+
+    def configure(self, setting: Union[str, list]):
+        """
+        Parameters
+        ----------
+        setting : Union[str, list]
+            A list of file names or a string of the list which can be
+            converted to a list using literal_eval and a string of the
+            coordinate file format.
+        """
+        values = setting
+        self["values"] = self._default
+        self._original_input = values
+
+        if type(values) is str:
+            if values:
+                try:
+                    # some issues when \ is used in the path as this
+                    # can be interpreted as an escape character by
+                    # literal_eval, on windows we can use \ or / so lets
+                    # just swap them here
+                    values = ast.literal_eval(values.replace("\\", "/"))
+                except (SyntaxError, ValueError) as e:
+                    self.error_status = f"Unable to evaluate string: {e}"
+                    return
+                if type(values) is not list:
+                    self.error_status = (
+                        f"Input values should be able to be evaluated as a list"
+                    )
+                    return
+            else:
+                values = []
+
+        if type(values) is list:
+            if not all([type(value) is str for value in values]):
+                self.error_status = f"Input values should be a list of str"
+                return
+        else:
+            self.error_status = f"Input values should be able to be evaluated as a list"
+            return
+
+        values = [PLATFORM.get_path(value) for value in values]
+
+        none_exist = []
+        for value in values:
+            if not os.path.isfile(value):
+                none_exist.append(value)
+
+        if none_exist:
+            self.error_status = f"The files {', '.join(none_exist)} do not exist."
+            return
+
+        self["values"] = values
+        self["filenames"] = values
+        self.error_status = "OK"
+
+    @property
+    def wildcard(self):
+        return self._wildcard
+
+    def get_information(self) -> str:
+        """
+        Returns
+        -------
+        str
+           Input file names.
+        """
+        try:
+            filenames = self["value"]
+        except KeyError:
+            filenames = ["None"]
+        return f"Input files: {', '.join(filenames)}.\n"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/XDATCARFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/XDATCARFileConfigurator.py
@@ -13,6 +13,8 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from typing import Iterable
+
 import numpy as np
 
 from MDANSE.Core.Error import Error
@@ -133,16 +135,12 @@ class XDATCARFileConfigurator(FileWithAtomDataConfigurator):
     def close(self):
         self["instance"].close()
 
-    def get_atom_labels(self) -> list[AtomLabel]:
+    def atom_labels(self) -> Iterable[AtomLabel]:
         """
-        Returns
-        -------
-        list[AtomLabel]
-            An ordered list of atom labels.
+        Yields
+        ------
+        AtomLabel
+            An atom label.
         """
-        labels = []
         for symbol in self["atoms"]:
-            label = AtomLabel(symbol)
-            if label not in labels:
-                labels.append(label)
-        return labels
+            yield AtomLabel(symbol)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/XTDFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/XTDFileConfigurator.py
@@ -13,6 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from typing import Iterable
 import collections
 import xml.etree.ElementTree as ElementTree
 
@@ -186,19 +187,15 @@ class XTDFileConfigurator(FileWithAtomDataConfigurator):
         realConf.fold_coordinates()
         self._chemicalSystem.configuration = realConf
 
-    def get_atom_labels(self) -> list[AtomLabel]:
+    def atom_labels(self) -> Iterable[AtomLabel]:
         """
-        Returns
-        -------
-        list[AtomLabel]
-            An ordered list of atom labels.
+        Yields
+        ------
+        AtomLabel
+            An atom label.
         """
-        labels = []
         for info in self._atoms.values():
-            label = AtomLabel(info["element"], type=info["atom_name"])
-            if label not in labels:
-                labels.append(label)
-        return labels
+            yield AtomLabel(info["element"], type=info["atom_name"])
 
     def get_atom_charges(self) -> np.ndarray:
         """Returns an array of partial electric charges

--- a/MDANSE/Src/MDANSE/Framework/Configurators/XYZFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/XYZFileConfigurator.py
@@ -13,7 +13,9 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from typing import Iterable
 import re
+
 import numpy as np
 
 from MDANSE.Core.Error import Error
@@ -140,16 +142,12 @@ class XYZFileConfigurator(FileWithAtomDataConfigurator):
         """Closes the file that was, until now, open for reading."""
         self["instance"].close()
 
-    def get_atom_labels(self) -> list[AtomLabel]:
+    def atom_labels(self) -> Iterable[AtomLabel]:
         """
-        Returns
-        -------
-        list[AtomLabel]
-            An ordered list of atom labels.
+        Yields
+        ------
+        AtomLabel
+            An atom label.
         """
-        labels = []
         for atm_label in self["atoms"]:
-            label = AtomLabel(atm_label)
-            if label not in labels:
-                labels.append(label)
-        return labels
+            yield AtomLabel(atm_label)

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
@@ -42,7 +42,7 @@ class MDAnalysis(Converter):
     label = "MDAnalysis"
     settings = collections.OrderedDict()
     settings["topology_file"] = (
-        "TopologyFileConfigurator",
+        "MDAnalysisTopologyFileConfigurator",
         {
             "wildcard": "All files (*)",
             "default": "INPUT_FILENAME",
@@ -50,7 +50,7 @@ class MDAnalysis(Converter):
         },
     )
     settings["coordinate_files"] = (
-        "CoordinateFileConfigurator",
+        "MDAnalysisCoordinateFileConfigurator",
         {
             "wildcard": "All files (*)",
             "default": "",

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -43,7 +43,7 @@ class MDTraj(Converter):
         "MDTrajTrajectoryFileConfigurator",
         {
             "wildcard": "All files (*)",
-            "default": "INPUT_FILENAME",
+            "default": '["INPUT_FILENAME"]',
             "label": "Trajectory files",
         },
     )
@@ -68,9 +68,9 @@ class MDTraj(Converter):
         "BooleanConfigurator",
         {"default": False, "label": "Fold coordinates into box"},
     )
-    settings["continuous"] = (
+    settings["discard_overlapping_frames"] = (
         "BooleanConfigurator",
-        {"default": False, "label": "Continuous frame stitching"},
+        {"default": False, "label": "Discard overlapping frames"},
     )
     settings["output_files"] = (
         "OutputTrajectoryConfigurator",
@@ -85,12 +85,23 @@ class MDTraj(Converter):
         """Load the trajectory using MDTraj and create the
         trajectory writer.
         """
-        traj_files = self.configuration["trajectory_files"]["filename"]
+        traj_files = self.configuration["trajectory_files"]["filenames"]
         top_file = self.configuration["topology_file"]["filename"]
         if top_file:
-            self.traj = md.load(traj_files, top=top_file)
+            self.traj = md.load(
+                traj_files,
+                top=top_file,
+                discard_overlapping_frames=self.configuration[
+                    "discard_overlapping_frames"
+                ]["value"],
+            )
         else:
-            self.traj = md.load(traj_files)
+            self.traj = md.load(
+                traj_files,
+                discard_overlapping_frames=self.configuration[
+                    "discard_overlapping_frames"
+                ]["value"],
+            )
 
         self.numberOfSteps = self.traj.n_frames
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -1,0 +1,177 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import collections
+
+import mdtraj as md
+
+from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
+from MDANSE.Framework.Converters.Converter import Converter
+from MDANSE.Chemistry.ChemicalEntity import ChemicalSystem, Atom
+from MDANSE.Framework.AtomMapping import get_element_from_mapping
+from MDANSE.MolecularDynamics.Configuration import (
+    PeriodicRealConfiguration,
+    RealConfiguration,
+)
+from MDANSE.MolecularDynamics.UnitCell import UnitCell
+
+
+class MDTraj(Converter):
+    """Using MDTraj, read the MD trajectory and write the data out to
+    the MDT file. MDTraj reads MD trajectories by specifying
+    trajectory files and optionally a topology file. Multiple files can
+    be used for the trajectory files so that trajectories will be
+    stitched together.
+    """
+
+    label = "MDTraj"
+    settings = collections.OrderedDict()
+
+    settings["trajectory_files"] = (
+        "MDTrajTrajectoryFileConfigurator",
+        {
+            "wildcard": "All files (*)",
+            "default": "INPUT_FILENAME",
+            "label": "Trajectory files",
+        },
+    )
+    settings["topology_file"] = (
+        "MDTrajTopologyFileConfigurator",
+        {
+            "wildcard": "All files (*)",
+            "default": "INPUT_FILENAME",
+            "label": "Topology file",
+            "dependencies": {"trajectory_files": "trajectory_files"},
+        },
+    )
+    settings["atom_aliases"] = (
+        "AtomMappingConfigurator",
+        {
+            "default": "{}",
+            "label": "Atom mapping",
+            "dependencies": {"input_file": "topology_file"},
+        },
+    )
+    settings["fold"] = (
+        "BooleanConfigurator",
+        {"default": False, "label": "Fold coordinates into box"},
+    )
+    settings["continuous"] = (
+        "BooleanConfigurator",
+        {"default": False, "label": "Continuous frame stitching"},
+    )
+    settings["output_files"] = (
+        "OutputTrajectoryConfigurator",
+        {
+            "label": "MDANSE trajectory (filename, format)",
+            "formats": ["MDTFormat"],
+            "root": "config_file",
+        },
+    )
+
+    def initialize(self):
+        """Load the trajectory using MDTraj and create the
+        trajectory writer.
+        """
+        traj_files = self.configuration["trajectory_files"]["filename"]
+        top_file = self.configuration["topology_file"]["filename"]
+        if top_file:
+            self.traj = md.load(traj_files, top=top_file)
+        else:
+            self.traj = md.load(traj_files)
+
+        self.numberOfSteps = self.traj.n_frames
+
+        self._chemical_system = ChemicalSystem()
+        for at in self.traj.topology.atoms:
+            element = get_element_from_mapping(
+                self.configuration["atom_aliases"]["value"],
+                at.name,
+                residue=at.residue.name,
+                symbol=at.element.symbol,
+            )
+            self._chemical_system.add_chemical_entity(
+                Atom(symbol=element, name=at.name)
+            )
+
+        kwargs = {
+            "positions_dtype": self.configuration["output_files"]["dtype"],
+            "chunking_limit": self.configuration["output_files"]["chunk_size"],
+            "compression": self.configuration["output_files"]["compression"],
+        }
+        self._trajectory = TrajectoryWriter(
+            self.configuration["output_files"]["file"],
+            self._chemical_system,
+            self.numberOfSteps,
+            **kwargs
+        )
+        super().initialize()
+
+    def run_step(self, index: int):
+        """For the given frame, read the MDTraj trajectory data,
+        convert and write it out to the MDT file.
+
+        Parameters
+        ----------
+        index : int
+            The frame index.
+
+        Returns
+        -------
+        tuple[int, None]
+            A tuple of the job index and None.
+        """
+        if self.traj.unitcell_vectors is None:
+            conf = RealConfiguration(
+                self._trajectory._chemical_system,
+                self.traj.xyz[index],
+            )
+        else:
+            conf = PeriodicRealConfiguration(
+                self._trajectory._chemical_system,
+                self.traj.xyz[index],
+                UnitCell(
+                    self.traj.unitcell_vectors[index],
+                ),
+            )
+            if self.configuration["fold"]["value"]:
+                conf.fold_coordinates()
+
+        self._trajectory._chemical_system.configuration = conf
+
+        # TODO as of 11/12/2024 MDTraj does not read velocity data
+        #  there is a discussion about this on GitHub
+        #  (https://github.com/mdtraj/mdtraj/issues/1824).
+        #  It doesn't look like they have any plans to add this but if
+        #  they change there minds then we should update our code to
+        #  support this.
+
+        self._trajectory.dump_configuration(
+            index * self.traj.timestep,
+            units={
+                "time": "ps",
+                "unit_cell": "nm",
+                "coordinates": "nm",
+            },
+        )
+
+        return index, None
+
+    def combine(self, index, x):
+        pass
+
+    def finalize(self):
+        self._trajectory.close()
+        super(MDTraj, self).finalize()

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -39,7 +39,7 @@ class MDTraj(Converter):
     label = "MDTraj"
     settings = collections.OrderedDict()
 
-    settings["trajectory_files"] = (
+    settings["coordinate_files"] = (
         "MDTrajTrajectoryFileConfigurator",
         {
             "wildcard": "All files (*)",
@@ -53,7 +53,7 @@ class MDTraj(Converter):
             "wildcard": "All files (*)",
             "default": "",
             "label": "Topology file (optional)",
-            "dependencies": {"trajectory_files": "trajectory_files"},
+            "dependencies": {"coordinate_files": "coordinate_files"},
         },
     )
     settings["atom_aliases"] = (
@@ -62,6 +62,18 @@ class MDTraj(Converter):
             "default": "{}",
             "label": "Atom mapping",
             "dependencies": {"input_file": "topology_file"},
+        },
+    )
+    settings["time_step"] = (
+        "MDTrajTimeStepConfigurator",
+        {
+            "label": "Time step (ps)",
+            "default": 0.0,
+            "mini": 0.0,
+            "dependencies": {
+                "coordinate_files": "coordinate_files",
+                "topology_file": "topology_file",
+            },
         },
     )
     settings["fold"] = (
@@ -85,11 +97,11 @@ class MDTraj(Converter):
         """Load the trajectory using MDTraj and create the
         trajectory writer.
         """
-        traj_files = self.configuration["trajectory_files"]["filenames"]
+        coord_files = self.configuration["coordinate_files"]["filenames"]
         top_file = self.configuration["topology_file"]["filename"]
         if top_file:
             self.traj = md.load(
-                traj_files,
+                coord_files,
                 top=top_file,
                 discard_overlapping_frames=self.configuration[
                     "discard_overlapping_frames"
@@ -97,7 +109,7 @@ class MDTraj(Converter):
             )
         else:
             self.traj = md.load(
-                traj_files,
+                coord_files,
                 discard_overlapping_frames=self.configuration[
                     "discard_overlapping_frames"
                 ]["value"],

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -122,8 +122,8 @@ class MDTraj(Converter):
             element = get_element_from_mapping(
                 self.configuration["atom_aliases"]["value"],
                 at.name,
-                residue=at.residue.name,
                 symbol=at.element.symbol,
+                residue=at.residue.name,
                 number=at.element.number,
                 mass=at.element.mass,
             )

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -186,7 +186,10 @@ class MDTraj(Converter):
         if self.numberOfSteps == 1:
             time = 0
         else:
-            time = index * self.traj.timestep
+            if float(self.configuration["time_step"]["value"]) == 0.0:
+                time = index * self.traj.timestep
+            else:
+                time = index * float(self.configuration["time_step"]["value"])
 
         self._trajectory.dump_configuration(
             time,

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -51,8 +51,8 @@ class MDTraj(Converter):
         "MDTrajTopologyFileConfigurator",
         {
             "wildcard": "All files (*)",
-            "default": "INPUT_FILENAME",
-            "label": "Topology file",
+            "default": "",
+            "label": "Topology file (optional)",
             "dependencies": {"trajectory_files": "trajectory_files"},
         },
     )
@@ -101,6 +101,8 @@ class MDTraj(Converter):
                 at.name,
                 residue=at.residue.name,
                 symbol=at.element.symbol,
+                number=at.element.number,
+                mass=at.element.mass,
             )
             self._chemical_system.add_chemical_entity(
                 Atom(symbol=element, name=at.name)
@@ -155,11 +157,16 @@ class MDTraj(Converter):
         #  there is a discussion about this on GitHub
         #  (https://github.com/mdtraj/mdtraj/issues/1824).
         #  It doesn't look like they have any plans to add this but if
-        #  they change there minds then we should update our code to
+        #  they change their minds then we should update our code to
         #  support this.
 
+        if self.numberOfSteps == 1:
+            time = 0
+        else:
+            time = index * self.traj.timestep
+
         self._trajectory.dump_configuration(
-            index * self.traj.timestep,
+            time,
             units={
                 "time": "ps",
                 "unit_cell": "nm",

--- a/MDANSE/Tests/UnitTests/AtomMapping/test_atom_mapping.py
+++ b/MDANSE/Tests/UnitTests/AtomMapping/test_atom_mapping.py
@@ -127,9 +127,21 @@ def test_fill_remaining_labels_fill_mapping_correctly_missing_mapping():
     assert mapping == {"molecule=mol1": {"label1": "C", "C1": "C"}}
 
 
-def test_check_mapping_valid_as_elements_are_correct():
+def test_check_mapping_valid_as_elements_are_correct_1():
     labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
     mapping = {"molecule=mol1": {"label1": "C", "C1": "C"}}
+    assert check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_valid_as_elements_are_correct_2():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
+    mapping = {"molecule=mol1": {"C1": "C", "label1": "C"}}
+    assert check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_valid_as_elements_are_correct_3():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol2")]
+    mapping = {"molecule=mol1": {"label1": "C"}, "molecule=mol2": {"C1": "C"}}
     assert check_mapping_valid(mapping, labels)
 
 
@@ -142,10 +154,76 @@ def test_check_mapping_not_valid_as_elements_not_correct():
     assert not check_mapping_valid(mapping, labels)
 
 
-def test_check_mapping_not_valid_due_to_missing_mappings():
+def test_check_mapping_not_valid_due_to_missing_mappings_1():
     labels = [
         AtomLabel("label1", molecule="mol1"),
         AtomLabel("label2", molecule="mol1"),
     ]
     mapping = {"molecule=mol1": {"label1": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_missing_mappings_2():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol2")]
+    mapping = {"molecule=mol1": {"label1": "C", "C1": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_incorrect_keys_1():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
+    mapping = {"molecule=mol1": {"label1": "C", "label2": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_incorrect_keys_2():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
+    mapping = {"molecule=mol1": {"label1": "C", "C1": "C", "label2": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_bad_keys_1():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
+    mapping = {"molecule==mol1": {"label1": "C", "C1": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_bad_keys_2():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
+    mapping = {"molecule===mol1": {"label1": "C", "C1": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_bad_keys_3():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
+    mapping = {"molecule=mol1;": {"label1": "C", "C1": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_bad_keys_4():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
+    mapping = {";molecule=mol1": {"label1": "C", "C1": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_bad_keys_5():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
+    mapping = {"molecule;=mol1": {"label1": "C", "C1": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_bad_keys_6():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
+    mapping = {"mole;cule=mol1": {"label1": "C", "C1": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_bad_keys_7():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol1")]
+    mapping = {"molecule=mo;l1": {"label1": "C", "C1": "C"}}
+    assert not check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_not_valid_due_to_bad_keys_8():
+    labels = [AtomLabel("label1", molecule="mol1"), AtomLabel("C1", molecule="mol2")]
+    mapping = {"molecule=mol1": {"label1": "C"}, "molec;ule=mol2": {"C1": "C"}}
     assert not check_mapping_valid(mapping, labels)

--- a/MDANSE/Tests/UnitTests/AtomMapping/test_atom_mapping.py
+++ b/MDANSE/Tests/UnitTests/AtomMapping/test_atom_mapping.py
@@ -163,6 +163,12 @@ def test_check_mapping_valid_as_elements_are_correct_6():
     assert check_mapping_valid(mapping, labels)
 
 
+def test_check_mapping_valid_as_elements_are_correct_7():
+    labels = [AtomLabel("label=1"), AtomLabel("C=1")]
+    mapping = {"": {"label1": "C", "C1": "C"}}
+    assert check_mapping_valid(mapping, labels)
+
+
 def test_check_mapping_not_valid_as_elements_not_correct():
     labels = [
         AtomLabel("label1", molecule="mol1"),

--- a/MDANSE/Tests/UnitTests/AtomMapping/test_atom_mapping.py
+++ b/MDANSE/Tests/UnitTests/AtomMapping/test_atom_mapping.py
@@ -145,6 +145,24 @@ def test_check_mapping_valid_as_elements_are_correct_3():
     assert check_mapping_valid(mapping, labels)
 
 
+def test_check_mapping_valid_as_elements_are_correct_4():
+    labels = [AtomLabel("label1", type="1*"), AtomLabel("C1", type="2*")]
+    mapping = {"type=1*": {"label1": "C"}, "type=2*": {"C1": "C"}}
+    assert check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_valid_as_elements_are_correct_5():
+    labels = [AtomLabel("label1", mass="12"), AtomLabel("C1", mass="13")]
+    mapping = {"mass=12": {"label1": "C"}, "mass=13": {"C1": "C"}}
+    assert check_mapping_valid(mapping, labels)
+
+
+def test_check_mapping_valid_as_elements_are_correct_6():
+    labels = [AtomLabel("label=1", molecule="mol=1"), AtomLabel("C=1", molecule="mol=2")]
+    mapping = {"molecule=mol1": {"label1": "C"}, "molecule=mol2": {"C1": "C"}}
+    assert check_mapping_valid(mapping, labels)
+
+
 def test_check_mapping_not_valid_as_elements_not_correct():
     labels = [
         AtomLabel("label1", molecule="mol1"),

--- a/MDANSE/Tests/UnitTests/test_converter.py
+++ b/MDANSE/Tests/UnitTests/test_converter.py
@@ -547,7 +547,7 @@ def test_mdanalysis_conversion_file_exists_and_loads_up_successfully(compression
 
 
 @pytest.mark.parametrize("compression", ["none", "gzip", "lzf"])
-def test_mdanalysis_conversion_file_exists_and_loads_up_successfully(compression):
+def test_mdtraj_conversion_file_exists_and_loads_up_successfully(compression):
     temp_name = tempfile.mktemp()
 
     parameters = {

--- a/MDANSE/Tests/UnitTests/test_converter.py
+++ b/MDANSE/Tests/UnitTests/test_converter.py
@@ -552,7 +552,7 @@ def test_mdtraj_conversion_file_exists_and_loads_up_successfully(compression):
 
     parameters = {
         "topology_file": hem_cam_pdb,
-        "trajectory_files": [hem_cam_dcd],
+        "coordinate_files": [hem_cam_dcd],
         "output_files": (temp_name, 64, 128, compression, "INFO"),
     }
 

--- a/MDANSE/Tests/UnitTests/test_converter.py
+++ b/MDANSE/Tests/UnitTests/test_converter.py
@@ -544,3 +544,26 @@ def test_mdanalysis_conversion_file_exists_and_loads_up_successfully(compression
     assert os.path.exists(temp_name + ".log")
     assert os.path.isfile(temp_name + ".log")
     os.remove(temp_name + ".log")
+
+
+@pytest.mark.parametrize("compression", ["none", "gzip", "lzf"])
+def test_mdanalysis_conversion_file_exists_and_loads_up_successfully(compression):
+    temp_name = tempfile.mktemp()
+
+    parameters = {
+        "topology_file": hem_cam_pdb,
+        "trajectory_files": [hem_cam_dcd],
+        "output_files": (temp_name, 64, 128, compression, "INFO"),
+    }
+
+    mdanalysis = Converter.create("MDTraj")
+    mdanalysis.run(parameters, status=True)
+
+    HDFTrajectoryConfigurator("trajectory").configure(temp_name + ".mdt")
+
+    assert os.path.exists(temp_name + ".mdt")
+    assert os.path.isfile(temp_name + ".mdt")
+    os.remove(temp_name + ".mdt")
+    assert os.path.exists(temp_name + ".log")
+    assert os.path.isfile(temp_name + ".log")
+    os.remove(temp_name + ".log")

--- a/MDANSE/Tests/UnitTests/test_ijob.py
+++ b/MDANSE/Tests/UnitTests/test_ijob.py
@@ -60,6 +60,7 @@ ALL_JOBS = [
     "ImprovedASE",
     "LAMMPS",
     "MDAnalysis",
+    "MDTraj",
     "VASP",
     "CHARMM",
     "NAMD",

--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "h5py",
     "ase",
     "rdkit",
-    "MDAnalysis"
+    "MDAnalysis",
+    "mdtraj"
 ]
 
 # dynamic = ["version", "description"]

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
@@ -108,7 +108,7 @@ class AtomMappingHelperDialog(QDialog):
         if not self._file_widget._configurator.valid:
             return
 
-        self.labels = self._file_widget._configurator.get_atom_labels()
+        self.labels = self._file_widget._configurator.get_labels()
         for i, label in enumerate(self.labels):
             w0 = QLabel(label.grp_label.replace(";", "\n"))
             w1 = QLabel(label.atm_label)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
@@ -108,7 +108,7 @@ class AtomMappingHelperDialog(QDialog):
         if not self._file_widget._configurator.valid:
             return
 
-        self.labels = self._file_widget._configurator.labels
+        self.labels = self._file_widget._configurator.generate_labels()
         for i, label in enumerate(self.labels):
             w0 = QLabel(label.grp_label.replace(";", "\n"))
             w1 = QLabel(label.atm_label)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
@@ -108,7 +108,7 @@ class AtomMappingHelperDialog(QDialog):
         if not self._file_widget._configurator.valid:
             return
 
-        self.labels = self._file_widget._configurator.get_labels()
+        self.labels = self._file_widget._configurator.labels
         for i, label in enumerate(self.labels):
             w0 = QLabel(label.grp_label.replace(";", "\n"))
             w1 = QLabel(label.atm_label)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
@@ -108,7 +108,7 @@ class AtomMappingHelperDialog(QDialog):
         if not self._file_widget._configurator.valid:
             return
 
-        self.labels = self._file_widget._configurator.unique_labels()
+        self.labels = self._file_widget._configurator.labels
         for i, label in enumerate(self.labels):
             w0 = QLabel(label.grp_label.replace(";", "\n"))
             w1 = QLabel(label.atm_label)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
@@ -64,7 +64,6 @@ class AtomMappingHelperDialog(QDialog):
         self._field = field
 
         self._file_widget = field_widget
-        self._file_widget.value_changed.connect(self.update_helper)
 
         self.layout = QVBoxLayout()
         buffer_0 = QWidget(self)
@@ -202,9 +201,13 @@ class AtomMappingWidget(WidgetBase):
         """
         if self._file_widget._configurator.valid:
             self.helper_button.setEnabled(True)
+            self.helper.update_helper()
+            self.helper.apply()
         else:
             self.helper_button.setEnabled(False)
-        self.helper.apply()
+            self.helper.close()
+            self.helper.clear_panel()
+            self.helper.apply()
 
     @Slot()
     def helper_dialog(self) -> None:
@@ -213,6 +216,16 @@ class AtomMappingWidget(WidgetBase):
             self.helper.close()
         else:
             self.helper.show()
+
+    def mark_error(self, error_text: str):
+        self.helper.clear_panel()
+        super().mark_error(error_text)
+        self.helper.update_helper()
+
+    def clear_error(self):
+        self.helper.clear_panel()
+        super().clear_error()
+        self.helper.update_helper()
 
     def get_widget_value(self) -> str:
         """

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
@@ -115,8 +115,7 @@ class AtomMappingHelperDialog(QDialog):
             w2 = QComboBox()
             # this combobox can be slow without this policy since we
             # are adding alot of items
-            w2.setSizeAdjustPolicy(
-                w2.AdjustToMinimumContentsLengthWithIcon)
+            w2.setSizeAdjustPolicy(w2.AdjustToMinimumContentsLengthWithIcon)
             w2.addItems(self.all_symbols)
             self.mapping_widgets.append((w0, w1, w2))
             self.mapping_layout.addWidget(w0, i, 0)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
@@ -108,7 +108,7 @@ class AtomMappingHelperDialog(QDialog):
         if not self._file_widget._configurator.valid:
             return
 
-        self.labels = self._file_widget._configurator.generate_labels()
+        self.labels = self._file_widget._configurator.unique_labels()
         for i, label in enumerate(self.labels):
             w0 = QLabel(label.grp_label.replace(";", "\n"))
             w1 = QLabel(label.atm_label)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomMappingWidget.py
@@ -113,6 +113,10 @@ class AtomMappingHelperDialog(QDialog):
             w0 = QLabel(label.grp_label.replace(";", "\n"))
             w1 = QLabel(label.atm_label)
             w2 = QComboBox()
+            # this combobox can be slow without this policy since we
+            # are adding alot of items
+            w2.setSizeAdjustPolicy(
+                w2.AdjustToMinimumContentsLengthWithIcon)
             w2.addItems(self.all_symbols)
             self.mapping_widgets.append((w0, w1, w2))
             self.mapping_layout.addWidget(w0, i, 0)
@@ -216,16 +220,6 @@ class AtomMappingWidget(WidgetBase):
             self.helper.close()
         else:
             self.helper.show()
-
-    def mark_error(self, error_text: str):
-        self.helper.clear_panel()
-        super().mark_error(error_text)
-        self.helper.update_helper()
-
-    def clear_error(self):
-        self.helper.clear_panel()
-        super().clear_error()
-        self.helper.update_helper()
 
     def get_widget_value(self) -> str:
         """

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDAnalysisCoordinateFileWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDAnalysisCoordinateFileWidget.py
@@ -21,10 +21,10 @@ from qtpy.QtWidgets import QFileDialog
 from qtpy.QtCore import Slot
 
 from MDANSE.MLogging import LOG
-from .TopologyFileWidget import TopologyFileWidget
+from .MDAnalysisTopologyFileWidget import MDAnalysisTopologyFileWidget
 
 
-class CoordinateFileWidget(TopologyFileWidget):
+class MDAnalysisCoordinateFileWidget(MDAnalysisTopologyFileWidget):
 
     def __init__(self, *args, file_dialog=QFileDialog.getOpenFileNames, **kwargs):
         super().__init__(

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDAnalysisCoordinateFileWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDAnalysisCoordinateFileWidget.py
@@ -13,18 +13,16 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-import os
-from pathlib import PurePath
-
 import MDAnalysis as mda
 from qtpy.QtWidgets import QFileDialog
-from qtpy.QtCore import Slot
 
-from MDANSE.MLogging import LOG
 from .MDAnalysisTopologyFileWidget import MDAnalysisTopologyFileWidget
+from .MultiInputFileWidget import MultiInputFileWidget
 
 
-class MDAnalysisCoordinateFileWidget(MDAnalysisTopologyFileWidget):
+class MDAnalysisCoordinateFileWidget(
+    MultiInputFileWidget, MDAnalysisTopologyFileWidget
+):
 
     def __init__(self, *args, file_dialog=QFileDialog.getOpenFileNames, **kwargs):
         super().__init__(
@@ -41,33 +39,3 @@ class MDAnalysisCoordinateFileWidget(MDAnalysisTopologyFileWidget):
                 ]
             ):
                 widget.value_changed.connect(self.updateValue)
-
-    @Slot()
-    def valueFromDialog(self):
-        paths_group = self._settings.group("paths")
-        try:
-            self.default_path = paths_group.get(self._job_name)
-        except:
-            LOG.warning(f"session.get_path failed for {self._job_name}")
-        new_value = self._file_dialog(
-            self.parent(),
-            "Load file",
-            str(self.default_path),
-            self._qt_file_association,
-        )
-
-        if new_value is not None and new_value[0]:
-            values = ['"' + str(PurePath(value)) + '"' for value in new_value[0]]
-            self._field.setText("[" + ", ".join(values) + "]")
-            self.updateValue()
-            try:
-                LOG.info(
-                    f"Settings path of {self._job_name} to {os.path.split(new_value[0][0])[0]}"
-                )
-                paths_group.set(
-                    self._job_name, str(PurePath(os.path.split(new_value[0][0])[0]))
-                )
-            except:
-                LOG.error(
-                    f"session.set_path failed for {self._job_name}, {os.path.split(new_value[0][0])[0]}"
-                )

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDAnalysisMDTrajTimeStepWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDAnalysisMDTrajTimeStepWidget.py
@@ -13,13 +13,10 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-import MDAnalysis as mda
-
-from MDANSE.MLogging import LOG
 from .FloatWidget import FloatWidget
 
 
-class MDAnalysisTimeStepWidget(FloatWidget):
+class MDAnalysisMDTrajTimeStepWidget(FloatWidget):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDAnalysisTimeStepWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDAnalysisTimeStepWidget.py
@@ -50,36 +50,8 @@ class MDAnalysisTimeStepWidget(FloatWidget):
         """Updates the time step field from the topology and coordinates
         files if possible else set it back to the default value.
         """
-        if (
-            self._topology_file_widget._configurator.valid
-            and self._coordinates_file_widget._configurator.valid
-        ):
-            try:
-                coord_format = self._coordinates_file_widget._configurator["format"]
-                coord_files = self._coordinates_file_widget._configurator["filenames"]
-
-                if len(coord_files) <= 1 or coord_format is None:
-                    value = mda.Universe(
-                        self._topology_file_widget._configurator["filename"],
-                        *coord_files,
-                        format=coord_format,
-                        topology_format=self._topology_file_widget._configurator[
-                            "format"
-                        ],
-                    ).trajectory.ts.dt
-                else:
-                    coord_files = [(i, coord_format) for i in coord_files]
-                    value = mda.Universe(
-                        self._topology_file_widget._configurator["filename"],
-                        coord_files,
-                        topology_format=self._topology_file_widget._configurator[
-                            "format"
-                        ],
-                    ).trajectory.ts.dt
-
-                self._field.setText(str(value))
-                return
-            except Exception as e:
-                LOG.warning(f"Failed to determine time step from MDAnalysis: {e}")
-
-        self._field.setText(str(self._default_value))
+        self._configurator.configure(None)
+        if self._configurator._valid:
+            self._field.setText(str(self._configurator["value"]))
+        else:
+            self._field.setText(str(self._default_value))

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDAnalysisTopologyFileWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDAnalysisTopologyFileWidget.py
@@ -20,7 +20,7 @@ from qtpy.QtWidgets import QLineEdit, QPushButton, QComboBox
 from .InputFileWidget import InputFileWidget
 
 
-class TopologyFileWidget(InputFileWidget):
+class MDAnalysisTopologyFileWidget(InputFileWidget):
 
     def __init__(self, *args, format_options=sorted(mda._PARSERS.keys()), **kwargs):
         self.format_options = ["AUTO"] + list(format_options)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDTrajTopologyFileWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDTrajTopologyFileWidget.py
@@ -1,0 +1,33 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from .InputFileWidget import InputFileWidget
+
+
+class MDTrajTopologyFileWidget(InputFileWidget):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # file input widgets should be loaded into the _widgets list
+        # before this one
+        for widget in self.parent()._widgets:
+            if (
+                widget._configurator
+                is self._configurator._configurable[
+                    self._configurator._dependencies["trajectory_files"]
+                ]
+            ):
+                widget.value_changed.connect(self.updateValue)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDTrajTopologyFileWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MDTrajTopologyFileWidget.py
@@ -27,7 +27,7 @@ class MDTrajTopologyFileWidget(InputFileWidget):
             if (
                 widget._configurator
                 is self._configurator._configurable[
-                    self._configurator._dependencies["trajectory_files"]
+                    self._configurator._dependencies["coordinate_files"]
                 ]
             ):
                 widget.value_changed.connect(self.updateValue)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MultiInputFileWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MultiInputFileWidget.py
@@ -1,0 +1,63 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import os
+from pathlib import PurePath
+
+from qtpy.QtCore import Slot
+from qtpy.QtWidgets import QFileDialog
+
+from MDANSE.MLogging import LOG
+from .InputFileWidget import InputFileWidget
+
+
+class MultiInputFileWidget(InputFileWidget):
+
+    def __init__(self, *args, file_dialog=QFileDialog.getOpenFileNames, **kwargs):
+        super().__init__(
+            *args,
+            file_dialog=file_dialog,
+            **kwargs,
+        )
+
+    @Slot()
+    def valueFromDialog(self):
+        paths_group = self._settings.group("paths")
+        try:
+            self.default_path = paths_group.get(self._job_name)
+        except:
+            LOG.warning(f"session.get_path failed for {self._job_name}")
+        new_value = self._file_dialog(
+            self.parent(),
+            "Load file",
+            str(self.default_path),
+            self._qt_file_association,
+        )
+
+        if new_value is not None and new_value[0]:
+            values = ['"' + str(PurePath(value)) + '"' for value in new_value[0]]
+            self._field.setText("[" + ", ".join(values) + "]")
+            self.updateValue()
+            try:
+                LOG.info(
+                    f"Settings path of {self._job_name} to {os.path.split(new_value[0][0])[0]}"
+                )
+                paths_group.set(
+                    self._job_name, str(PurePath(os.path.split(new_value[0][0])[0]))
+                )
+            except:
+                LOG.error(
+                    f"session.set_path failed for {self._job_name}, {os.path.split(new_value[0][0])[0]}"
+                )

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -82,7 +82,8 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "InstrumentResolutionConfigurator": InstrumentResolutionWidget,
     "PartialChargeConfigurator": PartialChargeWidget,
     "UnitCellConfigurator": UnitCellWidget,
-    "MDAnalysisTimeStepConfigurator": MDAnalysisTimeStepWidget,
+    "MDAnalysisTimeStepConfigurator": MDAnalysisMDTrajTimeStepWidget,
+    "MDTrajTimeStepConfigurator": MDAnalysisMDTrajTimeStepWidget,
     "MDTrajTrajectoryFileConfigurator": MultiInputFileWidget,
     "MDTrajTopologyFileConfigurator": MDTrajTopologyFileWidget,
 }

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -83,6 +83,8 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "PartialChargeConfigurator": PartialChargeWidget,
     "UnitCellConfigurator": UnitCellWidget,
     "MDAnalysisTimeStepConfigurator": MDAnalysisTimeStepWidget,
+    "MDTrajTrajectoryFileConfigurator": InputFileWidget,
+    "MDTrajTopologyFileConfigurator": InputFileWidget,
 }
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -56,9 +56,9 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "ASEFileConfigurator": InputFileWidget,
     "AseInputFileConfigurator": AseInputFileWidget,
     "ConfigFileConfigurator": InputFileWidget,
-    "CoordinateFileConfigurator": CoordinateFileWidget,
+    "MDAnalysisCoordinateFileConfigurator": MDAnalysisCoordinateFileWidget,
     "InputFileConfigurator": InputFileWidget,
-    "TopologyFileConfigurator": TopologyFileWidget,
+    "MDAnalysisTopologyFileConfigurator": MDAnalysisTopologyFileWidget,
     "MDFileConfigurator": InputFileWidget,
     "FieldFileConfigurator": InputFileWidget,
     "XDATCARFileConfigurator": InputFileWidget,
@@ -84,7 +84,7 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "UnitCellConfigurator": UnitCellWidget,
     "MDAnalysisTimeStepConfigurator": MDAnalysisTimeStepWidget,
     "MDTrajTrajectoryFileConfigurator": InputFileWidget,
-    "MDTrajTopologyFileConfigurator": InputFileWidget,
+    "MDTrajTopologyFileConfigurator": MDTrajTopologyFileWidget,
 }
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -83,7 +83,7 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "PartialChargeConfigurator": PartialChargeWidget,
     "UnitCellConfigurator": UnitCellWidget,
     "MDAnalysisTimeStepConfigurator": MDAnalysisTimeStepWidget,
-    "MDTrajTrajectoryFileConfigurator": InputFileWidget,
+    "MDTrajTrajectoryFileConfigurator": MultiInputFileWidget,
     "MDTrajTopologyFileConfigurator": MDTrajTopologyFileWidget,
 }
 


### PR DESCRIPTION
**Description of work**
Added MDTraj converter and optimized the atom mapping code. 

Similarly to the MDAnalysis converter, the MDTraj converter converts trajectories with trajectory files and a topology file. Trajectory files can include one or more files but should only be of a single type e.g. xtc. In MDTraj topology files are optional if the trajectory files contain topology information.

**To test**
1) Convert some gromacs trajectories from the MDANSE-Examples repository. 
Enter PDB files into the topology file setting and trr or xtc files into the trajectory files setting and convert the trajectory. Atom mapping should be generated faster than before.
2) Convert some charmm trajectories from the MDANSE-Examples repository. 
Enter PDB files into the topology file setting and dcd files into the trajectory files setting and convert the trajectory.
3) Try converting a trajectory using multiple coordinate files.
Either generate multiple coordinate files or copy and rename them. Convert the trajectory, if you copy and renamed it then the MDANSE trajectory should be twice as long and repeat itself.
