### PR TITLE
Numerical derivatives configurators now check there are enough MD frames.

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurable.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurable.py
@@ -124,17 +124,21 @@ class Configurable(object):
 
         return self._configuration
 
-    def setup(self, parameters):
-        """
-        Setup the configuration according to a set of input parameters.
+    def setup(self, parameters: dict, rebuild: bool = True):
+        """Builds and sets the configuration according to a set of
+        input parameters.
 
-        :param parameters: the input parameters
-        :type parameters: dict
+        Parameters
+        ----------
+        parameters : dict
+            A dictionary of setting parameters.
+        rebuild : bool
+            Rebuilds all the configurators if true.
         """
-
         self._configured = False
 
-        self.build_configuration()
+        if rebuild:
+            self.build_configuration()
 
         # If no configurator has to be configured, just return
         if not self._configuration:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DerivativeOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DerivativeOrderConfigurator.py
@@ -41,6 +41,11 @@ class DerivativeOrderConfigurator(IntegerConfigurator):
         value : int or None
             The interpolation order to use.
         """
+        frames_configurator = self._configurable[self._dependencies["frames"]]
+        if not frames_configurator._valid:
+            self.error_status = f"Frames configurator is not valid."
+            return
+
         self._original_input = value
         if value is None:
             value = self._default
@@ -51,6 +56,13 @@ class DerivativeOrderConfigurator(IntegerConfigurator):
             self.error_status = (
                 f"Use an interpolation order less than or equal to zero or "
                 f"greater than 5 is not implemented."
+            )
+            return
+
+        number = frames_configurator["number"]
+        if number < value + 1:
+            self.error_status = (
+                f"Not enough MD frames to apply derivatives of order {value}"
             )
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
@@ -48,6 +48,10 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
         :param value: the interpolation order to be configured.
         :type value: str one of *'no interpolation'*,*'1st order'*,*'2nd order'*,*'3rd order'*,*'4th order'* or *'5th order'*.
         """
+        frames_configurator = self._configurable[self._dependencies["frames"]]
+        if not frames_configurator._valid:
+            self.error_status = f"Frames configurator is not valid."
+            return
 
         self._original_input = value
         if value is None or value == "":
@@ -71,5 +75,12 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
             return
 
         else:
+            number = frames_configurator["number"]
+            if number < value + 1:
+                self.error_status = (
+                    f"Not enough MD frames to apply derivatives of order {value}"
+                )
+                return
+
             self["variable"] = "coordinates"
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
@@ -71,8 +71,7 @@ class CurrentCorrelationFunction(IJob):
         "InterpolationOrderConfigurator",
         {
             "label": "velocities",
-            "dependencies": {"trajectory": "trajectory"},
-            "default": 1,
+            "dependencies": {"trajectory": "trajectory", "frames": "frames"},
         },
     )
     settings["q_vectors"] = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -53,7 +53,10 @@ class DensityOfStates(IJob):
     )
     settings["interpolation_order"] = (
         "InterpolationOrderConfigurator",
-        {"label": "velocities", "dependencies": {"trajectory": "trajectory"}},
+        {
+            "label": "velocities",
+            "dependencies": {"trajectory": "trajectory", "frames": "frames"},
+        },
     )
     settings["projection"] = (
         "ProjectionConfigurator",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
@@ -47,7 +47,10 @@ class Infrared(IJob):
     )
     settings["derivative_order"] = (
         "DerivativeOrderConfigurator",
-        {"label": "d/dt dipole numerical derivative"},
+        {
+            "label": "d/dt dipole numerical derivative",
+            "dependencies": {"frames": "frames"},
+        },
     )
     settings["molecule_name"] = (
         "MoleculeSelectionConfigurator",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -56,8 +56,7 @@ class Temperature(IJob):
         "InterpolationOrderConfigurator",
         {
             "label": "velocities",
-            "dependencies": {"trajectory": "trajectory"},
-            "default": 1,
+            "dependencies": {"trajectory": "trajectory", "frames": "frames"},
         },
     )
     settings["output_files"] = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -68,7 +68,10 @@ class VelocityAutoCorrelationFunction(IJob):
     )
     settings["interpolation_order"] = (
         "InterpolationOrderConfigurator",
-        {"label": "velocities", "dependencies": {"trajectory": "trajectory"}},
+        {
+            "label": "velocities",
+            "dependencies": {"trajectory": "trajectory", "frames": "frames"},
+        },
     )
     settings["projection"] = (
         "ProjectionConfigurator",

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/DerivativeOrderWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/DerivativeOrderWidget.py
@@ -38,7 +38,7 @@ class DerivativeOrderWidget(WidgetBase):
         self._field.setValue(3)
         label = QLabel("Interpolation order", self._base)
         self.numerator = QLabel("st order")
-        self.adjust_numerator(3)
+        self.adjust_numerator_and_update(3)
 
         self._layout.addWidget(label)
         self._layout.addWidget(self._field)
@@ -53,7 +53,16 @@ class DerivativeOrderWidget(WidgetBase):
 
         self._field.setToolTip(tooltip_text)
         self.numerator.setToolTip(tooltip_text)
-        self._field.valueChanged.connect(self.adjust_numerator)
+        self._field.valueChanged.connect(self.adjust_numerator_and_update)
+
+        for widget in self.parent()._widgets:
+            if (
+                widget._configurator
+                is self._configurator._configurable[
+                    self._configurator._dependencies["frames"]
+                ]
+            ):
+                widget.value_changed.connect(self.updateValue)
 
     def configure_using_default(self):
         """This is too simple to have a default value"""
@@ -65,10 +74,11 @@ class DerivativeOrderWidget(WidgetBase):
             self._tooltip = "The order of the polynomial function used for interpolating time-dependent variables."
 
     @Slot(int)
-    def adjust_numerator(self, order: int):
+    def adjust_numerator_and_update(self, order: int):
         text_order = str(order)
         new_numerator = suffix_dict.get(text_order[-1])
         self.numerator.setText(new_numerator)
+        self.updateValue()
 
     def get_widget_value(self):
         value = self._field.value()

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InterpolationOrderWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InterpolationOrderWidget.py
@@ -46,7 +46,7 @@ class InterpolationOrderWidget(WidgetBase):
             self._field.setValue(3)
         label = QLabel("Interpolation order", self._base)
         self.numerator = QLabel("st order")
-        self.adjust_numerator(3)
+        self.adjust_numerator_and_update(3)
 
         self._layout.addWidget(label)
         self._layout.addWidget(self._field)
@@ -60,7 +60,16 @@ class InterpolationOrderWidget(WidgetBase):
             tooltip_text = "The order of the polynomial function used for interpolating velocity values from atom positions. If zero, velocity values present in the trajectory will be used."
         self._field.setToolTip(tooltip_text)
         self.numerator.setToolTip(tooltip_text)
-        self._field.valueChanged.connect(self.adjust_numerator)
+        self._field.valueChanged.connect(self.adjust_numerator_and_update)
+
+        for widget in self.parent()._widgets:
+            if (
+                widget._configurator
+                is self._configurator._configurable[
+                    self._configurator._dependencies["frames"]
+                ]
+            ):
+                widget.value_changed.connect(self.updateValue)
 
     def configure_using_default(self):
         """This is too simple to have a default value"""
@@ -76,10 +85,11 @@ class InterpolationOrderWidget(WidgetBase):
             self._tooltip = "The order of the polynomial function used for interpolating velocity values from atom positions. If zero, velocity values present in the trajectory will be used."
 
     @Slot(int)
-    def adjust_numerator(self, order: int):
+    def adjust_numerator_and_update(self, order: int):
         text_order = str(order)
         new_numerator = suffix_dict.get(text_order[-1], " - no interpolation")
         self.numerator.setText(new_numerator)
+        self.updateValue()
 
     def get_widget_value(self):
         value = self._field.value()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -336,7 +336,7 @@ class Action(QWidget):
             self.allow_execution()
             LOG.info("Show output prediction")
             pardict = self.set_parameters()
-            self._job_instance.setup(pardict)
+            self._job_instance.setup(pardict, rebuild=False)
             axes = self._job_instance.preview_output_axis()
             LOG.info(f"Axes = {axes.keys()}")
             text = "<p><b>The results will cover the following range:</b></p>"


### PR DESCRIPTION
**Description of work**
Updated the numerical derivatives configurators now check there are enough MD frames and corresponding widgets so that they go into the invalid state when the frames and derivatives orders are not valid.

![Animation62](https://github.com/user-attachments/assets/6e06ee8e-8cc7-4c3a-ae22-b0291865f761)

**Fixes**
Fixes #583

**To test**
Test calculations that apply the numerical derivatives such as DOS and VACF. Using the GUI check that the configurator widgets go into an invalid state when there aren't enough frames for the selected interpolation order e.g. order 5 with the number of MD frames equal 2.


