### PR TITLE
Bond tolerance update and trajectory editor widget fixes.

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -79,7 +79,7 @@ class TrajectoryEditor(IJob):
         "OptionalFloatConfigurator",
         {
             "default": [False, 0.04],
-            "label_text": "Search for molecules (using the following bond length tolerance)",
+            "label_text": "Search for molecules (covalent radii plus the tolerance in nm)",
         },
     )
     settings["output_files"] = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -78,7 +78,7 @@ class TrajectoryEditor(IJob):
     settings["molecule_tolerance"] = (
         "OptionalFloatConfigurator",
         {
-            "default": [False, 0.25],
+            "default": [False, 0.04],
             "label_text": "Search for molecules (using the following bond length tolerance)",
         },
     )

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Connectivity.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Connectivity.py
@@ -15,7 +15,7 @@
 #
 
 from itertools import product
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 from numpy.typing import NDArray
@@ -145,27 +145,29 @@ class Connectivity:
             tree2 = KDTree(coordinates + offset.reshape((1, 3)))
             yield num, tree1.sparse_distance_matrix(tree2, max_distance=max_distance)
 
-    def find_bonds(self, frames: List[int] = None, tolerance: float = 0.2):
+    def find_bonds(self, frames: Optional[List[int]] = None, tolerance: float = 0.04):
         """Checks several frames of the trajectory for the presence of atom pairs
         close enough to each other to form chemical bonds. The detected bonds
         are stored internally.
 
-        Keyword Arguments:
-            frames -- a list of specific trajectory frames at which to check the bond
-                length. Optional (default: {None})
-            tolerance -- A float constant specifying the tolerance of bond length used
-                in bond detection. 0.2 means that distance between atoms may be
-                up to 20% larger than the nominal length of the bond (default: {0.2})
+        Parameters
+        ----------
+        frames : Optional[List[int]]
+            A list of specific trajectory frames at which to check the bond
+            length. Optional (default: {None})
+        tolerance : float
+            A float constant specifying the tolerance of bond length used
+            in bond detection. A bond between two atoms is defined as the
+            sum of their covalent radii plus the tolerance in nm.
         """
         if frames is None:
             samples = [len(self._frames) // denom for denom in [2, 3, 4, 5, 6, 7]]
         else:
             samples = frames
         samples = list(np.unique(samples))
-        bonds = []
         pairs = product(self._unique_elements, repeat=2)
         maxbonds = {
-            pair: (self._radii[pair[0]] + self._radii[pair[1]]) * (1.0 + tolerance)
+            pair: (self._radii[pair[0]] + self._radii[pair[1]]) + tolerance
             for pair in pairs
         }
         total_max_length = np.max([x for x in maxbonds.values()])

--- a/MDANSE/Tests/UnitTests/TrajectoryEditor/test_editor.py
+++ b/MDANSE/Tests/UnitTests/TrajectoryEditor/test_editor.py
@@ -222,7 +222,7 @@ def test_editor_find_molecules():
     parameters = {}
     parameters["output_files"] = (temp_name, 64, 128, "gzip", "INFO")
     parameters["trajectory"] = short_traj
-    parameters["molecule_tolerance"] = [True, 0.25]
+    parameters["molecule_tolerance"] = [True, 0.04]
     parameters["frames"] = (0, 501, 1)
     temp = IJob.create("TrajectoryEditor")
     temp.run(parameters, status=True)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OptionalFloatWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OptionalFloatWidget.py
@@ -18,9 +18,11 @@ from qtpy.QtGui import QDoubleValidator
 from qtpy.QtCore import Slot, Qt
 
 from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
+from MDANSE.MLogging import LOG
 
 
 class OptionalFloatWidget(WidgetBase):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         try:
@@ -92,5 +94,13 @@ class OptionalFloatWidget(WidgetBase):
             return [False, self._default_value]
         strval = self._field.text().strip()
         if len(strval) < 1:
-            self._empty = True
+            strval = self._default_value
         return [True, strval]
+
+    def configure_using_default(self):
+        """Makes the configurator use its default value, and highlights it
+        in the GUI"""
+        default = self._configurator.default
+        LOG.info(f"Setting {default} as placeholder text")
+        self._field.setPlaceholderText(str(self._default_value))
+        self._configurator.configure(default)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/UnitCellWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/UnitCellWidget.py
@@ -42,7 +42,9 @@ class UnitCellWidget(WidgetBase):
             self.start_values = self._configurator._default
         for row in range(3):
             for column in range(3):
-                temp = QLineEdit(str(round(self.start_values[row][column], 5)), self._base)
+                temp = QLineEdit(
+                    str(round(self.start_values[row][column], 5)), self._base
+                )
                 temp.setValidator(QDoubleValidator())
                 temp.setEnabled(False)
                 temp.setPlaceholderText(str(round(self.start_values[row][column], 5)))

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/UnitCellWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/UnitCellWidget.py
@@ -22,6 +22,7 @@ from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
 
 
 class UnitCellWidget(WidgetBase):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, layout_type="grid", **kwargs)
         self._changing_label = QLabel("Unit cell", parent=self._base)
@@ -36,14 +37,15 @@ class UnitCellWidget(WidgetBase):
         self._array_fields = {}
         self._configurator.update_trajectory_information()
         try:
-            start_values = self._configurator._recommended_cell
+            self.start_values = self._configurator._recommended_cell
         except AttributeError:
-            start_values = self._configurator._default
+            self.start_values = self._configurator._default
         for row in range(3):
             for column in range(3):
-                temp = QLineEdit(str(round(start_values[row][column], 5)), self._base)
+                temp = QLineEdit(str(round(self.start_values[row][column], 5)), self._base)
                 temp.setValidator(QDoubleValidator())
                 temp.setEnabled(False)
+                temp.setPlaceholderText(str(round(self.start_values[row][column], 5)))
                 self._layout.addWidget(temp, row, column + 1)
                 self._array_fields[(row, column)] = temp
         self._mode = 0
@@ -71,7 +73,7 @@ class UnitCellWidget(WidgetBase):
 
     def get_widget_value(self):
         """Collect the results from the input widgets and return the value."""
-        array = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        array = self.start_values
         apply = self._apply_box.checkState() == Qt.CheckState.Checked
         if apply:
             for key, value in self._array_fields.items():


### PR DESCRIPTION
**Description of work**
Adjusted the way that the bonds are determined, previously it was the sum of the covalent radii multiplied by (1 + tolerance).  I have changed this so that it is the sum of covalent radii plus ~0.4 angstrom. This is the standard method, I don't know where this came from I think probably from the CCDC since they did some work determining the covalent radii using the CSD. But anyway here are some places where this method is used.

https://www.ccdc.cam.ac.uk/media/superstar-1.pdf (see section 10.2.9 COVALENT_TOLERANCE)
https://pubs.acs.org/doi/10.1021/ci700028w
https://jcheminf.biomedcentral.com/articles/10.1186/1758-2946-3-33 (see section Bond Perception and Atom Typing)
https://docs.eyesopen.com/toolkits/python/oechemtk/OEChemFunctions/OEDetermineConnectivity.html

**Fixes**
Fixes #637

**To test**

- Run the trajectory editor with molecule finder and check that the expected molecules are found. 
- Check that the default values are filled and used after running the job when the entry boxes are empty in the unit cell and molecule finder widgets.
