### PR TITLE
Add the final progress update to IJob._run_multicore

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -356,6 +356,9 @@ class IJob(Configurable, metaclass=SubclassFactory):
                 n_results += 1
                 self.combine(index, result)
 
+        if self._status is not None:
+            self._status.fixed_status(n_results)
+
         for p in self._processes:
             p.join()
 


### PR DESCRIPTION
**Description of work**
Job progress bars have been showing 100% in single core, but <100% in multicore runs.

**Fixes**
1. Final progress update has been added in `IJob._run_multicore`, once the loop over steps has ended.

**To test**
Run several analysis jobs in multicore mode. They should show 100% completion once finished.
