### PR TITLE
Rename workflow to include information

### DIFF
--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Install MDANSE_GUI on ${{ matrix.os }}
+    name: (${{ matrix.os }}-${{ matrix.python-version }}) Install MDANSE & MDANSE_GUI
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -24,7 +24,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: install MDANSE
-        run: (cd MDANSE && python -m pip install .)
+        working-directory: MDANSE
+        run: python -m pip install .
 
       - name: install MDANSE_GUI
-        run: (cd MDANSE_GUI && python -m pip install .)
+        working-directory: MDANSE_GUI
+        run: python -m pip install .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Build MDANSE and run tests on ${{ matrix.os }}
+    name: (${{ matrix.os }}-${{ matrix.python-version }}) Build MDANSE and run tests
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -15,6 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # os: [ubuntu-20.04, windows-2019, macOS-11, ubuntu-latest, windows-latest, macOS-latest]
+
     if: |
       !contains( github.ref, 'legacy' )
     steps:
@@ -27,10 +28,10 @@ jobs:
       - name: Install pytest
         run: python -m pip install pytest pytest-timeout
 
-      - name: install MDANSE
-        run: (cd MDANSE && python -m pip install .)
+      - name: Install MDANSE
+        working-directory: MDANSE
+        run: python -m pip install .
 
-      - name: run unit tests
-        run: |
-          cd MDANSE/Tests/UnitTests
-          python -m pytest
+      - name: Run unit tests
+        working-directory: MDANSE/Tests/UnitTests
+        run: python -m pytest


### PR DESCRIPTION
**Description of work**
- Include Python version in workflow name. 
- Make important information come first to avoid elision.
- Use `working-directory`

**Fixes**
Fixes #701 

**To test**
May require adjusting of required workflows when merged.