### PR TITLE
Improve atom property caching in MdanseTrajectory

### DIFF
--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -48,6 +48,8 @@ class Trajectory:
         self._format = trajectory_format
         if self._format is None:
             self.guess_correct_format()
+        if self._format is None:
+            self._format = 'MDANSE'
         self._trajectory = self.open_trajectory(self._format)
         self._min_span = np.zeros(3)
         self._max_span = np.zeros(3)

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -55,7 +55,6 @@ class MdanseTrajectory:
         self._property_map = {}
         self._data_types = {}
         self._property_cache = {}
-        self._atom_database_cache = {}
 
         self._h5_filename = Path(h5_filename)
 
@@ -109,7 +108,8 @@ class MdanseTrajectory:
         self._h5_file.close()
 
     def __getitem__(
-        self, frame: int
+        self,
+        frame: int,
     ) -> Union[RealConfiguration, PeriodicRealConfiguration]:
         """Return the atom configuration for a specific frame.
 
@@ -206,7 +206,8 @@ class MdanseTrajectory:
         return grp["coordinates"][frame].astype(np.float64)
 
     def configuration(
-        self, frame: int
+        self,
+        frame: int,
     ) -> Union[RealConfiguration, PeriodicRealConfiguration]:
         """Return the atom configuration for a specific frame.
 
@@ -284,7 +285,13 @@ class MdanseTrajectory:
         return grp["coordinates"].shape[0]
 
     def read_com_trajectory(
-        self, atom_indices, first=0, last=None, step=1, box_coordinates=False
+        self,
+        atom_indices,
+        first=0,
+        last=None,
+        step=1,
+        *,
+        box_coordinates=False,
     ):
         """Build the trajectory of the center of mass of a set of atoms.
 
@@ -389,7 +396,13 @@ class MdanseTrajectory:
         return box_coordinates
 
     def read_atomic_trajectory(
-        self, index, first=0, last=None, step=1, box_coordinates=False
+        self,
+        index,
+        first=0,
+        last=None,
+        step=1,
+        *,
+        box_coordinates=False,
     ):
         """Read an atomic trajectory. The trajectory is corrected from box jumps.
 
@@ -477,23 +490,49 @@ class MdanseTrajectory:
         """
         return variable in self._h5_file["/configuration"]
 
-    def get_atom_property(self, symbol: str, property: str):
+    def get_atom_property(
+        self, symbol: str, property_name: str
+    ) -> Union[float, int, str]:
+        """Get the value of a property for an atom type.
+
+        If the trajectory's built-in atom database does not have
+        the right atom, the function will fall back on the
+        global atom database.
+
+        Parameters
+        ----------
+        symbol : str
+            Atom type label
+        property_name : str
+            Name of the atom property
+
+        Returns
+        -------
+        Union[float, int, str]
+            The value from the database converted to its type
+
+        Raises
+        ------
+        KeyError
+            The property name is not in the trajectory's database
+
+        """
         if not self._has_database:
-            return ATOMS_DATABASE.get_atom_property(symbol, property)
-        elif symbol not in self._has_atoms:
+            return ATOMS_DATABASE.get_atom_property(symbol, property_name)
+        if symbol not in self._has_atoms:
             if symbol in self._h5_file["/atom_database"]:
                 self._has_atoms.append(symbol)
             else:
-                return ATOMS_DATABASE.get_atom_property(symbol, property)
-        if property not in self._property_map:
+                return ATOMS_DATABASE.get_atom_property(symbol, property_name)
+        if property_name not in self._property_map:
             temp = np.where(
                 self._h5_file["/atom_database/property_labels"][:]
-                == property.encode("utf-8")
+                == property_name.encode("utf-8"),
             )[0]
             if len(temp) == 0:
-                if property == "dummy":
+                if property_name == "dummy":
                     try:
-                        return ATOMS_DATABASE.get_atom_property(symbol, property)
+                        return ATOMS_DATABASE.get_atom_property(symbol, property_name)
                     except KeyError:
                         if (
                             "_" in symbol
@@ -501,11 +540,11 @@ class MdanseTrajectory:
                             return 0  # the molecule atoms are not dummy
                 else:
                     raise KeyError(
-                        f"Property {property} is not in the trajectory's internal database."
+                        f"Property {property_name} is not in the trajectory's internal database."
                     )
             index = temp.flatten()[0]
-            self._property_map[property] = index
-        index = self._property_map[property]
+            self._property_map[property_name] = index
+        index = self._property_map[property_name]
         if index not in self._data_types:
             self._data_types[index] = self._h5_file["/atom_database/property_types"][
                 index
@@ -517,27 +556,45 @@ class MdanseTrajectory:
                 value = value.real
             self._property_cache[(symbol, index)] = value
         value = self._property_cache[(symbol, index)]
-        if property == "color":
+        if property_name == "color":
             value = float(value)
             num1 = round(value // 0x10000)
             num2 = round((value - num1 * 0x10000) // 0x100)
-            num3 = round((value - num1 * 0x10000 - num2 * 0x100))
+            num3 = round(value - num1 * 0x10000 - num2 * 0x100)
             return ";".join([str(int(x)) for x in [num1, num2, num3]])
         if data_type == b"int":
             return int(value)
-        elif data_type == b"str":
+        if data_type == b"str":
             if isinstance(value, bytes):
                 return value.decode("utf-8")
             return value
-        value = float(value)
-        return value
+        return float(value)
 
     def atoms_in_database(self) -> list[str]:
+        """Return the list of all the atom types in the database.
+
+        This list should match the list of unique atom types in the
+        ChemicalSystem of this trajectory.
+
+        Returns
+        -------
+        list[str]
+            All the atom types saved in the trajectory's database
+
+        """
         if "atom_database" not in self._h5_file:
             return ATOMS_DATABASE.atoms
         return list(self._h5_file["/atom_database"].keys())
 
     def properties_in_database(self) -> list[str]:
+        """Return all the atom properties saved in the trajectory's database.
+
+        Returns
+        -------
+        list[str]
+            All the properties saved in the trajectory's database
+
+        """
         if "atom_database" not in self._h5_file:
             return ATOMS_DATABASE.properties
         return [
@@ -546,11 +603,14 @@ class MdanseTrajectory:
         ]
 
     @property
-    def chemical_system(self):
-        """Return the chemical system stored in the trajectory.
+    def chemical_system(self) -> ChemicalSystem:
+        """Return the ChemicalSystem of this trajectory.
 
-        :return: the chemical system
-        :rtype: MDANSE.Chemistry.ChemicalSystem.ChemicalSystem
+        Returns
+        -------
+        ChemicalSystem
+            Object storing the information about atoms and bonds
+
         """
         return self._chemical_system
 

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -14,15 +14,16 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
-import numpy as np
 import h5py
+import numpy as np
 
-from MDANSE.MLogging import LOG
 from MDANSE.Chemistry import ATOMS_DATABASE
 from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
+from MDANSE.Framework.Units import measure
 from MDANSE.Mathematics.Geometry import center_of_mass
+from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.Configuration import (
     PeriodicRealConfiguration,
     RealConfiguration,
@@ -35,21 +36,32 @@ from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 
 class MdanseTrajectory:
-    """This used to be Trajectory, but has now been renamed.
-    Trajectory is now a wrapper object, and MdanseTrajectory
-    is the original implementation of the Mdanse HDF5 format.
+    """Reads the MDANSE .mdt trajectory (HDF5).
+
+    Trajectory is a wrapper object, and MdanseTrajectory
+    is the specific implementation for the Mdanse HDF5 format.
     """
 
     def __init__(self, h5_filename: Union[Path, str]):
-        """Constructor.
+        """Open the file and build a trajectory.
 
-        :param h5_filename: the trajectory filename
-        :type h5_filename: str
+        Parameters
+        ----------
+        h5_filename : Union[Path, str]
+            path to the trajectory file
+
         """
+        self.warned_about_complex_numbers = False
+        self._property_map = {}
+        self._data_types = {}
+        self._property_cache = {}
+        self._atom_database_cache = {}
 
         self._h5_filename = Path(h5_filename)
 
         self._h5_file = h5py.File(self._h5_filename, "r")
+        self._has_database = "atom_database" in self._h5_file
+        self._has_atoms = []
 
         # Load the chemical system
         self._chemical_system = ChemicalSystem(self._h5_filename.stem, self)
@@ -60,6 +72,7 @@ class MdanseTrajectory:
 
     @classmethod
     def file_is_right(self, filename: Union[Path, str]):
+        """Check if the input file is likely to be an .mdt trajectory."""
         filename = Path(filename)
         result = True
         try:
@@ -68,37 +81,55 @@ class MdanseTrajectory:
             result = False
         else:
             try:
-                temp_cs = ChemicalSystem(filename.stem)
-                temp_cs.load(file_object)
+                with MdanseTrajectory(filename) as mdtraj:
+                    chem = ChemicalSystem(file_object, mdtraj)
+                    chem.load(filename)
             except Exception:
                 LOG.warning(
                     f"Could not load ChemicalSystem from {filename}. MDANSE will try to read it as H5MD next."
                 )
                 result = False
+            else:
+                return True
+            try:
+                grp = file_object["/composition"]
+                _ = grp.attrs["name"]
+            except KeyError:
+                LOG.warning(
+                    f"Could not find /composition from {filename}. MDANSE will try to read it as H5MD next."
+                )
+                result = False
+            else:
+                result = True
             file_object.close()
         return result
 
     def close(self):
         """Close the trajectory."""
-
         self._h5_file.close()
 
-    def __getitem__(self, frame):
-        """Return the configuration at a given frame
+    def __getitem__(
+        self, frame: int
+    ) -> Union[RealConfiguration, PeriodicRealConfiguration]:
+        """Return the atom configuration for a specific frame.
 
-        :param frame: the frame
-        :type frame: int
+        Parameters
+        ----------
+        frame : int
+            index of a simulation frame
 
-        :return: the configuration
-        :rtype: dict of ndarray
+        Returns
+        -------
+        Union[RealConfiguration, PeriodicRealConfiguration]
+            Atom configuration, with unit cell (if defined)
+
         """
-
         grp = self._h5_file["/configuration"]
         configuration = {}
         for k, v in grp.items():
             configuration[k] = v[frame].astype(np.float64)
 
-        for k in self._h5_file.keys():
+        for k in self._h5_file:
             if k in ("time", "unit_cell"):
                 configuration[k] = self._h5_file[k][frame].astype(np.float64)
 
@@ -113,16 +144,25 @@ class MdanseTrajectory:
         self.__dict__ = state
         self._h5_file = h5py.File(state["_h5_filename"], "r")
 
-    def charges(self, frame):
-        """Return the electrical charge of atoms at a given frame.
+    def charges(self, frame: int) -> np.ndarray:
+        """Return the electrical charge array for given time step.
 
-        :param frame: the frame
-        :type frame: int
+        Parameters
+        ----------
+        frame : int
+            frame (time step) index
 
-        :return: the charge array
-        :rtype: ndarray
+        Returns
+        -------
+        np.ndarray
+            array of float values of partial charges
+
+        Raises
+        ------
+        IndexError
+            if the requested frame is not in the file
+
         """
-
         if frame < 0 or frame >= len(self):
             raise IndexError(f"Invalid frame number: {frame}")
 
@@ -139,16 +179,25 @@ class MdanseTrajectory:
 
         return charges.astype(np.float64)
 
-    def coordinates(self, frame):
-        """Return the coordinates at a given frame.
+    def coordinates(self, frame: int) -> np.ndarray:
+        """Return the atom position array for given time step.
 
-        :param frame: the frame
-        :type frame: int
+        Parameters
+        ----------
+        frame : int
+            frame (time step) index
 
-        :return: the coordinates
-        :rtype: ndarray
+        Returns
+        -------
+        np.ndarray
+            array of float values of atom coordinates
+
+        Raises
+        ------
+        IndexError
+            if the requested frame is not in the file
+
         """
-
         if frame < 0 or frame >= len(self):
             raise IndexError(f"Invalid frame number: {frame}")
 
@@ -156,23 +205,26 @@ class MdanseTrajectory:
 
         return grp["coordinates"][frame].astype(np.float64)
 
-    def configuration(self, frame):
-        """Build and return a configuration at a given frame.
+    def configuration(
+        self, frame: int
+    ) -> Union[RealConfiguration, PeriodicRealConfiguration]:
+        """Return the atom configuration for a specific frame.
 
-        :param frame: the frame
-        :type frame: int
+        Parameters
+        ----------
+        frame : int
+            index of a simulation frame
 
-        :return: the configuration
-        :rtype: MDANSE.MolecularDynamics.Configuration.Configuration
+        Returns
+        -------
+        Union[RealConfiguration, PeriodicRealConfiguration]
+            Atom configuration, with unit cell (if defined)
+
         """
-
         if frame < 0 or frame >= len(self):
             raise IndexError(f"Invalid frame number: {frame}")
 
-        if self._unit_cells is not None:
-            unit_cell = self._unit_cells[frame]
-        else:
-            unit_cell = None
+        unit_cell = self._unit_cells[frame] if self._unit_cells is not None else None
 
         variables = {}
         for k, v in self._h5_file["configuration"].items():
@@ -186,7 +238,10 @@ class MdanseTrajectory:
             conf = RealConfiguration(self._chemical_system, coordinates, **variables)
         else:
             conf = PeriodicRealConfiguration(
-                self._chemical_system, coordinates, unit_cell, **variables
+                self._chemical_system,
+                coordinates,
+                unit_cell,
+                **variables,
             )
 
         return conf
@@ -199,6 +254,7 @@ class MdanseTrajectory:
             self._unit_cells = None
 
     def time(self):
+        """Return the time array for all the frames."""
         return self._h5_file["time"][:]
 
     def unit_cell(self, frame):
@@ -210,22 +266,19 @@ class MdanseTrajectory:
         :return: the unit cell
         :rtype: ndarray
         """
-
         if frame < 0 or frame >= len(self):
             raise IndexError(f"Invalid frame number: {frame}")
 
         if self._unit_cells is not None:
             return self._unit_cells[frame]
-        else:
-            return None
+        return None
 
     def __len__(self):
-        """Returns the length of the trajectory.
+        """Return the length of the trajectory.
 
         :return: the number of frames of the trajectory
         :rtype: int
         """
-
         grp = self._h5_file["/configuration"]
 
         return grp["coordinates"].shape[0]
@@ -249,7 +302,6 @@ class MdanseTrajectory:
         :return: 2D array containing the center of mass trajectory for the selected frames
         :rtype: ndarray
         """
-
         if last is None:
             last = len(self)
 
@@ -269,7 +321,7 @@ class MdanseTrajectory:
                 [
                     ATOMS_DATABASE.get_atom_property(at, "atomic_weight")
                     for at in self.chemical_system.atom_list
-                ]
+                ],
             )
         masses = [masses[index] for index in atom_indices]
         grp = self._h5_file["/configuration"]
@@ -281,10 +333,10 @@ class MdanseTrajectory:
 
         if self._unit_cells is not None:
             direct_cells = np.array(
-                [uc.direct for uc in self._unit_cells[first:last:step]]
+                [uc.direct for uc in self._unit_cells[first:last:step]],
             )
             inverse_cells = np.array(
-                [uc.inverse for uc in self._unit_cells[first:last:step]]
+                [uc.inverse for uc in self._unit_cells[first:last:step]],
             )
             temp_coords = contiguous_coordinates_real(
                 coords,
@@ -297,14 +349,15 @@ class MdanseTrajectory:
                 [
                     center_of_mass(temp_coords[tstep], masses)
                     for tstep in range(len(temp_coords))
-                ]
+                ],
             )
 
             com_traj = atomic_trajectory(com_coords, direct_cells, inverse_cells)
 
         else:
             com_traj = np.sum(
-                coords[:, atom_indices, :] * masses[np.newaxis, :, np.newaxis], axis=1
+                coords[:, atom_indices, :] * masses[np.newaxis, :, np.newaxis],
+                axis=1,
             )
             com_traj /= np.sum(masses)
 
@@ -325,7 +378,6 @@ class MdanseTrajectory:
         :return: 2D array containing the real coordinates converted from box coordinates.
         :rtype: ndarray
         """
-
         if self._unit_cells is not None:
             real_coordinates = np.empty(box_coordinates.shape, dtype=np.float64)
             comp = 0
@@ -334,8 +386,7 @@ class MdanseTrajectory:
                 real_coordinates[comp, :] = box_coordinates[comp, :] @ direct_cell
                 comp += 1
             return real_coordinates
-        else:
-            return box_coordinates
+        return box_coordinates
 
     def read_atomic_trajectory(
         self, index, first=0, last=None, step=1, box_coordinates=False
@@ -356,7 +407,6 @@ class MdanseTrajectory:
         :return: 2D array containing the atomic trajectory for the selected frames
         :rtype: ndarray
         """
-
         if last is None:
             last = len(self)
 
@@ -365,20 +415,26 @@ class MdanseTrajectory:
 
         if self._unit_cells is not None:
             direct_cells = np.array(
-                [self._unit_cells[nf].direct for nf in range(first, last, step)]
+                [self._unit_cells[nf].direct for nf in range(first, last, step)],
             )
             inverse_cells = np.array(
-                [self._unit_cells[nf].inverse for nf in range(first, last, step)]
+                [self._unit_cells[nf].inverse for nf in range(first, last, step)],
             )
-            atomic_traj = atomic_trajectory(
-                coords, direct_cells, inverse_cells, box_coordinates
+            return atomic_trajectory(
+                coords,
+                direct_cells,
+                inverse_cells,
+                box_coordinates,
             )
-            return atomic_traj
-        else:
-            return coords
+        return coords
 
     def read_configuration_trajectory(
-        self, index, first=0, last=None, step=1, variable="velocities"
+        self,
+        index,
+        first=0,
+        last=None,
+        step=1,
+        variable="velocities",
     ):
         """Read a given configuration variable through the trajectory for a given ato.
 
@@ -396,7 +452,6 @@ class MdanseTrajectory:
         :return: 2D array containing the atomic trajectory for the selected frames
         :rtype: ndarray
         """
-
         if last is None:
             last = len(self)
 
@@ -404,13 +459,10 @@ class MdanseTrajectory:
             raise KeyError(f"The variable {variable} is not stored in the trajectory")
 
         grp = self._h5_file["/configuration"]
-        variable = grp[variable][first:last:step, index, :].astype(np.float64)
-
-        return variable
+        return grp[variable][first:last:step, index, :].astype(np.float64)
 
     def has_variable(self, variable: str) -> bool:
-        """Check if the trajectory has a specific variable e.g.
-        velocities.
+        """Check if the trajectory has a specific variable e.g. velocities.
 
         Parameters
         ----------
@@ -421,60 +473,77 @@ class MdanseTrajectory:
         -------
         bool
             True if variable exists.
+
         """
-        if variable in self._h5_file["/configuration"]:
-            return True
-        else:
-            return False
+        return variable in self._h5_file["/configuration"]
 
     def get_atom_property(self, symbol: str, property: str):
-        if "atom_database" not in self._h5_file:
+        if not self._has_database:
             return ATOMS_DATABASE.get_atom_property(symbol, property)
-        elif symbol not in self._h5_file["/atom_database"]:
-            return ATOMS_DATABASE.get_atom_property(symbol, property)
-        temp = np.where(
-            self._h5_file["/atom_database/property_labels"][:]
-            == property.encode("utf-8")
-        )[0]
-        if len(temp) == 0:
-            if property == "dummy":
-                try:
-                    return ATOMS_DATABASE.get_atom_property(symbol, property)
-                except KeyError:
-                    if (
-                        "_" in symbol
-                    ):  # this is most likely an artificial atom from a molecule
-                        return 0  # the molecule atoms are not dummy
+        elif symbol not in self._has_atoms:
+            if symbol in self._h5_file["/atom_database"]:
+                self._has_atoms.append(symbol)
             else:
-                raise KeyError(
-                    f"Property {property} is not in the trajectory's internal database."
-                )
-        index = temp.flatten()[0]
-        data_type = self._h5_file["/atom_database/property_types"][index]
-        value = self._h5_file[f"/atom_database/{symbol}"][index]
-        if data_type == b"int":
-            return int(value)
+                return ATOMS_DATABASE.get_atom_property(symbol, property)
+        if property not in self._property_map:
+            temp = np.where(
+                self._h5_file["/atom_database/property_labels"][:]
+                == property.encode("utf-8")
+            )[0]
+            if len(temp) == 0:
+                if property == "dummy":
+                    try:
+                        return ATOMS_DATABASE.get_atom_property(symbol, property)
+                    except KeyError:
+                        if (
+                            "_" in symbol
+                        ):  # this is most likely an artificial atom from a molecule
+                            return 0  # the molecule atoms are not dummy
+                else:
+                    raise KeyError(
+                        f"Property {property} is not in the trajectory's internal database."
+                    )
+            index = temp.flatten()[0]
+            self._property_map[property] = index
+        index = self._property_map[property]
+        if index not in self._data_types:
+            self._data_types[index] = self._h5_file["/atom_database/property_types"][
+                index
+            ]
+        data_type = self._data_types[index]
+        if (symbol, index) not in self._property_cache:
+            value = self._h5_file[f"/atom_database/{symbol}"][index]
+            if data_type != b"complex":
+                value = value.real
+            self._property_cache[(symbol, index)] = value
+        value = self._property_cache[(symbol, index)]
         if property == "color":
+            value = float(value)
             num1 = round(value // 0x10000)
             num2 = round((value - num1 * 0x10000) // 0x100)
             num3 = round((value - num1 * 0x10000 - num2 * 0x100))
             return ";".join([str(int(x)) for x in [num1, num2, num3]])
+        if data_type == b"int":
+            return int(value)
+        elif data_type == b"str":
+            if isinstance(value, bytes):
+                return value.decode("utf-8")
+            return value
+        value = float(value)
         return value
 
-    def atoms_in_database(self) -> List[str]:
+    def atoms_in_database(self) -> list[str]:
         if "atom_database" not in self._h5_file:
             return ATOMS_DATABASE.atoms
-        else:
-            return list(self._h5_file["/atom_database"].keys())
+        return list(self._h5_file["/atom_database"].keys())
 
-    def properties_in_database(self) -> List[str]:
+    def properties_in_database(self) -> list[str]:
         if "atom_database" not in self._h5_file:
             return ATOMS_DATABASE.properties
-        else:
-            return list(
-                label.decode("utf-8")
-                for label in self._h5_file["/atom_database/property_labels"]
-            )
+        return [
+            label.decode("utf-8")
+            for label in self._h5_file["/atom_database/property_labels"]
+        ]
 
     @property
     def chemical_system(self):
@@ -492,7 +561,6 @@ class MdanseTrajectory:
         :return: the trajectory file object
         :rtype: HDF5 file object
         """
-
         return self._h5_file
 
     @property
@@ -502,17 +570,11 @@ class MdanseTrajectory:
         :return: the trajectory filename
         :rtype: str
         """
-
         return self._h5_filename
 
     def variable(self, name: str):
-        """Returns a specific dataset corresponding
-        to a trajectory variable called 'name'.
-        """
-
-        grp = self._h5_file["/configuration/" + name]
-
-        return grp
+        """Return a specific dataset corresponding to a variable called 'name'."""
+        return self._h5_file["/configuration/" + name]
 
     def variables(self):
         """Return the configuration variables stored in this trajectory.
@@ -520,7 +582,6 @@ class MdanseTrajectory:
         :return; the configuration variable
         :rtype: list
         """
-
         grp = self._h5_file["/configuration"]
 
         return list(grp.keys())


### PR DESCRIPTION
**Description of work**
Originally part of #740, these changes reduce the total running time of our current unit tests by 1 minute.

**Fixes**
1. MdanseTrajectory calls uses dictionaries as a cache of atom properties and property types to minimise the number of times properties are read from trajectory files.

**To test**
All tests should pass.
