### PR TITLE
[WIP] Storing and re-using atom selections

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/__init__.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/__init__.py
@@ -13,3 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+from .selection_storage import SelectionStorage
+
+SELECTION_STORAGE = SelectionStorage()

--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/selection_storage.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/selection_storage.py
@@ -18,12 +18,9 @@ import json
 from pathlib import Path
 from typing import Any, Optional
 
-import h5py
-
 from MDANSE import PLATFORM
 from MDANSE.Framework.AtomSelector.selector import ReusableSelection
 from MDANSE.MLogging import LOG
-from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
 DEFAULT_DATABASE = (
     PLATFORM.base_directory() / "MDANSE" / "Framework" / "selection_storage.json"
@@ -46,7 +43,7 @@ class SingleEntry:
             string label of the selection in the database, by default None
 
         """
-        self.data_fields = ["name", "json_string"]
+        self.data_fields = {"name", "json_string"}
         self.name = name
         self.json_string = json_string
 
@@ -54,7 +51,7 @@ class SingleEntry:
         """Set values from a dictionary, typically loaded from file."""
         for key, value in saved_values.items():
             setattr(self, key, value)
-            self.data_fields.append(key)
+            self.data_fields.add(key)
 
     def to_json(self) -> str:
         """Save all the data fields as a single dictionary in a JSON string."""
@@ -63,7 +60,7 @@ class SingleEntry:
 
 
 class SelectionStorage:
-    """Stores atom selection logic used most often by the users."""
+    """Stores atom selection sequences used by the users."""
 
     def __init__(self, filename: Optional[str] = None):
         """Create a backend for finding selection strings.
@@ -97,7 +94,8 @@ class SelectionStorage:
         path = Path(filename)
         if not path.exists():
             LOG.warning(
-                f"File {filename} was not found." "Atoms selections will not be loaded."
+                "File %s was not found." "Atoms selections will not be loaded.",
+                (filename),
             )
             return
         with path.open() as source:

--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/selection_storage.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/selection_storage.py
@@ -1,0 +1,125 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import h5py
+
+from MDANSE import PLATFORM
+from MDANSE.Framework.AtomSelector.selector import ReusableSelection
+from MDANSE.MLogging import LOG
+from MDANSE.MolecularDynamics.Trajectory import Trajectory
+
+DEFAULT_DATABASE = (
+    PLATFORM.base_directory() / "MDANSE" / "Framework" / "selection_storage.json"
+)
+
+USER_DATABASE = PLATFORM.application_directory() / "selection_storage.json"
+
+
+class SingleEntry:
+    """A ReusableSelection together with its usage statistics."""
+
+    def __init__(self, json_string: Optional[str] = None, name: Optional[str] = None):
+        """Create an emtpy entry in the selection database.
+
+        Parameters
+        ----------
+        json_string : Optional[str], optional
+            The input to a ReusableSelection, by default None
+        name : Optional[str], optional
+            string label of the selection in the database, by default None
+
+        """
+        self.data_fields = ["name", "json_string"]
+        self.name = name
+        self.json_string = json_string
+
+    def from_dictionary(self, saved_values: dict[str, Any]):
+        """Set values from a dictionary, typically loaded from file."""
+        for key, value in saved_values.items():
+            setattr(self, key, value)
+            self.data_fields.append(key)
+
+    def to_json(self) -> str:
+        """Save all the data fields as a single dictionary in a JSON string."""
+        results = {key: getattr(self, key, "") for key in self.data_fields}
+        return json.dumps(results)
+
+
+class SelectionStorage:
+    """Stores atom selection logic used most often by the users."""
+
+    def __init__(self, filename: Optional[str] = None):
+        """Create a backend for finding selection strings.
+
+        Parameters
+        ----------
+        filename : Optional[str], optional
+            Name of a non-standard file from which to load selections, by default None
+
+        """
+        self._named_entries = {}
+        self._unnamed_entries = []
+        self.load_from_file(DEFAULT_DATABASE)
+        if not filename:
+            self.load_from_file(USER_DATABASE)
+        else:
+            self.load_from_file(filename)
+
+    def load_from_file(self, filename: str):
+        """Populate the internal list with entries from a file.
+
+        If an entry with a specific key already exists, it will
+        be overwritten.
+
+        Parameters
+        ----------
+        filename : str
+            name of the file containing the selection definitions
+
+        """
+        path = Path(filename)
+        if not path.exists():
+            LOG.warning(
+                f"File {filename} was not found." "Atoms selections will not be loaded."
+            )
+            return
+        with path.open() as source:
+            entries = json.load(source)
+        for entry_dict in entries:
+            temp_entry = SingleEntry()
+            temp_entry.from_dictionary(entry_dict)
+            if name_str := entry_dict["name"]:
+                self._named_entries[name_str] = temp_entry
+            else:
+                self._unnamed_entries.append(temp_entry)
+
+    def save_to_file(self, filename: str):
+        """Write all entires to the specified file.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the file where the selections will be saved.
+
+        """
+        path = Path(filename)
+        with path.open("w") as target:
+            target.write(json.dumps(self._named_entries))
+            target.write(json.dumps(self._unnamed_entries))

--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/selector.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/selector.py
@@ -17,6 +17,8 @@
 import json
 from typing import Any, Optional
 
+import h5py
+from MDANSE.MLogging import LOG
 from MDANSE.Framework.AtomSelector.atom_selection import select_atoms
 from MDANSE.Framework.AtomSelector.general_selection import (
     invert_selection,
@@ -233,3 +235,24 @@ class ReusableSelection:
             if not isinstance(v0, dict):
                 raise TypeError(f"Selection {v0} is not a dictionary.")
             self.set_selection(number=k0, function_parameters=v0)
+
+    def load_from_hdf5(self, filename: str):
+        """Load selection from an HDF5 output file (MDA format).
+
+        Parameters
+        ----------
+        filename : str
+            path to an MDA file, given as string
+
+        """
+        source = h5py.File(filename)
+        try:
+            byte_string = source["metadata/inputs/atom_selection"][0]
+        except KeyError:
+            LOG.error(f"atom selection string not found in file {filename}")
+            source.close()
+            return
+        else:
+            json_string = json.loads(byte_string.decode())
+        source.close()
+        self.load_from_json(json_string)

--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/selector.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/selector.py
@@ -18,7 +18,7 @@ import json
 from typing import Any, Optional
 
 import h5py
-from MDANSE.MLogging import LOG
+
 from MDANSE.Framework.AtomSelector.atom_selection import select_atoms
 from MDANSE.Framework.AtomSelector.general_selection import (
     invert_selection,
@@ -31,6 +31,7 @@ from MDANSE.Framework.AtomSelector.spatial_selection import (
     select_positions,
     select_sphere,
 )
+from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
 function_lookup = {

--- a/MDANSE/Tests/UnitTests/test_reusable_selection.py
+++ b/MDANSE/Tests/UnitTests/test_reusable_selection.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 
+from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.AtomSelector.selector import ReusableSelection
 from MDANSE.Framework.InputData.HDFTrajectoryInputData import HDFTrajectoryInputData
 
@@ -31,6 +32,26 @@ traj_2vb1 = os.path.join(
 @pytest.fixture(scope='module')
 def trajectory(request):
    return HDFTrajectoryInputData(request.param)
+
+
+def run_simple_job(tmp_path, input_trajectory, selection):
+    temp_name = tmp_path / "output"
+    out_file = temp_name.with_suffix(".mda")
+    log_file = temp_name.with_suffix(".log")
+
+    parameters = {
+        "atom_selection": selection,
+        "output_files": (temp_name, ("MDAFormat",), "INFO"),
+        "running_mode": ("single-core",),
+        "trajectory": input_trajectory,
+    }
+
+    temp = IJob.create("Eccentricity")
+    temp.run(parameters, status=True)
+
+    assert out_file.is_file()
+    assert log_file.is_file()
+    return out_file
 
 
 @pytest.mark.parametrize("trajectory", [short_traj, mdmc_traj, com_traj], indirect=True)
@@ -199,3 +220,21 @@ def test_selection_with_multiple_steps(trajectory):
     another_selection.load_from_json(json_string)
     water_oxygen_selection = another_selection.select_in_trajectory(trajectory.trajectory)
     assert len(water_oxygen_selection) == int(28746/3)
+
+
+@pytest.mark.parametrize("trajectory", [short_traj], indirect=True)
+@pytest.mark.parametrize("index_slice, expected", (
+    ([150,350,10], 20),
+    ([470,510,5], 2),
+))
+def test_load_selection_from_output(tmp_path, trajectory, index_slice, expected):
+    reusable_selection = ReusableSelection()
+    reusable_selection.set_selection(number=None, function_parameters={'function_name': 'select_atoms', 'index_slice': index_slice})
+    range_selection = reusable_selection.select_in_trajectory(trajectory.trajectory)
+    assert len(range_selection) == expected
+    json_string = reusable_selection.convert_to_json()
+    result_file = run_simple_job(tmp_path, trajectory.trajectory._filename, json_string)
+    another_selection = ReusableSelection()
+    another_selection.load_from_hdf5(result_file)
+    repeated_selection = another_selection.select_in_trajectory(trajectory.trajectory)
+    assert repeated_selection == range_selection

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -16,6 +16,7 @@
 
 import json
 from enum import StrEnum
+from pathlib import PurePath
 
 from MDANSE.Framework.AtomSelector.selector import ReusableSelection
 from MDANSE.Framework.InputData.HDFTrajectoryInputData import HDFTrajectoryInputData
@@ -24,6 +25,7 @@ from qtpy.QtGui import QStandardItem, QStandardItemModel
 from qtpy.QtWidgets import (
     QAbstractItemView,
     QDialog,
+    QFileDialog,
     QGroupBox,
     QHBoxLayout,
     QLabel,
@@ -152,6 +154,14 @@ class SelectionModel(QStandardItemModel):
         new_item.setEditable(False)
         self.appendRow(new_item)
         self.selection_changed.emit()
+
+    @Slot(str)
+    def create_from_string(self, json_string: str):
+        """Initialise a new selection from a string."""
+        self.clear()
+        dictionary = json.loads(json_string)
+        for selection_line in dictionary.values():
+            self.accept_from_widget(json.dumps(selection_line))
 
 
 class SelectionHelper(QDialog):
@@ -398,7 +408,9 @@ class SelectionHelper(QDialog):
 class AtomSelectionWidget(WidgetBase):
     """The atoms selection widget."""
 
-    _push_button_text = "Atom selection helper"
+    _push_button_text = "Create using helper dialog"
+    _database_button_text = "Pick from database"
+    _mda_button_text = "Load from .MDA file"
     _default_value = "{}"
     _tooltip_text = "Specify which atoms will be used in the analysis. The input is a JSON string, and can be created using the helper dialog."
 
@@ -415,11 +427,16 @@ class AtomSelectionWidget(WidgetBase):
         ]
         traj_filename = traj_config["filename"]
         hdf_traj = traj_config["hdf_trajectory"]
+        self._trajectory_path = PurePath(traj_filename).stem
         self.helper = self.create_helper((traj_filename, hdf_traj))
         helper_button = QPushButton(self._push_button_text, self._base)
+        database_button = QPushButton(self._database_button_text, self._base)
+        file_button = QPushButton(self._mda_button_text, self._base)
         helper_button.clicked.connect(self.helper_dialog)
-        self._layout.addWidget(self._field)
-        self._layout.addWidget(helper_button)
+        database_button.clicked.connect(self.database_dialog)
+        file_button.clicked.connect(self.mda_file_dialog)
+        for widget in [self._field, database_button, file_button, helper_button]:
+            self._layout.addWidget(widget)
         self.update_labels()
         self.updateValue()
         self._field.setToolTip(self._tooltip_text)
@@ -445,6 +462,29 @@ class AtomSelectionWidget(WidgetBase):
 
         """
         return SelectionHelper(traj_data, self._field, self._base)
+
+    @Slot()
+    def database_dialog(self) -> None:
+        """Pick a selection from the internal database."""
+
+    @Slot()
+    def mda_file_dialog(self) -> None:
+        """Load a selection from an .MDA file."""
+        fnames = QFileDialog.getOpenFileNames(
+            self._base,
+            "Load selection from an MDA file (MDANSE analysis results)",
+            self._trajectory_path,
+            "MDANSE result files (*.mda);;HDF5 files (*.h5);;HDF5 files(*.hdf);;All files(*.*)",
+        )
+        if fnames is None:
+            return
+        if len(fnames[0]) < 1:
+            return
+        temp_selection = ReusableSelection()
+        temp_selection.load_from_hdf5(fnames[0][0])
+        new_selection = temp_selection.convert_to_json()
+        self._field.setText(new_selection)
+        self.helper.selection_model.create_from_string(new_selection)
 
     @Slot()
     def helper_dialog(self) -> None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -44,6 +44,7 @@ from MDANSE_GUI.Tabs.Models.SelectionModel import SelectionGUIModel
 from MDANSE_GUI.Tabs.PlotSelectionTab import PlotSelectionTab
 from MDANSE_GUI.Tabs.PlotTab import PlotTab
 from MDANSE_GUI.Tabs.RunTab import RunTab
+from MDANSE_GUI.Tabs.SelectionTab import SelectionTab
 from MDANSE_GUI.Tabs.TrajectoryTab import TrajectoryTab
 from MDANSE_GUI.UnitsEditor import UnitsEditor
 from MDANSE_GUI.UserSettingsEditor import UserSettingsEditor
@@ -130,6 +131,7 @@ class TabbedWindow(QMainWindow):
         self.createPlotSelection()
         self.createPlotHolder()
         self.createInstrumentSelector()
+        self.createSelectionTab()
         self.createLogViewer()
         self.setupMenubar()
         self.setupToolbar()
@@ -340,6 +342,20 @@ class TabbedWindow(QMainWindow):
         plot_tab.connect_units()
         self.tabs.addTab(plot_tab._core, name)
         self._tabs[name] = plot_tab
+
+    def createSelectionTab(self):
+        name = "Atom Selections"
+        selection_tab = SelectionTab.gui_instance(
+            self.tabs,
+            name,
+            self._session,
+            self._settings,
+            self._logger,
+            trajectory_model=self._trajectory_model,
+            selection_model=self._selection_holder,
+        )
+        self.tabs.addTab(selection_tab._core, name)
+        self._tabs[name] = selection_tab
 
     def createLogViewer(self):
         name = "Logger"

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -38,6 +38,7 @@ from MDANSE_GUI.UserSettingsEditor import UserSettingsEditor
 from MDANSE_GUI.PeriodicTableViewer import PeriodicTableViewer
 from MDANSE_GUI.ElementsDatabaseEditor import ElementsDatabaseEditor
 from MDANSE_GUI.Tabs.Models.GeneralModel import GeneralModel
+from MDANSE_GUI.Tabs.Models.SelectionModel import SelectionModel
 from MDANSE_GUI.Tabs.Models.JobHolder import JobHolder
 from MDANSE_GUI.Tabs.TrajectoryTab import TrajectoryTab
 from MDANSE_GUI.Tabs.JobTab import JobTab
@@ -118,6 +119,7 @@ class TabbedWindow(QMainWindow):
     def createCommonModels(self):
         self._trajectory_model = GeneralModel()
         self._instrument_model = GeneralModel()
+        self._selection_holder = SelectionModel()
         self._job_holder = JobHolder()
         self._gui_log_handler = GuiLogHandler()
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -14,50 +14,49 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 import os
-from pathlib import PurePath
 from collections import defaultdict
 from importlib import metadata
-
-from qtpy.QtCore import Slot, QTimer, Signal, QMessageLogger
-from qtpy.QtWidgets import (
-    QMainWindow,
-    QFileDialog,
-    QToolBar,
-    QMenuBar,
-    QMessageBox,
-    QApplication,
-    QAction,
-)
+from pathlib import PurePath
 
 from MDANSE.MLogging import LOG
+from qtpy.QtCore import QMessageLogger, QTimer, Signal, Slot
+from qtpy.QtWidgets import (
+    QAction,
+    QApplication,
+    QFileDialog,
+    QMainWindow,
+    QMenuBar,
+    QMessageBox,
+    QToolBar,
+)
 
-from MDANSE_GUI.Session.StructuredSession import StructuredSession
-from MDANSE_GUI.Resources import Resources
-from MDANSE_GUI.UnitsEditor import UnitsEditor
-from MDANSE_GUI.UserSettingsEditor import UserSettingsEditor
-from MDANSE_GUI.PeriodicTableViewer import PeriodicTableViewer
 from MDANSE_GUI.ElementsDatabaseEditor import ElementsDatabaseEditor
-from MDANSE_GUI.Tabs.Models.GeneralModel import GeneralModel
-from MDANSE_GUI.Tabs.Models.SelectionModel import SelectionModel
-from MDANSE_GUI.Tabs.Models.JobHolder import JobHolder
-from MDANSE_GUI.Tabs.TrajectoryTab import TrajectoryTab
-from MDANSE_GUI.Tabs.JobTab import JobTab
-from MDANSE_GUI.Tabs.RunTab import RunTab
-from MDANSE_GUI.Tabs.LoggingTab import LoggingTab, GuiLogHandler
+from MDANSE_GUI.PeriodicTableViewer import PeriodicTableViewer
+from MDANSE_GUI.Resources import Resources
+from MDANSE_GUI.Session.StructuredSession import StructuredSession
 from MDANSE_GUI.Tabs.ConverterTab import ConverterTab
+from MDANSE_GUI.Tabs.InstrumentTab import InstrumentTab
+from MDANSE_GUI.Tabs.JobTab import JobTab
+from MDANSE_GUI.Tabs.LoggingTab import GuiLogHandler, LoggingTab
+from MDANSE_GUI.Tabs.Models.GeneralModel import GeneralModel
+from MDANSE_GUI.Tabs.Models.JobHolder import JobHolder
+from MDANSE_GUI.Tabs.Models.SelectionModel import SelectionGUIModel
 from MDANSE_GUI.Tabs.PlotSelectionTab import PlotSelectionTab
 from MDANSE_GUI.Tabs.PlotTab import PlotTab
-from MDANSE_GUI.Tabs.InstrumentTab import InstrumentTab
-from MDANSE_GUI.Widgets.StyleDialog import StyleDialog, StyleDatabase
+from MDANSE_GUI.Tabs.RunTab import RunTab
+from MDANSE_GUI.Tabs.TrajectoryTab import TrajectoryTab
+from MDANSE_GUI.UnitsEditor import UnitsEditor
+from MDANSE_GUI.UserSettingsEditor import UserSettingsEditor
 from MDANSE_GUI.Widgets.NotificationTabWidget import NotificationTabWidget
+from MDANSE_GUI.Widgets.StyleDialog import StyleDatabase, StyleDialog
 
 
 class TabbedWindow(QMainWindow):
-    """The main window of the MDANSE GUI,
-    inherits QMainWindow.
+    """The main window of the MDANSE GUI, inherits QMainWindow.
 
     Args:
         QMainWindow - the base class.
+
     """
 
     def __init__(
@@ -119,7 +118,7 @@ class TabbedWindow(QMainWindow):
     def createCommonModels(self):
         self._trajectory_model = GeneralModel()
         self._instrument_model = GeneralModel()
-        self._selection_holder = SelectionModel()
+        self._selection_holder = SelectionGUIModel()
         self._job_holder = JobHolder()
         self._gui_log_handler = GuiLogHandler()
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -131,7 +131,7 @@ class TabbedWindow(QMainWindow):
         self.createPlotSelection()
         self.createPlotHolder()
         self.createInstrumentSelector()
-        self.createSelectionTab()
+        # self.createSelectionTab()
         self.createLogViewer()
         self.setupMenubar()
         self.setupToolbar()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/SelectionModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/SelectionModel.py
@@ -13,31 +13,25 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-from typing import Optional
+import json
 import time
+from typing import Optional
 
-from qtpy.QtCore import QObject, Slot, Signal, QMutex, QModelIndex, Qt
-from qtpy.QtGui import QStandardItemModel, QStandardItem
-
-
-class SelectionEntry:
-    """Database entry of a ReusableSelection definition"""
-
-    def __init__(self):
-        self.name: str = ""
-        self.selection_dict = {}
-        self.selection_json = ""
-        self.used_by = []
-        self.last_use_time = 0
+from MDANSE.Framework.AtomSelector.selection_storage import (
+    SelectionStorage,
+    SingleEntry,
+)
+from qtpy.QtCore import QModelIndex, QMutex, QObject, Qt, Signal, Slot
+from qtpy.QtGui import QStandardItem, QStandardItemModel
 
 
 class SelectionGUIModel(QStandardItemModel):
-    """ """
+    """Encapsulates an MDANSE SelectionStorage for GUI access."""
 
     error = Signal(str)
     all_elements = Signal(object)
 
-    def __init__(self, parent: QObject = None):
+    def __init__(self, parent: QObject = None, filename: Optional[str] = None):
         """Load database from file.
 
         Parameters
@@ -46,67 +40,63 @@ class SelectionGUIModel(QStandardItemModel):
             path to a database file.
         parent : QObject, optional
             parent in the Qt object hierarchy
+        filename : str, optional
+            name of an additional file containing atom selections
 
         """
         super().__init__(parent=parent)
         self.mutex = QMutex()
-        self._node_numbers = []
-        self._nodes = {}
-        self._next_number = 0
+        self._selection_storage = SelectionStorage(filename=filename)
+        self.build_model_from_storage(self._selection_storage)
 
-    @Slot(tuple)
-    def append_object(self, input: tuple):
-        thing, label = input
-        self.mutex.lock()
-        self._nodes[self._next_number] = thing
-        self._node_numbers.append(self._next_number)
-        retval = int(self._next_number)
-        self._next_number += 1
-        item = QStandardItem(label)
-        item.setData(retval)
-        self.appendRow(item)
-        self.mutex.unlock()
-        self.summarise_items()
-        return retval
+    def build_model_from_storage(self, storage: SelectionStorage):
+        """Initialise the GUI model from an MDANSE storage instance.
 
-    @Slot(tuple)
-    def append_object_and_embed(self, input: tuple):
-        thing, label = input
-        self.mutex.lock()
-        self._nodes[self._next_number] = thing
-        self._node_numbers.append(self._next_number)
-        retval = int(self._next_number)
-        self._next_number += 1
-        item = QStandardItem(label)
-        item.setData(retval)
-        thing._list_item = item
-        thing._model_index = retval
-        self.appendRow(item)
-        self.mutex.unlock()
-        self.summarise_items()
-        return retval
+        Parameters
+        ----------
+        storage : SelectionStorage
+            an instance of MDANSE SelectionStorage
 
-    def summarise_items(self):
-        result = []
-        self.mutex.lock()
-        for nrow in range(self.rowCount()):
-            index = self.index(nrow, 0)
-            item = self.itemFromIndex(index)
-            result.append([item.text(), item.data()])
-        self.mutex.unlock()
-        self.all_elements.emit(result)
+        """
+        self.clear()
+        for entry in storage._named_entries.values():
+            self.add_single_selection(entry)
+        for entry in storage._unnamed_entries:
+            self.add_single_selection(entry)
 
-    def removeRow(self, row: int, parent: QModelIndex = None):
-        self.mutex.lock()
-        try:
-            node_number = self.item(row).data()
-        except AttributeError:
-            return
-        self._nodes.pop(node_number)
-        self._node_numbers.pop(self._node_numbers.index(node_number))
-        if parent is None:
-            super().removeRow(row)
-        else:
-            super().removeRow(row, parent)
-        self.mutex.unlock()
-        self.summarise_items()
+    def column_headers(self) -> dict[str, int]:
+        """Get the mapping of data field names to column numbers.
+
+        Returns
+        -------
+        dict[str, int]
+            A dictionary of column numbers for each data field name
+
+        """
+        return {
+            self.headerData(col_number, Qt.Orientation.Horizontal): col_number
+            for col_number in range(len(self.columnCount()))
+        }
+
+    def add_single_selection(self, entry: SingleEntry):
+        """Add an entry to be displayed in the GUI via the model.
+
+        Parameters
+        ----------
+        entry : SingleEntry
+            a SingleEntry object from the MDANSE selection storage
+
+        """
+        column_dict = self.column_headers()
+        column_headers = list(column_dict.keys())
+        for field in entry.data_fields:
+            if field not in column_headers:
+                column_headers.add(field)
+        self.setHorizontalHeaderLabels(column_headers)
+        new_column_dict = self.column_headers()
+        row = len(new_column_dict) * [None]
+        for field in new_column_dict:
+            data_entry = QStandardItem(json.dumps(getattr(entry, field, "")))
+            data_entry.setEditable(False)
+            row[new_column_dict[field]] = data_entry
+        self.appendRow(row)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/SelectionModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/SelectionModel.py
@@ -1,0 +1,112 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from typing import Optional
+import time
+
+from qtpy.QtCore import QObject, Slot, Signal, QMutex, QModelIndex, Qt
+from qtpy.QtGui import QStandardItemModel, QStandardItem
+
+
+class SelectionEntry:
+    """Database entry of a ReusableSelection definition"""
+
+    def __init__(self):
+        self.name: str = ""
+        self.selection_dict = {}
+        self.selection_json = ""
+        self.used_by = []
+        self.last_use_time = 0
+
+
+class SelectionGUIModel(QStandardItemModel):
+    """ """
+
+    error = Signal(str)
+    all_elements = Signal(object)
+
+    def __init__(self, parent: QObject = None):
+        """Load database from file.
+
+        Parameters
+        ----------
+        source_file : str, optional
+            path to a database file.
+        parent : QObject, optional
+            parent in the Qt object hierarchy
+
+        """
+        super().__init__(parent=parent)
+        self.mutex = QMutex()
+        self._node_numbers = []
+        self._nodes = {}
+        self._next_number = 0
+
+    @Slot(tuple)
+    def append_object(self, input: tuple):
+        thing, label = input
+        self.mutex.lock()
+        self._nodes[self._next_number] = thing
+        self._node_numbers.append(self._next_number)
+        retval = int(self._next_number)
+        self._next_number += 1
+        item = QStandardItem(label)
+        item.setData(retval)
+        self.appendRow(item)
+        self.mutex.unlock()
+        self.summarise_items()
+        return retval
+
+    @Slot(tuple)
+    def append_object_and_embed(self, input: tuple):
+        thing, label = input
+        self.mutex.lock()
+        self._nodes[self._next_number] = thing
+        self._node_numbers.append(self._next_number)
+        retval = int(self._next_number)
+        self._next_number += 1
+        item = QStandardItem(label)
+        item.setData(retval)
+        thing._list_item = item
+        thing._model_index = retval
+        self.appendRow(item)
+        self.mutex.unlock()
+        self.summarise_items()
+        return retval
+
+    def summarise_items(self):
+        result = []
+        self.mutex.lock()
+        for nrow in range(self.rowCount()):
+            index = self.index(nrow, 0)
+            item = self.itemFromIndex(index)
+            result.append([item.text(), item.data()])
+        self.mutex.unlock()
+        self.all_elements.emit(result)
+
+    def removeRow(self, row: int, parent: QModelIndex = None):
+        self.mutex.lock()
+        try:
+            node_number = self.item(row).data()
+        except AttributeError:
+            return
+        self._nodes.pop(node_number)
+        self._node_numbers.pop(self._node_numbers.index(node_number))
+        if parent is None:
+            super().removeRow(row)
+        else:
+            super().removeRow(row, parent)
+        self.mutex.unlock()
+        self.summarise_items()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/SelectionTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/SelectionTab.py
@@ -1,0 +1,127 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import os
+from functools import partial
+from pathlib import PurePath
+
+from MDANSE import PLATFORM
+from MDANSE.Framework.AtomSelector import SelectionStorage
+from MDANSE.Framework.InputData.HDFTrajectoryInputData import HDFTrajectoryInputData
+from MDANSE.MLogging import LOG
+from qtpy.QtCore import QSortFilterProxyModel, Slot
+from qtpy.QtWidgets import QComboBox, QLabel, QTableView, QWidget
+
+from MDANSE_GUI.MolecularViewer.MolecularViewer import MolecularViewerWithPicking
+from MDANSE_GUI.Session.LocalSession import LocalSession
+from MDANSE_GUI.Tabs.GeneralTab import GeneralTab
+from MDANSE_GUI.Tabs.Layouts.MultiPanel import MultiPanel
+from MDANSE_GUI.Tabs.Models.GeneralModel import GeneralModel
+from MDANSE_GUI.Tabs.Views.InstrumentList import InstrumentList
+from MDANSE_GUI.Tabs.Visualisers.InstrumentDetails import InstrumentDetails
+from MDANSE_GUI.Tabs.Visualisers.TextInfo import TextInfo
+from MDANSE_GUI.Tabs.Visualisers.View3D import View3D
+
+label_text = """Browse through the saved atom selection definitions,
+and preview what they will select in the current trajectory.
+"""
+
+
+class SelectionTab(GeneralTab):
+    """Tab for visualising different atom selections."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        trajectory_model = kwargs.get("trajectory_model")
+        self._trajectory_combo = QComboBox()
+        self._trajectory_combo.setEditable(False)
+        self._trajectory_combo.currentIndexChanged.connect(self.set_current_trajectory)
+        if trajectory_model is not None:
+            self._trajectory_combo.setModel(trajectory_model)
+        selection_model = kwargs.get("selection_model")
+        if selection_model is None:
+            selection_model = SelectionStorage()
+        self._view.setModel(selection_model)
+        self._core.add_widget(QLabel("Trajectory:"))
+        self._core.add_widget(self._trajectory_combo)
+        self._core.add_button("Load from MDA", self._view.add_instrument)
+        self._core.add_button("Save Selections", self._view.save_to_file, upper=False)
+
+    @Slot(int)
+    def set_current_trajectory(self, index: int) -> None:
+        """Pass the trajectory from combo to 3D view.
+
+        Parameters
+        ----------
+        index : int
+            model index of the trajectory
+
+        """
+        self._current_trajectory = self._trajectory_combo.currentText()
+        traj_model = self._trajectory_combo.model()
+        node_number = traj_model.item(index, 0).data()
+        traj_instance = traj_model._nodes[node_number]
+        self._visualiser.update_panel((self._current_trajectory, traj_instance))
+
+    @classmethod
+    def standard_instance(cls):
+        the_tab = cls(
+            window,
+            name="Instruments",
+            session=LocalSession(),
+            model=GeneralModel(),
+            view=QTableView(),
+            visualiser=View3D(MolecularViewerWithPicking()),
+            layout=partial(MultiPanel, left_panels=[TextInfo()]),
+            label_text=label_text,
+        )
+        return the_tab
+
+    @classmethod
+    def gui_instance(
+        cls,
+        parent: QWidget,
+        name: str,
+        session: LocalSession,
+        settings,
+        logger,
+        **kwargs,
+    ):
+        the_tab = cls(
+            parent,
+            name=name,
+            session=session,
+            settings=settings,
+            logger=logger,
+            model=kwargs.get("model", GeneralModel()),
+            view=QTableView(),
+            visualiser=View3D(MolecularViewerWithPicking()),
+            layout=partial(MultiPanel, left_panels=[TextInfo()]),
+            label_text=label_text,
+        )
+        return the_tab
+
+
+if __name__ == "__main__":
+    import sys
+
+    from qtpy.QtWidgets import QApplication, QMainWindow
+
+    app = QApplication(sys.argv)
+    window = QMainWindow()
+    the_tab = SelectionTab.standard_instance()
+    window.setCentralWidget(the_tab._core)
+    window.show()
+    app.exec()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/SelectionTable.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/SelectionTable.py
@@ -1,0 +1,118 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from MDANSE.MLogging import LOG
+from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt, Signal, Slot
+from qtpy.QtGui import QContextMenuEvent, QStandardItem
+from qtpy.QtWidgets import QAbstractItemView, QMenu, QMessageBox, QTableView
+
+from MDANSE_GUI.Tabs.Views.Delegates import ProgressDelegate
+from MDANSE_GUI.Tabs.Visualisers.TextInfo import TextInfo
+from MDANSE_GUI.Tabs.Visualisers.View3D import View3D
+
+
+class SelectionTable(QTableView):
+    """An MDANSE View for finding atom selections."""
+
+    item_details = Signal(object)
+    jobs_logs = Signal(object)
+    error = Signal(str)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.clicked.connect(self.item_picked)
+        self._progbar = ProgressDelegate()
+        self.setItemDelegateForColumn(1, self._progbar)
+        vh = self.verticalHeader()
+        vh.setVisible(False)
+
+    def setModel(self, model: QAbstractItemModel) -> None:
+        result = super().setModel(model)
+        self.model().dataChanged.connect(self.resizeColumnsToContents)
+        return result
+
+    def contextMenuEvent(self, event: QContextMenuEvent) -> None:
+        index = self.indexAt(event.pos())
+        if index.row() == -1:
+            # block right click when it's not on a job
+            return
+        model = self.model()
+        item = model.itemData(index)
+        menu = QMenu()
+        self.populateMenu(menu, item)
+        menu.exec_(event.globalPos())
+
+    def populateMenu(self, menu: QMenu, item: QStandardItem):
+        _ = self.getSelection()
+        for action, method in [
+            ("Delete", self.deleteNode),
+        ]:
+            temp_action = menu.addAction(action)
+            temp_action.triggered.connect(method)
+
+    def getJobObjects(self):
+        model = self.model()
+        index = self.currentIndex()
+        item_row = index.row()
+        entry_number = model.index(item_row, 0).data(role=Qt.ItemDataRole.UserRole)
+        try:
+            entry_number = int(entry_number)
+        except ValueError:
+            LOG.error(f"Could not use {entry_number} as int")
+            return
+        return
+
+    @Slot()
+    def deleteNode(self):
+        entry, watcher, process, listener = self.getJobObjects()
+        try:
+            process.close()
+        except ValueError:
+            LOG.error("The process is still running!")
+        else:
+            model = self.model()
+            index = self.currentIndex()
+            model.removeRow(index.row())
+            self.item_details.emit("")
+            self.jobs_logs.emit(([], []))
+
+    @Slot(QModelIndex)
+    def item_picked(self, index: QModelIndex):
+        model = self.model()
+        index = self.currentIndex()
+        item_row = index.row()
+        node_number = model.index(item_row, 0).data(role=Qt.ItemDataRole.UserRole)
+        job_entry = model.existing_jobs[node_number]
+        self.item_details.emit(job_entry.text_summary())
+        self.jobs_logs.emit(job_entry.handler.msgs_and_levels())
+
+    def connect_to_visualiser(self, visualiser: TextInfo) -> None:
+        """Connect to a visualiser.
+
+        Parameters
+        ----------
+        visualiser : TextInfo
+            A visualiser to connect to this view.
+
+        """
+        if type(visualiser) is TextInfo:
+            self.item_details.connect(visualiser.update_panel)
+        if type(visualiser) is View3D:
+            self.item_details.connect(visualiser.update_panel)
+        else:
+            raise NotImplementedError(
+                f"Unable to connect view {type(self)} to visualiser {type(visualiser)}"
+            )

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/View3D.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/View3D.py
@@ -51,3 +51,8 @@ class View3D(QWidget):
         except AttributeError:
             self.error.emit(f"3D View could not visualise {fullpath}")
             self._viewer.clear_trajectory()
+
+    @Slot(str)
+    def update_selection(self, json_string: str):
+        """:TODO: make it create a selection."""
+        self._viewer.mark_selected_atoms(json_string)


### PR DESCRIPTION
**Description of work**
This PR, once complete, will implement a way of storing, previewing and re-using atom selections. The atom selection definitions are meant to be abstract and do not have to be tied to a specific trajectory file.

**Fixes**
Complete:
1. Added the option of loading a selection from an MDA file.
In progress:
2. Planning to add an extra tab to the GUI, which will allow users to choose one of the stored selection operation sequences, and preview the effect it will have on a specific trajectory.
3. Planning to add an extra selection operation, which will group and apply atom selection done in the 3D view by clicking on individual atoms.
4. Initial work has been done on adding code to the backend for storing atom selections.

**To test**
Will be filled out later.
