### PR TITLE
Add timeout to MDANSE unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install pytest
-        run: python -m pip install pytest
+        run: python -m pip install pytest pytest-timeout
 
       - name: install MDANSE
         run: (cd MDANSE && python -m pip install .)

--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -58,6 +58,9 @@ MDANSE = ["Chemistry/*.json",
 [project.scripts]
 mdanse = "MDANSE.Scripts.mdanse:main"
 
+[tool.pytest.ini_options]
+timeout = 240
+
 [tool.ruff]
 line-length = 88
 indent-width = 4


### PR DESCRIPTION
**Description of work**

Following the discussion of #673 we add timeout to unit tests.

**Fixes**
Added pytest-timeout to the workflow.
Set tests timeout in pyproject.toml.

**To test**
Tests should pass same as before.
