### PR TITLE
Use configurator defaults for VectorWidget

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/VectorWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/VectorWidget.py
@@ -23,20 +23,20 @@ class VectorWidget(WidgetBase):
         super().__init__(*args, **kwargs)
         self._changing_label = QLabel("Vector", parent=self._base)
         self._layout.addWidget(self._changing_label)
-        vfields = []
-        for val in ["0", "0", "1"]:
-            temp = QLineEdit(val, self._base)
-            self._layout.addWidget(temp)
-            vfields.append(temp)
-        self._vector_fields = vfields
-        self._mode = 0
-        self.updateValue()
+        self._vector_fields = [
+            QLineEdit(val, self._base) for val in map(str, self._configurator.default)
+        ]
+
         if self._tooltip:
             tooltip_text = self._tooltip
         else:
             tooltip_text = "The spatial properties in the analysis can be projected on a plane or on an axis, as chosen here."
-        for wid in vfields:
-            wid.setToolTip(tooltip_text)
+
+        for field in self._vector_fields:
+            self._layout.addWidget(field)
+            field.setToolTip(tooltip_text)
+        self._mode = 0
+        self.updateValue()
 
     def configure_using_default(self):
         """This is too complex to have a default value"""


### PR DESCRIPTION
**Description of work**
Since `VectorWidget` is always associated with a `Configurator`, use its defaults rather than `[0, 0, 1]`.

**Fixes**
Uses `Configurator` to set initial default.

**To test**
Ensure the GUI loads vector widgets with correct defaults.