### PR TITLE
Output files setting fix

### DIFF
--- a/MDANSE/Src/MDANSE/Core/Platform.py
+++ b/MDANSE/Src/MDANSE/Core/Platform.py
@@ -22,6 +22,8 @@ import inspect
 import os
 import re
 import subprocess
+import tempfile
+
 
 from MDANSE.Core.Error import Error
 
@@ -147,21 +149,48 @@ class Platform(object, metaclass=abc.ABCMeta):
 
         os.chdir(directory)
 
-    def is_directory_writable(self, path):
+    @classmethod
+    def is_directory_writable(cls, path):
+        """Check if the directories can be created and a file can be
+        written into it.
+
+        Parameters
+        ----------
+        path : str
+            The path to test if a file can be written to it.
+
+        Returns
+        -------
+        bool
+            True if a file can be written to the input path.
         """
-        Check whether a given directory is writable.
+        path = cls.get_path(path)
 
-        :param path: the directory to be tested for writable status
-        :type path: str
+        if os.path.exists(path):
+            while True:
+                file = os.path.join(path, next(tempfile._get_candidate_names()))
+                if not os.path.isfile(file):
+                    try:
+                        open(file, "w").close()
+                        os.remove(file)
+                    except OSError:
+                        return False
+                    return True
 
-        :return: true if the directory is writable, false otherwise
-        :rtype: bool
-        """
+        head, tail = os.path.split(path)
+        if not tail:
+            head, tail = os.path.split(head)
 
-        # Gets an absolute version of the path to check
-        path = self.get_path(path)
-
-        return os.access(path, os.W_OK | os.X_OK)
+        if os.path.exists(head):
+            try:
+                os.mkdir(path)
+            except OSError:
+                return False
+            writable = cls.is_directory_writable(path)
+            os.rmdir(path)
+            return writable
+        else:
+            return cls.is_directory_writable(head)
 
     def create_directory(self, path):
         """
@@ -187,7 +216,8 @@ class Platform(object, metaclass=abc.ABCMeta):
                 "{0}: /n {1}".format(str(path), e)
             )
 
-    def get_path(self, path):
+    @classmethod
+    def get_path(cls, path):
         """
         Return a normalized and absolute version of a given path
 

--- a/MDANSE/Src/MDANSE/Core/Platform.py
+++ b/MDANSE/Src/MDANSE/Core/Platform.py
@@ -150,47 +150,49 @@ class Platform(object, metaclass=abc.ABCMeta):
         os.chdir(directory)
 
     @classmethod
-    def is_directory_writable(cls, path):
+    def is_file_writable(cls, filepath: str) -> bool:
         """Check if the directories can be created and a file can be
         written into it.
 
         Parameters
         ----------
-        path : str
-            The path to test if a file can be written to it.
+        filepath : str
+            The filepath to test if the file can be written.
 
         Returns
         -------
         bool
-            True if a file can be written to the input path.
+            True if a file can be written.
         """
-        path = cls.get_path(path)
+        dirname = cls.get_path(os.path.dirname(filepath))
 
-        if os.path.exists(path):
-            while True:
-                file = os.path.join(path, next(tempfile._get_candidate_names()))
-                if not os.path.isfile(file):
+        def recursive_check(head_0: str) -> bool:
+            """Builds the directories up and tests if the file can be
+            written and then removes everything so that no changes are
+            made to the filesystem.
+            """
+            if os.path.exists(dirname):
+                if not os.path.isfile(filepath):
                     try:
-                        open(file, "w").close()
-                        os.remove(file)
+                        open(filepath, "w").close()
+                        os.remove(filepath)
                     except OSError:
                         return False
                     return True
 
-        head, tail = os.path.split(path)
-        if not tail:
-            head, tail = os.path.split(head)
+            head, tail = os.path.split(head_0)
+            if os.path.exists(head):
+                try:
+                    os.mkdir(head_0)
+                except OSError:
+                    return False
+                writable = recursive_check(dirname)
+                os.rmdir(head_0)
+                return writable
+            else:
+                return recursive_check(head)
 
-        if os.path.exists(head):
-            try:
-                os.mkdir(path)
-            except OSError:
-                return False
-            writable = cls.is_directory_writable(path)
-            os.rmdir(path)
-            return writable
-        else:
-            return cls.is_directory_writable(head)
+        return recursive_check(dirname)
 
     def create_directory(self, path):
         """

--- a/MDANSE/Src/MDANSE/Core/Platform.py
+++ b/MDANSE/Src/MDANSE/Core/Platform.py
@@ -172,13 +172,12 @@ class Platform(object, metaclass=abc.ABCMeta):
             made to the filesystem.
             """
             if os.path.exists(dirname):
-                if not os.path.isfile(filepath):
-                    try:
-                        open(filepath, "w").close()
-                        os.remove(filepath)
-                    except OSError:
-                        return False
-                    return True
+                try:
+                    open(filepath, "w").close()
+                    os.remove(filepath)
+                except OSError:
+                    return False
+                return True
 
             head, tail = os.path.split(head_0)
             if os.path.exists(head):
@@ -192,7 +191,10 @@ class Platform(object, metaclass=abc.ABCMeta):
             else:
                 return recursive_check(head)
 
-        return recursive_check(dirname)
+        if os.path.isfile(filepath):
+            return os.access(filepath, os.W_OK)
+        else:
+            return recursive_check(dirname)
 
     def create_directory(self, path):
         """

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputFilesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputFilesConfigurator.py
@@ -75,10 +75,8 @@ class OutputFilesConfigurator(IConfigurator):
             self.error_status = "empty root name for the output file."
             return
 
-        dirname = os.path.dirname(root)
-
-        if not PLATFORM.is_directory_writable(dirname):
-            self.error_status = f"the directory {dirname} is not writable"
+        if not PLATFORM.is_file_writable(root):
+            self.error_status = f"the file {root} is not writable"
             return
 
         if not formats:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputFilesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputFilesConfigurator.py
@@ -77,9 +77,7 @@ class OutputFilesConfigurator(IConfigurator):
 
         dirname = os.path.dirname(root)
 
-        try:
-            PLATFORM.create_directory(dirname)
-        except:
+        if not PLATFORM.is_directory_writable(dirname):
             self.error_status = f"the directory {dirname} is not writable"
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputStructureConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputStructureConfigurator.py
@@ -74,10 +74,8 @@ class OutputStructureConfigurator(IConfigurator):
             self.error_status = "empty root name for the output file."
             return
 
-        dirname = os.path.dirname(root)
-
-        if not PLATFORM.is_directory_writable(dirname):
-            self.error_status = f"the directory {dirname} is not writable"
+        if not PLATFORM.is_file_writable(root):
+            self.error_status = f"the file {root} is not writable"
             return
 
         if not format in self.formats:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputStructureConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputStructureConfigurator.py
@@ -76,9 +76,7 @@ class OutputStructureConfigurator(IConfigurator):
 
         dirname = os.path.dirname(root)
 
-        try:
-            PLATFORM.create_directory(dirname)
-        except:
+        if not PLATFORM.is_directory_writable(dirname):
             self.error_status = f"the directory {dirname} is not writable"
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
@@ -73,9 +73,7 @@ class OutputTrajectoryConfigurator(IConfigurator):
 
         dirname = os.path.dirname(root)
 
-        try:
-            PLATFORM.create_directory(dirname)
-        except:
+        if not PLATFORM.is_directory_writable(dirname):
             self.error_status = f"the directory {dirname} is not writable"
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
@@ -71,10 +71,8 @@ class OutputTrajectoryConfigurator(IConfigurator):
             self.error_status = "empty root name for the output file."
             return
 
-        dirname = os.path.dirname(root)
-
-        if not PLATFORM.is_directory_writable(dirname):
-            self.error_status = f"the directory {dirname} is not writable"
+        if not PLATFORM.is_file_writable(root):
+            self.error_status = f"the file {root} is not writable"
             return
 
         if dtype < 17:

--- a/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
@@ -21,6 +21,7 @@ import h5py
 
 from MDANSE.Framework.Formats.IFormat import IFormat
 from MDANSE.MLogging import LOG
+from MDANSE import PLATFORM
 
 if TYPE_CHECKING:
     from MDANSE.Framework.OutputVariables.IOutputVariable import IOutputVariable
@@ -71,6 +72,7 @@ class HDFFormat(IFormat):
         filename = "%s%s" % (filename, extension)
 
         # The HDF output file is opened for writing.
+        PLATFORM.create_directory(os.path.dirname(filename))
         outputFile = h5py.File(filename, "w")
 
         if header:

--- a/MDANSE/Src/MDANSE/Framework/Formats/TextFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/TextFormat.py
@@ -24,8 +24,8 @@ from importlib import metadata
 
 import numpy as np
 
-
 from MDANSE.Framework.Formats.IFormat import IFormat
+from MDANSE import PLATFORM
 
 if TYPE_CHECKING:
     from MDANSE.Framework.Jobs.IJob import IJob
@@ -64,6 +64,7 @@ class TextFormat(IFormat):
         filename = os.path.splitext(filename)[0]
         filename = "%s_text.tar" % filename
 
+        PLATFORM.create_directory(os.path.dirname(filename))
         tf = tarfile.open(filename, "w")
 
         if header:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
@@ -13,7 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-
+import os
 import collections
 
 import numpy as np
@@ -23,6 +23,7 @@ from ase.atoms import Atoms, Atom
 from MDANSE.Framework.Units import measure
 from MDANSE.MolecularDynamics.TrajectoryUtils import sorted_atoms
 from MDANSE.Framework.Jobs.IJob import IJob
+from MDANSE import PLATFORM
 
 
 class AverageStructure(IJob):
@@ -184,6 +185,7 @@ class AverageStructure(IJob):
             correction = np.floor(temp)
             self._ase_atoms.set_scaled_positions(temp - correction)
 
+        PLATFORM.create_directory(os.path.dirname(self.configuration["output_files"]["file"]))
         ase_write(
             self.configuration["output_files"]["file"],
             self._ase_atoms,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
@@ -185,7 +185,9 @@ class AverageStructure(IJob):
             correction = np.floor(temp)
             self._ase_atoms.set_scaled_positions(temp - correction)
 
-        PLATFORM.create_directory(os.path.dirname(self.configuration["output_files"]["file"]))
+        PLATFORM.create_directory(
+            os.path.dirname(self.configuration["output_files"]["file"])
+        )
         ase_write(
             self.configuration["output_files"]["file"],
             self._ase_atoms,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -523,6 +523,7 @@ class %(classname)s(IJob):
             The log level.
         """
         self._log_filename = filename
+        PLATFORM.create_directory(os.path.dirname(filename))
         fh = FileHandler(filename, mode="w")
         # set the name so that we can track it and then close it later,
         # tracking the fh by storing it in this object causes issues

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -13,7 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-
+import os
 from ast import operator
 from typing import Collection
 import math
@@ -33,6 +33,7 @@ from MDANSE.MolecularDynamics.TrajectoryUtils import (
     sorted_atoms,
     resolve_undefined_molecules_name,
 )
+from MDANSE import PLATFORM
 
 
 available_formats = {
@@ -355,7 +356,7 @@ class TrajectoryWriter:
         """
 
         self._h5_filename = h5_filename
-
+        PLATFORM.create_directory(os.path.dirname(h5_filename))
         self._h5_file = h5py.File(self._h5_filename, "w")
 
         self._chemical_system = chemical_system

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
@@ -110,6 +110,7 @@ class DataWidget(QWidget):
         self.layout().addLayout(layout)
         layout.addWidget(QLabel("Output file:"))
         self._output_widget = QLineEdit("", self)
+        self._output_widget.textChanged.connect(self.check_file_writable)
         layout.addWidget(self._output_widget)
         self._browse_button = QPushButton("Browse", self)
         self._browse_button.clicked.connect(self.output_file_dialog)
@@ -129,6 +130,15 @@ class DataWidget(QWidget):
         self._output_button = QPushButton("Save file", self)
         self._output_button.clicked.connect(self.save_to_file)
         layout.addWidget(self._output_button)
+
+    @Slot()
+    def check_file_writable(self):
+        if PLATFORM.is_file_writable(self._output_widget.text()):
+            self._output_button.setEnabled(True)
+            self._output_widget.setStyleSheet("")
+        else:
+            self._output_button.setEnabled(False)
+            self._output_widget.setStyleSheet("color: red;")
 
     @Slot()
     def output_file_dialog(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataWidget.py
@@ -40,6 +40,7 @@ from qtpy.QtWidgets import (
 from qtpy.QtCore import Slot, Signal, Qt
 
 from MDANSE.MLogging import LOG
+from MDANSE import PLATFORM
 
 from MDANSE_GUI.Tabs.Plotters.Plotter import Plotter
 
@@ -154,6 +155,7 @@ class DataWidget(QWidget):
             if nsets == 0:  # do not create a file if there are no data
                 return
         try:
+            PLATFORM.create_directory(os.path.dirname(self._output_widget.text()))
             target = open(target_path, "w", newline="")
         except:
             LOG.error(f"Could not open file for writing: {target_path}")


### PR DESCRIPTION
**Description of work**
Updated the output file configurations so that directories are not created each time their configure methods are called. File configurations now also check the filename can be created so that, for example, on Windows reserved filenames cannot be used. The data view has been updated so that files can now be saved into nested directories that do not exist yet and are also blocked from saving into files with file paths that are not valid.

**Fixes**
Fixes #627
Fixes #630

**To test**
Run the trajectory converter and manually edit the output file directory. No directories should be created until the job is run and finished. The configurator should continue to block the user from writing to protected directories. For example, on Windows, I am unable to edit the C:\Users directory without admin privileges. Check that the analysis jobs and average structure jobs work as usual. 

Check the save .csv file with the data view plot works with nested directories that do not exist yet, they should get created when the file is saved. Check that you are blocked from saving to invalid filepaths, for example on windows CON is a reserved filename.


