### PR TITLE
Fix issue when MultiInput... has non-extant files

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/MultiInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MultiInputFileConfigurator.py
@@ -68,14 +68,12 @@ class MultiInputFileConfigurator(IConfigurator):
             return
 
         values = [PLATFORM.get_path(value) for value in values]
-
-        none_exist = []
-        for value in values:
-            if not value.is_file():
-                none_exist.append(value)
+        none_exist = [value for value in values if not value.is_file()]
 
         if none_exist:
-            self.error_status = f"The files {', '.join(none_exist)} do not exist."
+            self.error_status = (
+                f"The files {', '.join(map(str, none_exist))} do not exist."
+            )
             return
 
         self["values"] = values


### PR DESCRIPTION
**Description of work**
`raise` fails due to passing `Path` to `str.join` which requires `str`ing.

**Fixes**
- Forces `Path`s to `str`ings.
- Simplify loop to comprehension with filter.

**To test**
Supply non-extant files to a multi-input configurator.
