### PR TITLE
Fixed failure to load up jobs after selecting the trajectory editor jobs.

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
@@ -160,8 +160,6 @@ class OutputTrajectoryWidget(WidgetBase):
         filename = self._field.text()
         if len(filename) < 1:
             filename = self._default_value[0]
-        else:
-            self._parent.set_trajectory(os.path.abspath(filename))
         dtype = dtype_lookup[self.dtype_box.currentText()]
         chunk_size = self.chunk_box.value()
         compression = self.compression_box.currentText()


### PR DESCRIPTION
**Description of work**
Fixed failure to load up jobs after selecting the trajectory editor jobs.

**Fixes**
Fixes #625
Fixes #624

**To test**
Test that the trajectory conversion jobs should work as usual. Check that on the Actions tab, switching from trajectory editor and other jobs should load up without issues. Analysis jobs and trajectory editor jobs should work as usual. Check auto-load results work as usual. 
