### PR TITLE
Fix issue with 3.11 `StrEnum`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,3 +42,18 @@ jobs:
         with:
           src: "./MDANSE_GUI/Src"
           args: "check"
+
+  lint_vermin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install vermin
+        run: python -m pip install vermin
+
+      - name: Run Vermin
+        run: vermin -t=3.9 --lint --quiet --no-parse-comments MDANSE/ MDANSE_GUI/

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -15,7 +15,7 @@
 #
 
 import json
-from enum import StrEnum
+from enum import Enum
 
 from MDANSE.Framework.AtomSelector.selector import ReusableSelection
 from MDANSE.Framework.InputData.HDFTrajectoryInputData import HDFTrajectoryInputData
@@ -51,7 +51,7 @@ from MDANSE_GUI.Widgets.SelectionWidgets import (
 )
 
 
-class SelectionValidity(StrEnum):
+class SelectionValidity(Enum):
     """Strings for selection check results."""
 
     VALID_SELECTION = "Valid selection"
@@ -82,8 +82,7 @@ class SelectionModel(QStandardItemModel):
         Returns
         -------
         SelectionValidity
-            result of the check on last_operation
-
+            Result of the check on last_operation.
         """
         self._selection = ReusableSelection()
         self._current_selection = set()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
@@ -299,9 +299,12 @@ class IndexSelection(BasicSelectionWidget):
         self.selection_type_combo.addItems(mode.value for mode in IndexSelectionMode)
         self.selection_type_combo.setEditable(False)
         layout.addWidget(self.selection_type_combo)
+
         self.selection_field = QLineEdit(self)
         layout.addWidget(self.selection_field)
         self.selection_type_combo.currentTextChanged.connect(self.switch_mode)
+        # Set default
+        self.switch_mode("list")
 
     @Slot(str)
     def switch_mode(self, new_mode: str):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
@@ -15,7 +15,7 @@
 #
 
 import json
-from enum import StrEnum
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -38,13 +38,16 @@ if TYPE_CHECKING:
     from MDANSE_GUI.MolecularViewer.MolecularViewer import MolecularViewer
 
 
-class IndexSelectionMode(StrEnum):
+class IndexSelectionMode(Enum):
     """Valid atom selection modes for select_atoms."""
 
     LIST = "list"
     RANGE = "range"
     SLICE = "slice"
 
+    @classmethod
+    def _missing_(cls, value: str):
+        return cls[value.upper()]
 
 class XYZValidator(QValidator):
     """A custom validator for a QLineEdit.
@@ -288,7 +291,7 @@ class IndexSelection(BasicSelectionWidget):
         layout = self.layout()
         layout.addWidget(QLabel("Select atoms by index"))
         self.selection_type_combo = QComboBox(self)
-        self.selection_type_combo.addItems(str(mode) for mode in IndexSelectionMode)
+        self.selection_type_combo.addItems(mode.value for mode in IndexSelectionMode)
         self.selection_type_combo.setEditable(False)
         layout.addWidget(self.selection_type_combo)
         self.selection_field = QLineEdit(self)
@@ -298,16 +301,18 @@ class IndexSelection(BasicSelectionWidget):
     @Slot(str)
     def switch_mode(self, new_mode: str):
         """Change the meaning of the text input field."""
+        new_mode = IndexSelectionMode[new_mode]
         self.selection_field.setText("")
-        if new_mode == IndexSelectionMode.LIST:
+
+        if new_mode is IndexSelectionMode.LIST:
             self.selection_field.setPlaceholderText("0,1,2")
             self.selection_keyword = "index_list"
             self.selection_separator = ","
-        elif new_mode == IndexSelectionMode.RANGE:
+        elif new_mode is IndexSelectionMode.RANGE:
             self.selection_field.setPlaceholderText("0-20")
             self.selection_keyword = "index_range"
             self.selection_separator = "-"
-        elif new_mode == IndexSelectionMode.SLICE:
+        elif new_mode is IndexSelectionMode.SLICE:
             self.selection_field.setPlaceholderText("first:last:step")
             self.selection_keyword = "index_slice"
             self.selection_separator = ":"

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
@@ -49,6 +49,7 @@ class IndexSelectionMode(Enum):
     def _missing_(cls, value: str):
         return cls[value.upper()]
 
+
 class XYZValidator(QValidator):
     """A custom validator for a QLineEdit.
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
@@ -47,7 +47,11 @@ class IndexSelectionMode(Enum):
 
     @classmethod
     def _missing_(cls, value: str):
-        return cls[value.upper()]
+        value = value.lower()
+        for member in cls:
+            if member.value == value:
+                return member
+        return None
 
 
 class XYZValidator(QValidator):
@@ -302,7 +306,7 @@ class IndexSelection(BasicSelectionWidget):
     @Slot(str)
     def switch_mode(self, new_mode: str):
         """Change the meaning of the text input field."""
-        new_mode = IndexSelectionMode[new_mode]
+        new_mode = IndexSelectionMode(new_mode)
         self.selection_field.setText("")
 
         if new_mode is IndexSelectionMode.LIST:


### PR DESCRIPTION
**Description of work**
- Replace `StrEnum` with `Enum` and verify compatibility
- Add Vermin to CI to ensure Python version compatibility

**Fixes**
Fixes #737 
Fixes #745

**To test**
- CI Should pass
- GUI should start on Python <3.10
- Atom selection modes should still work in GUI
