### PR TITLE
Fixed discover fold setting

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Converters/Discover.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Discover.py
@@ -363,7 +363,8 @@ class Discover(Converter):
         conf["coordinates"][movableAtoms, :] = config
         conf["velocities"][movableAtoms, :] = vel
 
-        conf.fold_coordinates()
+        if self.configuration["fold"]["value"]:
+            conf.fold_coordinates()
 
         self._trajectory.chemical_system.configuration = conf
 


### PR DESCRIPTION
**Description of work**
Previously the Discover converter always folded the trajectory whether or not the setting had been selected.

**Fixes**
The discover converter fold setting.

**To test**
Run the discover converter job and check that the fold setting works correctly.
