### PR TITLE
Update os env setting to make numpy use one thread when the GUI is used

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/__init__.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/__init__.py
@@ -13,6 +13,14 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+import os
+
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
+
 import importlib.metadata
 
 __version__ = importlib.metadata.version("MDANSE_GUI")

--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -27,13 +27,6 @@ from MDANSE.MLogging import LOG, FMT
 from MDANSE_GUI.TabbedWindow import TabbedWindow
 
 
-os.environ["OMP_NUM_THREADS"] = "1"
-os.environ["OPENBLAS_NUM_THREADS"] = "1"
-os.environ["MKL_NUM_THREADS"] = "1"
-os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
-os.environ["NUMEXPR_NUM_THREADS"] = "1"
-
-
 # an additonal section which will pass exception information to the logger
 def catch_exceptions(t, val, tb):
     LOG.error(f"EXCEPTION:\n{t}\n{val}\n{tb}")

--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -28,6 +28,10 @@ from MDANSE_GUI.TabbedWindow import TabbedWindow
 
 
 os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
 
 
 # an additonal section which will pass exception information to the logger


### PR DESCRIPTION
**Description of work**
Update the os envs setting in the GUI main.py. The following environment variables are set.

```
os.environ["OMP_NUM_THREADS"] = "1"
os.environ["OPENBLAS_NUM_THREADS"] = "1"
os.environ["MKL_NUM_THREADS"] = "1"
os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
os.environ["NUMEXPR_NUM_THREADS"] = "1"
```

**To test**
Run a job with MDANSE_GUI on single or multicore and check that all Python processes do not use more than 100 %CPU.
