### PR TITLE
Update tests to use assert_allclose

### DIFF
--- a/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
@@ -69,12 +69,12 @@ def test_vacf(interp_order, normalise):
     with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
         for key in ["vacf_Cu", "vacf_S", "vacf_Sb", "vacf_total"]:
             if normalise:
-                np.testing.assert_array_almost_equal(
+                np.testing.assert_allclose(
                     actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                     desired[f"/{key}"],
                 )
             else:
-                np.testing.assert_array_almost_equal(
+                np.testing.assert_allclose(
                     actual[f"/{key}"], desired[f"/{key}"],
                 )
 
@@ -109,7 +109,7 @@ def test_pps():
             "pps_Sb",
             "pps_total",
         ]:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                 desired[f"/{key}"],
             )
@@ -199,12 +199,12 @@ def test_dynamics_analysis(
             for key in keys:
                 # reference results may or may not have been scaled/normalized
                 if job_info[2]:
-                    np.testing.assert_array_almost_equal(
+                    np.testing.assert_allclose(
                         actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                         desired[f"/{key}"],
                     )
                 else:
-                    np.testing.assert_array_almost_equal(
+                    np.testing.assert_allclose(
                         actual[f"/{key}"], desired[f"/{key}"],
                     )
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_infrared.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_infrared.py
@@ -50,7 +50,7 @@ def test_dacf_analysis():
     result_file = os.path.join(result_dir, "dacf_analysis.mda")
 
     with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/dacf"] * actual["/dacf"].attrs["scaling_factor"], desired["/dacf"]
         )
 
@@ -92,11 +92,11 @@ def test_ir_analysis():
     result_file = os.path.join(result_dir, "ir_analysis.mda")
 
     with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/ddacf"] * actual["/ddacf"].attrs["scaling_factor"],
             desired["/ddacf"],
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/ir"] * actual["/ir"].attrs["scaling_factor"], desired["/ir"]
         )
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_mdmc_h5md.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_mdmc_h5md.py
@@ -45,16 +45,16 @@ def test_h5md_temperature(trajectory, interp_order):
     result_file = os.path.join(result_dir, f"h5md_temperature_{interp_order}.mda")
 
     with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/kinetic_energy"], desired["/kinetic_energy"]
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/temperature"], desired["/temperature"]
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/avg_kinetic_energy"], desired["/avg_kinetic_energy"]
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/avg_temperature"], desired["/avg_temperature"]
         )
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
@@ -45,10 +45,10 @@ def test_basic_meansquare():
     result_file = os.path.join(result_dir, "basic_meansquare.mda")
 
     with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
-        np.testing.assert_array_almost_equal(actual["/msd_Cu"], desired["/msd_Cu"])
-        np.testing.assert_array_almost_equal(actual["/msd_S"], desired["/msd_S"])
-        np.testing.assert_array_almost_equal(actual["/msd_Sb"], desired["/msd_Sb"])
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(actual["/msd_Cu"], desired["/msd_Cu"])
+        np.testing.assert_allclose(actual["/msd_S"], desired["/msd_S"])
+        np.testing.assert_allclose(actual["/msd_Sb"], desired["/msd_Sb"])
+        np.testing.assert_allclose(
             actual["/msd_total"], desired["/msd_total"]
         )
 
@@ -81,7 +81,7 @@ def test_parallel_meansquare():
     ):
         for kk in single.keys():
             if not "metadata" in kk:
-                np.testing.assert_array_almost_equal(
+                np.testing.assert_allclose(
                     np.array(single[kk]), np.array(parallel[kk])
                 )
     os.remove(temp_name + ".mda")

--- a/MDANSE/Tests/UnitTests/Analysis/test_mock_dynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_mock_dynamics.py
@@ -53,12 +53,12 @@ def test_vacf(interp_order, normalise):
     with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
         for key in ["vacf_H", "vacf_O", "vacf_Si", "vacf_total"]:
             if normalise:
-                np.testing.assert_array_almost_equal(
+                np.testing.assert_allclose(
                     actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                     desired[f"/{key}"],
                 )
             else:
-                np.testing.assert_array_almost_equal(
+                np.testing.assert_allclose(
                     actual[f"/{key}"], desired[f"/{key}"],
                 )
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_molecule_names.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_molecule_names.py
@@ -75,7 +75,7 @@ def test_structure_analysis(parameters, job_info):
 
     with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
         for key in job_info[1]:
-            np.testing.assert_array_almost_equal(actual[f"/{key}"], desired[f"/{key}"])
+            np.testing.assert_allclose(actual[f"/{key}"], desired[f"/{key}"])
 
     os.remove(temp_name + ".mda")
     assert path.exists(temp_name + ".log")

--- a/MDANSE/Tests/UnitTests/Analysis/test_resolutions.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_resolutions.py
@@ -110,7 +110,7 @@ def test_dos(trajectory, resolution_generator):
             "vacf_Sb",
             "vacf_total",
         ]:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                 desired[f"/{key}"],
             )

--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -114,7 +114,7 @@ def test_dcsf(traj_info, qvector_grid):
             if any(key.startswith(j) for j in ["f(q,t)", "s(q,f)"])
         ]
         for key in keys:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                 desired[f"/{key}"] * desired[f"/{key}"].attrs["scaling_factor"],
             )
@@ -155,7 +155,7 @@ def test_ccf(traj_info, qvector_grid):
             i for i in desired.keys() if any([j in i for j in ["J(q,f)", "j(q,t)"]])
         ]
         for key in keys:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                 desired[f"/{key}"] * desired[f"/{key}"].attrs["scaling_factor"],
             )
@@ -215,7 +215,7 @@ def test_disf(traj_info, qvector_grid):
             i for i in desired.keys() if any([j in i for j in ["f(q,t)", "s(q,f)"]])
         ]
         for key in keys:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                 desired[f"/{key}"] * desired[f"/{key}"].attrs["scaling_factor"],
             )
@@ -253,7 +253,7 @@ def test_eisf(traj_info, qvector_grid):
     with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
         keys = [i for i in desired.keys() if "eisf" in i]
         for key in keys:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                 desired[f"/{key}"],
             )
@@ -294,7 +294,7 @@ def test_gdisf(traj_info):
             i for i in desired.keys() if any([j in i for j in ["f(q,t)", "s(q,f)", "msd"]])
         ]
         for key in keys:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                 desired[f"/{key}"] * desired[f"/{key}"].attrs["scaling_factor"],
             )
@@ -329,7 +329,7 @@ def test_ndtsf(disf, dcsf, qvector_grid):
             i for i in desired.keys() if any([j in i for j in ["f(q,t)", "s(q,f)"]])
         ]
         for key in keys:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual[f"/{key}"] * actual[f"/{key}"].attrs["scaling_factor"],
                 desired[f"/{key}"] * desired[f"/{key}"].attrs["scaling_factor"],
             )

--- a/MDANSE/Tests/UnitTests/Analysis/test_structure.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_structure.py
@@ -128,7 +128,7 @@ def test_structure_analysis(
         with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
             keys = [i for i in desired.keys() if any([j in i for j in job_info[1]])]
             for key in keys:
-                np.testing.assert_array_almost_equal(
+                np.testing.assert_allclose(
                     actual[f"/{key}"], desired[f"/{key}"]
                 )
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_thermodynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_thermodynamics.py
@@ -63,16 +63,16 @@ def test_temperature(traj_info, interp_order):
     )
 
     with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/kinetic_energy"], desired["/kinetic_energy"]
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/temperature"], desired["/temperature"]
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/avg_kinetic_energy"], desired["/avg_kinetic_energy"]
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/avg_temperature"], desired["/avg_temperature"]
         )
 
@@ -109,16 +109,16 @@ def test_density(traj_info, output_format):
         result_file = os.path.join(result_dir, f"density_{traj_info[0]}.mda")
 
         with h5py.File(temp_name + ".mda") as actual, h5py.File(result_file) as desired:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual["/atomic_density"], desired["/atomic_density"]
             )
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual["/mass_density"], desired["/mass_density"]
             )
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual["/avg_atomic_density"], desired["/avg_atomic_density"]
             )
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 actual["/avg_mass_density"], desired["/avg_mass_density"]
             )
 

--- a/MDANSE/Tests/UnitTests/TrajectoryEditor/test_editor.py
+++ b/MDANSE/Tests/UnitTests/TrajectoryEditor/test_editor.py
@@ -67,10 +67,10 @@ def test_editor_null():
     changed.close()
 
     with h5py.File(temp_name + ".mdt") as actual, h5py.File(short_traj) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/configuration/coordinates"], desired["/configuration/coordinates"]
         )
-        np.testing.assert_array_almost_equal(actual["/time"], desired["/time"])
+        np.testing.assert_allclose(actual["/time"], desired["/time"])
 
     os.remove(temp_name + ".mdt")
     os.remove(temp_name + ".log")
@@ -101,11 +101,11 @@ def test_editor_frames():
     changed.close()
 
     with h5py.File(temp_name + ".mdt") as actual, h5py.File(short_traj) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/configuration/coordinates"],
             desired["/configuration/coordinates"][0:501:10],
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/time"], desired["/time"][0:501:10]
         )
 
@@ -139,11 +139,11 @@ def test_editor_atoms():
     changed.close()
 
     with h5py.File(temp_name + ".mdt") as actual, h5py.File(short_traj) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/configuration/coordinates"],
             desired["/configuration/coordinates"][:, 6:20, :],
         )
-        np.testing.assert_array_almost_equal(actual["/time"], desired["/time"])
+        np.testing.assert_allclose(actual["/time"], desired["/time"])
 
     os.remove(temp_name + ".mdt")
     os.remove(temp_name + ".log")
@@ -177,10 +177,10 @@ def test_editor_unit_cell():
     changed.close()
 
     with h5py.File(temp_name + ".mdt") as actual, h5py.File(short_traj) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/configuration/coordinates"], desired["/configuration/coordinates"]
         )
-        np.testing.assert_array_almost_equal(actual["/time"], desired["/time"])
+        np.testing.assert_allclose(actual["/time"], desired["/time"])
 
     os.remove(temp_name + ".mdt")
     os.remove(temp_name + ".log")
@@ -218,10 +218,10 @@ def test_editor_transmute():
     changed.close()
 
     with h5py.File(temp_name + ".mdt") as actual, h5py.File(short_traj) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/configuration/coordinates"], desired["/configuration/coordinates"]
         )
-        np.testing.assert_array_almost_equal(actual["/time"], desired["/time"])
+        np.testing.assert_allclose(actual["/time"], desired["/time"])
 
     os.remove(temp_name + ".mdt")
     os.remove(temp_name + ".log")
@@ -252,10 +252,10 @@ def test_editor_set_charges():
     changed.close()
 
     with h5py.File(temp_name + ".mdt") as actual, h5py.File(short_traj) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/configuration/coordinates"], desired["/configuration/coordinates"]
         )
-        np.testing.assert_array_almost_equal(actual["/time"], desired["/time"])
+        np.testing.assert_allclose(actual["/time"], desired["/time"])
 
     os.remove(temp_name + ".mdt")
     os.remove(temp_name + ".log")
@@ -283,10 +283,10 @@ def test_editor_find_molecules():
     changed.close()
 
     with h5py.File(temp_name + ".mdt") as actual, h5py.File(short_traj) as desired:
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             actual["/configuration/coordinates"], desired["/configuration/coordinates"]
         )
-        np.testing.assert_array_almost_equal(actual["/time"], desired["/time"])
+        np.testing.assert_allclose(actual["/time"], desired["/time"])
 
     os.remove(temp_name + ".mdt")
     os.remove(temp_name + ".log")

--- a/MDANSE/Tests/UnitTests/test_converter.py
+++ b/MDANSE/Tests/UnitTests/test_converter.py
@@ -68,7 +68,7 @@ def _converter_test(tmp_path, converter_type, result, compare, parameters, compr
 
     with h5py.File(out_name) as actual, h5py.File(result_name) as desired:
         for prop in compare:
-            np.testing.assert_array_almost_equal(actual[prop], desired[prop])
+            np.testing.assert_allclose(actual[prop], desired[prop])
 
     assert out_name.is_file()
     assert log_name.is_file()


### PR DESCRIPTION
**Description of work**
Update array test to use assert_allclose. A lot of tests used assert_array_almost_equal, which only checks if `abs(desired-actual) < 1.5 * 10**(-decimal)` where `decimal=6` this is not good when checking values that are small.

**To test**
Test must pass
