### PR TITLE
Check for length-1 arrays in PlottingContext

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -274,9 +274,15 @@ class SingleDataset:
             axis_values = self.x_axis(axis_name)
             axis_unit = self._current_units[axis_name]
             picked_value = axis_values[index_tuple[axis_index]]
-            significant_digit = np.floor(
-                np.log10(abs(np.mean(axis_values[1:] - axis_values[:-1])))
-            ).astype(int)
+            if len(axis_values) > 1:
+                significant_digit = np.floor(
+                    np.log10(abs(np.mean(axis_values[1:] - axis_values[:-1])))
+                ).astype(int)
+            elif len(axis_values) == 1:
+                significant_digit = np.floor(np.log10(abs(axis_values[0]))).astype(int)
+            else:
+                label += f"{axis_name} has no values, unit {axis_unit}"
+                continue
             if significant_digit < 0:
                 picked_value = round(picked_value, abs(significant_digit) + 2)
             else:


### PR DESCRIPTION
**Description of work**
At the moment, labels for 1D cuts of a 2D array do not work correctly if the array is shaped (1, N). This PR adds a correction to generate a meaningful label in this case.

closes #786 

**Fixes**
A check for the axis array length has been added. A different formula is used to calculate rounding precision in that case.

**To test**
Load a 2D array with only one row, and plot the results. The plot legend should contain the value of the corresponding axis at its only index.
