### PR TITLE
Fix tab switching performance issues.

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -291,7 +291,8 @@ class Action(QWidget):
             return
         self.check_inputs()
         for widget in self._widgets:
-            widget.updateValue()
+            if isinstance(widget, (OutputFilesWidget, OutputTrajectoryWidget)):
+                widget.updateValue()
         self.allow_execution()
 
     def apply_instrument(self):


### PR DESCRIPTION
**Description of work**
Updated test_file_outputs so that it only updates the output file widgets. Previously it would update all widgets which could be slow for large trajectories.

**To test**
Test that the output file widgets are correctly blocked/unblocked when the MDA/MDT files are loaded or unloaded into the GUI.
