### PR TITLE
Atom selection normalisation update.

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomSelectionConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomSelectionConfigurator.py
@@ -77,7 +77,8 @@ class AtomSelectionConfigurator(IConfigurator):
 
         self["selection_length"] = len(self["flatten_indices"])
         self["indices"] = [[idx] for idx in self["flatten_indices"]]
-
+        self["all_names"] = list(atoms)
+        self["all_elements"] = [[at] for at in atoms]
         self["elements"] = [[at] for at in selectedAtoms]
         self["names"] = list(selectedAtoms)
         self["unique_names"] = sorted(set(self["names"]))
@@ -100,6 +101,17 @@ class AtomSelectionConfigurator(IConfigurator):
 
         """
         return Counter(self["names"])
+
+    def get_all_natoms(self) -> dict[str, int]:
+        """Count all atoms, per element.
+
+        Returns
+        -------
+        dict
+            A dictionary of the number of atom per element.
+
+        """
+        return Counter(self["all_names"])
 
     def get_total_natoms(self) -> int:
         """Count all the selected atoms.

--- a/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
@@ -93,6 +93,8 @@ class GroupingLevelConfigurator(SingleChoiceConfigurator):
         indices = []
         elements = []
         names = []
+        all_elements = []
+        all_names = []
         masses = []
         group_names = []
         group_elements = {}
@@ -112,6 +114,8 @@ class GroupingLevelConfigurator(SingleChoiceConfigurator):
                     chemical_system._clusters[mol_name]
                 ):
                     for x in cluster:
+                        all_elements.append([chemical_system.atom_list[x]])
+                        all_names.append(f"[{mol_name}]_{chemical_system.atom_list[x]}")
                         if x not in atomSelectionConfig["flatten_indices"]:
                             continue
                         mol_selected = True
@@ -148,6 +152,8 @@ class GroupingLevelConfigurator(SingleChoiceConfigurator):
         atomSelectionConfig["elements"] = elements
         atomSelectionConfig["masses"] = masses
         atomSelectionConfig["names"] = names
+        atomSelectionConfig["all_elements"] = all_elements
+        atomSelectionConfig["all_names"] = all_names
         atomSelectionConfig["selection_length"] = len(names)
         atomSelectionConfig["unique_names"] = sorted(set(names))
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/GroupingLevelConfigurator.py
@@ -280,7 +280,15 @@ class GroupingLevelConfigurator(SingleChoiceConfigurator):
                 eles_j = sorted(set(self["group_elements"][grp_j]))
                 conc_i = self["group_n_atms"][grp_i] / tot_n_atms
                 conc_j = self["group_n_atms"][grp_j] / tot_n_atms
-                conc = (conc_i * conc_j) ** conc_exp
+                if grp_i != grp_j:
+                    # for the cross terms we divide by 2 since f(q,t)_OH
+                    # includes only OH or HO, it gets summed to the total
+                    # properly by the weight scheme. Similarly, we will
+                    # have a factor of two in the scaling factor for the
+                    # cross terms of the molecular case.
+                    conc = 2 * (conc_i * conc_j) ** conc_exp
+                else:
+                    conc = (conc_i * conc_j) ** conc_exp
 
                 if grp_i == grp_j:
                     iterable = it.combinations_with_replacement(eles_i, 2)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/WeightsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/WeightsConfigurator.py
@@ -108,7 +108,9 @@ class WeightsConfigurator(SingleChoiceConfigurator):
         self["property"] = value
         self.error_status = "OK"
 
-    def get_weights(self, prop: Optional[str] = None):
+    def get_weights(
+        self, *, prop: Optional[str] = None
+    ) -> tuple[dict[str, float], dict[str, float]]:
         """Generate a dictionary of weights.
 
         Parameters
@@ -119,30 +121,34 @@ class WeightsConfigurator(SingleChoiceConfigurator):
 
         Returns
         -------
-        dict[str, float]
+        tuple[dict[str, float], dict[str, float]]
             The dictionary of the weights.
         """
         if not prop:
             prop = self["property"]
 
-        atom_selection_configurator = self._configurable[
-            self._dependencies["atom_selection"]
-        ]
+        atm_select = self._configurable[self._dependencies["atom_selection"]]
 
-        weights = defaultdict(float)
-        for name, elements in itertools.islice(
-            zip(
-                atom_selection_configurator["names"],
-                atom_selection_configurator["elements"],
+        weights = []
+        for n_elements, atm_names, atm_elements in [
+            (atm_select.get_natoms(), atm_select["names"], atm_select["elements"]),
+            (
+                atm_select.get_all_natoms(),
+                atm_select["all_names"],
+                atm_select["all_elements"],
             ),
-            atom_selection_configurator["selection_length"],
-        ):
-            weights[name] += sum(
-                self._trajectory.get_atom_property(element, prop)
-                for element in elements
-            )
+        ]:
+            w = defaultdict(float)
+            for name, elements in itertools.islice(
+                zip(atm_names, atm_elements),
+                len(atm_names),
+            ):
+                w[name] += sum(
+                    self._trajectory.get_atom_property(element, prop)
+                    for element in elements
+                )
+            for element, num_atoms in n_elements.items():
+                w[element] /= num_atoms
+            weights.append(w)
 
-        for element, num_atoms in atom_selection_configurator.get_natoms().items():
-            weights[element] /= num_atoms
-
-        return weights
+        return tuple(weights)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/WeightsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/WeightsConfigurator.py
@@ -139,10 +139,7 @@ class WeightsConfigurator(SingleChoiceConfigurator):
             ),
         ]:
             w = defaultdict(float)
-            for name, elements in itertools.islice(
-                zip(atm_names, atm_elements),
-                len(atm_names),
-            ):
+            for name, elements in zip(atm_names, atm_elements):
                 w[name] += sum(
                     self._trajectory.get_atom_property(element, prop)
                     for element in elements

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
@@ -536,8 +536,15 @@ class CurrentCorrelationFunction(IJob):
                     fft="rfft",
                 )
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 2, conc_exp=0.5)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            2,
+            conc_exp=0.5
+        )
         assign_weights(self._outputData, weight_dict, "j(q,t)_long_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "j(q,t)_trans_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "J(q,f)_long_%s", self.labels)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
@@ -543,7 +543,7 @@ class CurrentCorrelationFunction(IJob):
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
             2,
-            conc_exp=0.5
+            conc_exp=0.5,
         )
         assign_weights(self._outputData, weight_dict, "j(q,t)_long_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "j(q,t)_trans_%s", self.labels)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
@@ -563,10 +563,16 @@ class CurrentCorrelationFunction(IJob):
                 self.labels,
             )
 
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
         jqtLongTotal = weighted_sum(self._outputData, "j(q,t)_long_%s", self.labels)
-        self._outputData["j(q,t)_long_total"][:] = jqtLongTotal
+        self._outputData["j(q,t)_long_total"][:] = jqtLongTotal / fact
+        self._outputData["j(q,t)_long_total"].scaling_factor = fact
         jqtTransTotal = weighted_sum(self._outputData, "j(q,t)_trans_%s", self.labels)
-        self._outputData["j(q,t)_trans_total"][:] = jqtTransTotal
+        self._outputData["j(q,t)_trans_total"][:] = jqtTransTotal / fact
+        self._outputData["j(q,t)_trans_total"].scaling_factor = fact
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,
             "j(q,t)_long",
@@ -617,11 +623,13 @@ class CurrentCorrelationFunction(IJob):
             sqfLongTotal = weighted_sum(
                 self._outputData, "J(q,f)_long_ideal_%s", self.labels
             )
-            self._outputData["J(q,f)_long_ideal_total"][:] = sqfLongTotal
+            self._outputData["J(q,f)_long_ideal_total"][:] = sqfLongTotal / fact
+            self._outputData["J(q,f)_long_ideal_total"].scaling_factor = fact
             sqfTransTotal = weighted_sum(
                 self._outputData, "J(q,f)_trans_ideal_%s", self.labels
             )
-            self._outputData["J(q,f)_trans_ideal_total"][:] = sqfTransTotal
+            self._outputData["J(q,f)_trans_ideal_total"][:] = sqfTransTotal / fact
+            self._outputData["J(q,f)_trans_ideal_total"].scaling_factor = fact
             self.configuration["grouping_level"].add_grouped_totals(
                 self._outputData,
                 "J(q,f)_long_ideal",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -293,12 +293,19 @@ class DensityOfStates(IJob):
         if self.add_ideal_results:
             assign_weights(self._outputData, weight_dict, "dos_ideal_%s", self.labels)
 
-        self._outputData["vacf_total"][:] = weighted_sum(
-            self._outputData, "vacf_%s", self.labels
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
+        self._outputData["vacf_total"][:] = (
+            weighted_sum(self._outputData, "vacf_%s", self.labels) / fact
         )
-        self._outputData["dos_total"][:] = weighted_sum(
-            self._outputData, "dos_%s", self.labels
+        self._outputData["vacf_total"].scaling_factor = fact
+        self._outputData["dos_total"][:] = (
+            weighted_sum(self._outputData, "dos_%s", self.labels) / fact
         )
+        self._outputData["dos_total"].scaling_factor = fact
+
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,
             "vacf",
@@ -317,9 +324,10 @@ class DensityOfStates(IJob):
         )
 
         if self.add_ideal_results:
-            self._outputData["dos_ideal_total"][:] = weighted_sum(
-                self._outputData, "dos_ideal_%s", self.labels
+            self._outputData["dos_ideal_total"][:] = (
+                weighted_sum(self._outputData, "dos_ideal_%s", self.labels) / fact
             )
+            self._outputData["dos_ideal_total"].scaling_factor = fact
             self.configuration["grouping_level"].add_grouped_totals(
                 self._outputData,
                 "dos_ideal",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -280,8 +280,14 @@ class DensityOfStates(IJob):
                     fft="rfft",
                 )
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1,
+        )
         assign_weights(self._outputData, weight_dict, "vacf_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "dos_%s", self.labels)
         if self.add_ideal_results:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
@@ -192,8 +192,14 @@ class DensityProfile(IJob):
         for element in n_atoms_per_element:
             self._outputData[f"dp_{element}"] /= self.numberOfSteps
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, n_atoms_per_element, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            n_atoms_per_element,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1
+        )
         assign_weights(self._outputData, weight_dict, "dp_%s", self.labels)
         dp_total = weighted_sum(self._outputData, "dp_%s", self.labels)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
@@ -201,11 +201,16 @@ class DensityProfile(IJob):
             1,
         )
         assign_weights(self._outputData, weight_dict, "dp_%s", self.labels)
-        dp_total = weighted_sum(self._outputData, "dp_%s", self.labels)
 
+        n_selected = sum(n_atoms_per_element.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
+        dp_total = weighted_sum(self._outputData, "dp_%s", self.labels) / fact
         self._outputData.add(
             "dp_total", "LineOutputVariable", dp_total, axis="r", units="au"
         )
+        self._outputData["dp_total"].scaling_factor = fact
 
         r_values = np.linspace(0, self._extent, self._n_bins + 1)
         self._outputData["r"][:] = (r_values[1:] + r_values[:-1]) / 2

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityProfile.py
@@ -198,7 +198,7 @@ class DensityProfile(IJob):
             all_weights,
             n_atoms_per_element,
             self.configuration["atom_selection"].get_all_natoms(),
-            1
+            1,
         )
         assign_weights(self._outputData, weight_dict, "dp_%s", self.labels)
         dp_total = weighted_sum(self._outputData, "dp_%s", self.labels)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
@@ -334,8 +334,15 @@ class DynamicCoherentStructureFactor(IJob):
         )
 
         nAtomsPerElement = self.configuration["atom_selection"].get_natoms()
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 2, conc_exp=0.5)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            2,
+            conc_exp=0.5
+        )
         assign_weights(self._outputData, weight_dict, "f(q,t)_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "s(q,f)_%s", self.labels)
         if self.add_ideal_results:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
@@ -341,7 +341,7 @@ class DynamicCoherentStructureFactor(IJob):
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
             2,
-            conc_exp=0.5
+            conc_exp=0.5,
         )
         assign_weights(self._outputData, weight_dict, "f(q,t)_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "s(q,f)_%s", self.labels)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
@@ -367,9 +367,15 @@ class DynamicCoherentStructureFactor(IJob):
                     axis=1,
                 )
 
-        self._outputData["f(q,t)_total"][:] = weighted_sum(
-            self._outputData, "f(q,t)_%s", self.labels
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
+        self._outputData["f(q,t)_total"][:] = (
+            weighted_sum(self._outputData, "f(q,t)_%s", self.labels) / fact
         )
+        self._outputData["f(q,t)_total"].scaling_factor = fact
+
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,
             "f(q,t)",
@@ -380,9 +386,11 @@ class DynamicCoherentStructureFactor(IJob):
             units="au",
         )
 
-        self._outputData["s(q,f)_total"][:] = weighted_sum(
-            self._outputData, "s(q,f)_%s", self.labels
+        self._outputData["s(q,f)_total"][:] = (
+            weighted_sum(self._outputData, "s(q,f)_%s", self.labels) / fact
         )
+        self._outputData["s(q,f)_total"].scaling_factor = fact
+
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,
             "s(q,f)",
@@ -396,9 +404,10 @@ class DynamicCoherentStructureFactor(IJob):
         )
 
         if self.add_ideal_results:
-            self._outputData["s(q,f)_ideal_total"][:] = weighted_sum(
-                self._outputData, "s(q,f)_ideal_%s", self.labels
+            self._outputData["s(q,f)_ideal_total"][:] = (
+                weighted_sum(self._outputData, "s(q,f)_ideal_%s", self.labels) / fact
             )
+            self._outputData["s(q,f)_ideal_total"].scaling_factor = fact
             self.configuration["grouping_level"].add_grouped_totals(
                 self._outputData,
                 "s(q,f)_ideal",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -284,7 +284,7 @@ class DynamicIncoherentStructureFactor(IJob):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            1
+            1,
         )
         assign_weights(self._outputData, weight_dict, "f(q,t)_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "s(q,f)_%s", self.labels)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -278,8 +278,14 @@ class DynamicIncoherentStructureFactor(IJob):
         )
 
         nAtomsPerElement = self.configuration["atom_selection"].get_natoms()
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1
+        )
         assign_weights(self._outputData, weight_dict, "f(q,t)_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "s(q,f)_%s", self.labels)
         if self.add_ideal_results:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -309,13 +309,20 @@ class DynamicIncoherentStructureFactor(IJob):
                     axis=1,
                 )
 
-        self._outputData["f(q,t)_total"][:] = weighted_sum(
-            self._outputData, "f(q,t)_%s", self.labels
-        )
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
 
-        self._outputData["s(q,f)_total"][:] = weighted_sum(
-            self._outputData, "s(q,f)_%s", self.labels
+        self._outputData["f(q,t)_total"][:] = (
+            weighted_sum(self._outputData, "f(q,t)_%s", self.labels) / fact
         )
+        self._outputData["f(q,t)_total"].scaling_factor = fact
+
+        self._outputData["s(q,f)_total"][:] = (
+            weighted_sum(self._outputData, "s(q,f)_%s", self.labels) / fact
+        )
+        self._outputData["s(q,f)_total"].scaling_factor = fact
+
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,
             "f(q,t)",
@@ -334,9 +341,11 @@ class DynamicIncoherentStructureFactor(IJob):
         )
 
         if self.add_ideal_results:
-            self._outputData["s(q,f)_ideal_total"][:] = weighted_sum(
-                self._outputData, "s(q,f)_ideal_%s", self.labels
+            self._outputData["s(q,f)_ideal_total"][:] = (
+                weighted_sum(self._outputData, "s(q,f)_ideal_%s", self.labels) / fact
             )
+            self._outputData["s(q,f)_ideal_total"].scaling_factor = fact
+
             self.configuration["grouping_level"].add_grouped_totals(
                 self._outputData,
                 "s(q,f)_ideal",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -210,7 +210,7 @@ class ElasticIncoherentStructureFactor(IJob):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            1
+            1,
         )
         assign_weights(self._outputData, weight_dict, "eisf_%s", self.labels)
         self._outputData["eisf_total"][:] = weighted_sum(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -204,8 +204,14 @@ class ElasticIncoherentStructureFactor(IJob):
         for element, number in list(nAtomsPerElement.items()):
             self._outputData[f"eisf_{element}"][:] /= number
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1
+        )
         assign_weights(self._outputData, weight_dict, "eisf_%s", self.labels)
         self._outputData["eisf_total"][:] = weighted_sum(
             self._outputData, "eisf_%s", self.labels

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -213,9 +213,15 @@ class ElasticIncoherentStructureFactor(IJob):
             1,
         )
         assign_weights(self._outputData, weight_dict, "eisf_%s", self.labels)
-        self._outputData["eisf_total"][:] = weighted_sum(
-            self._outputData, "eisf_%s", self.labels
+
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
+        self._outputData["eisf_total"][:] = (
+            weighted_sum(self._outputData, "eisf_%s", self.labels) / fact
         )
+        self._outputData["eisf_total"].scaling_factor = fact
 
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -305,7 +305,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            1
+            1,
         )
         assign_weights(self._outputData, weight_dict, "f(q,t)_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "s(q,f)_%s", self.labels)
@@ -351,13 +351,15 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
 
         # since GDISF ~ exp(-msd * q2 / 6.0) the MSD isn't weighted in
         # the exp lets save the MSD with equal weights
-        selected_weights, all_weights = self.configuration["weights"].get_weights(prop="equal")
+        selected_weights, all_weights = self.configuration["weights"].get_weights(
+            prop="equal"
+        )
         weight_dict = get_weights(
             selected_weights,
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            1
+            1,
         )
         assign_weights(self._outputData, weight_dict, "msd_%s", self.labels)
         self._outputData["msd_total"][:] = weighted_sum(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -299,8 +299,14 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
                     axis=1,
                 )
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1
+        )
         assign_weights(self._outputData, weight_dict, "f(q,t)_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "s(q,f)_%s", self.labels)
         if self.add_ideal_results:
@@ -345,8 +351,14 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
 
         # since GDISF ~ exp(-msd * q2 / 6.0) the MSD isn't weighted in
         # the exp lets save the MSD with equal weights
-        weights = self.configuration["weights"].get_weights("equal")
-        weight_dict = get_weights(weights, nAtomsPerElement, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights(prop="equal")
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1
+        )
         assign_weights(self._outputData, weight_dict, "msd_%s", self.labels)
         self._outputData["msd_total"][:] = weighted_sum(
             self._outputData, "msd_%s", self.labels

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -314,12 +314,19 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
                 self._outputData, weight_dict, "s(q,f)_ideal_%s", self.labels
             )
 
-        self._outputData["f(q,t)_total"][:] = weighted_sum(
-            self._outputData, "f(q,t)_%s", self.labels
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
+        self._outputData["f(q,t)_total"][:] = (
+            weighted_sum(self._outputData, "f(q,t)_%s", self.labels) / fact
         )
-        self._outputData["s(q,f)_total"][:] = weighted_sum(
-            self._outputData, "s(q,f)_%s", self.labels
+        self._outputData["f(q,t)_total"].scaling_factor = fact
+        self._outputData["s(q,f)_total"][:] = (
+            weighted_sum(self._outputData, "s(q,f)_%s", self.labels) / fact
         )
+        self._outputData["s(q,f)_total"].scaling_factor = fact
+
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,
             "f(q,t)",
@@ -338,9 +345,11 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         )
 
         if self.add_ideal_results:
-            self._outputData["s(q,f)_ideal_total"][:] = weighted_sum(
-                self._outputData, "s(q,f)_ideal_%s", self.labels
+            self._outputData["s(q,f)_ideal_total"][:] = (
+                weighted_sum(self._outputData, "s(q,f)_ideal_%s", self.labels) / fact
             )
+            self._outputData["s(q,f)_ideal_total"].scaling_factor = fact
+
             self.configuration["grouping_level"].add_grouped_totals(
                 self._outputData,
                 "s(q,f)_ideal",
@@ -362,9 +371,11 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
             1,
         )
         assign_weights(self._outputData, weight_dict, "msd_%s", self.labels)
-        self._outputData["msd_total"][:] = weighted_sum(
-            self._outputData, "msd_%s", self.labels
+        self._outputData["msd_total"][:] = (
+            weighted_sum(self._outputData, "msd_%s", self.labels) / fact
         )
+        self._outputData["msd_total"].scaling_factor = fact
+
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,
             "msd",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -206,7 +206,7 @@ class MeanSquareDisplacement(IJob):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            1
+            1,
         )
         assign_weights(self._outputData, weight_dict, "msd_%s", self.labels)
         msdTotal = weighted_sum(self._outputData, "msd_%s", self.labels)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -209,7 +209,12 @@ class MeanSquareDisplacement(IJob):
             1,
         )
         assign_weights(self._outputData, weight_dict, "msd_%s", self.labels)
-        msdTotal = weighted_sum(self._outputData, "msd_%s", self.labels)
+
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
+        msdTotal = weighted_sum(self._outputData, "msd_%s", self.labels) / fact
         self._outputData.add(
             "msd_total",
             "LineOutputVariable",
@@ -218,6 +223,7 @@ class MeanSquareDisplacement(IJob):
             units="nm2",
             main_result=True,
         )
+        self._outputData["msd_total"].scaling_factor = fact
 
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -200,8 +200,14 @@ class MeanSquareDisplacement(IJob):
         for element, number in list(nAtomsPerElement.items()):
             self._outputData[f"msd_{element}"] /= number
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1
+        )
         assign_weights(self._outputData, weight_dict, "msd_%s", self.labels)
         msdTotal = weighted_sum(self._outputData, "msd_%s", self.labels)
         self._outputData.add(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
@@ -385,13 +385,11 @@ class NeutronDynamicTotalStructureFactor(IJob):
         """
 
         nAtomsPerElement = self.configuration["atom_selection"].get_natoms()
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
 
-        # Compute concentrations
-        nTotalAtoms = 0
-        for val in list(nAtomsPerElement.values()):
-            nTotalAtoms += val
-
-        norm_natoms = 1.0 / nTotalAtoms
+        norm_natoms = 1.0 / n_total
         # Compute coherent functions and structure factor
         for pair_str, (label_i, label_j) in self.pair_labels:
             ele_i = self.configuration["grouping_level"].get_element_from_label(label_i)
@@ -416,11 +414,16 @@ class NeutronDynamicTotalStructureFactor(IJob):
             self._outputData["f(q,t)_coh_total"][:] += (
                 self._outputData[f"f(q,t)_coh_{pair_str}"][:]
                 * self._outputData[f"f(q,t)_coh_{pair_str}"].scaling_factor
+                / fact
             )
             self._outputData["s(q,f)_coh_total"][:] += (
                 self._outputData[f"s(q,f)_coh_{pair_str}"][:]
                 * self._outputData[f"s(q,f)_coh_{pair_str}"].scaling_factor
+                / fact
             )
+
+        self._outputData["f(q,t)_coh_total"].scaling_factor = fact
+        self._outputData["s(q,f)_coh_total"].scaling_factor = fact
 
         # Compute incoherent functions and structure factor
         for label, number in nAtomsPerElement.items():
@@ -437,11 +440,16 @@ class NeutronDynamicTotalStructureFactor(IJob):
             self._outputData["f(q,t)_inc_total"][:] += (
                 self._outputData[f"f(q,t)_inc_{label}"][:]
                 * self._outputData[f"f(q,t)_inc_{label}"].scaling_factor
+                / fact
             )
             self._outputData["s(q,f)_inc_total"][:] += (
                 self._outputData[f"s(q,f)_inc_{label}"][:]
                 * self._outputData[f"s(q,f)_inc_{label}"].scaling_factor
+                / fact
             )
+
+        self._outputData["f(q,t)_inc_total"].scaling_factor = fact
+        self._outputData["s(q,f)_inc_total"].scaling_factor = fact
 
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,
@@ -485,10 +493,12 @@ class NeutronDynamicTotalStructureFactor(IJob):
             self._outputData["f(q,t)_coh_total"][:]
             + self._outputData["f(q,t)_inc_total"][:]
         )
+        self._outputData["f(q,t)_total"].scaling_factor = fact
         self._outputData["s(q,f)_total"][:] = (
             self._outputData["s(q,f)_coh_total"][:]
             + self._outputData["s(q,f)_inc_total"][:]
         )
+        self._outputData["s(q,f)_total"].scaling_factor = fact
 
         self._outputData.write(
             self.configuration["output_files"]["root"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
@@ -198,7 +198,7 @@ class PairDistributionFunction(DistanceHistogram):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            2
+            2,
         )
         if self.intra:
             for i in ["_intra", "_inter", ""]:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
@@ -200,6 +200,11 @@ class PairDistributionFunction(DistanceHistogram):
             self.configuration["atom_selection"].get_all_natoms(),
             2,
         )
+
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        factor = (n_selected / n_total) ** 2
+
         if self.intra:
             for i in ["_intra", "_inter", ""]:
                 if i == "_intra":
@@ -208,15 +213,19 @@ class PairDistributionFunction(DistanceHistogram):
                     labels = self.labels
                 assign_weights(self._outputData, weight_dict, f"pdf{i}_%s", labels)
                 pdf = weighted_sum(self._outputData, f"pdf{i}_%s", labels)
-                self._outputData[f"pdf{i}_total"][:] = pdf
+                self._outputData[f"pdf{i}_total"][:] = pdf / factor
                 self._outputData[f"rdf{i}_total"][:] = (
-                    shellSurfaces * self.averageDensity * pdf
+                    shellSurfaces * self.averageDensity * pdf / factor
                 )
                 self._outputData[f"tcf{i}_total"][:] = (
                     densityFactor
                     * self.averageDensity
-                    * (pdf if i == "_intra" else pdf - 1)
+                    * (pdf / factor if i == "_intra" else (pdf - factor) / factor)
                 )
+                self._outputData[f"pdf{i}_total"].scaling_factor = factor
+                self._outputData[f"rdf{i}_total"].scaling_factor = factor
+                self._outputData[f"tcf{i}_total"].scaling_factor = factor
+
                 for j in ["pdf", "rdf", "tcf"]:
                     self.configuration["grouping_level"].add_grouped_totals(
                         self._outputData,
@@ -232,11 +241,16 @@ class PairDistributionFunction(DistanceHistogram):
         else:
             assign_weights(self._outputData, weight_dict, "pdf_%s", self.labels)
             pdf = weighted_sum(self._outputData, "pdf_%s", self.labels)
-            self._outputData["pdf_total"][:] = pdf
-            self._outputData["rdf_total"][:] = shellSurfaces * self.averageDensity * pdf
-            self._outputData["tcf_total"][:] = (
-                densityFactor * self.averageDensity * (pdf - 1)
+            self._outputData["pdf_total"][:] = pdf / factor
+            self._outputData["rdf_total"][:] = (
+                shellSurfaces * self.averageDensity * pdf / factor
             )
+            self._outputData["tcf_total"][:] = (
+                densityFactor * self.averageDensity * (pdf - factor) / factor
+            )
+            self._outputData[f"pdf_total"].scaling_factor = factor
+            self._outputData[f"rdf_total"].scaling_factor = factor
+            self._outputData[f"tcf_total"].scaling_factor = factor
 
         self._outputData.write(
             self.configuration["output_files"]["root"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
@@ -248,9 +248,9 @@ class PairDistributionFunction(DistanceHistogram):
             self._outputData["tcf_total"][:] = (
                 densityFactor * self.averageDensity * (pdf - factor) / factor
             )
-            self._outputData[f"pdf_total"].scaling_factor = factor
-            self._outputData[f"rdf_total"].scaling_factor = factor
-            self._outputData[f"tcf_total"].scaling_factor = factor
+            self._outputData["pdf_total"].scaling_factor = factor
+            self._outputData["rdf_total"].scaling_factor = factor
+            self._outputData["tcf_total"].scaling_factor = factor
 
         self._outputData.write(
             self.configuration["output_files"]["root"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
@@ -192,8 +192,14 @@ class PairDistributionFunction(DistanceHistogram):
             calc_func, self._outputData
         )
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 2)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            2
+        )
         if self.intra:
             for i in ["_intra", "_inter", ""]:
                 if i == "_intra":

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -173,8 +173,14 @@ class PositionAutoCorrelationFunction(IJob):
         for element, number in list(nAtomsPerElement.items()):
             self._outputData[f"pacf_{element}"] /= number
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1
+        )
         assign_weights(self._outputData, weight_dict, "pacf_%s", self.labels)
         pacfTotal = weighted_sum(self._outputData, "pacf_%s", self.labels)
         self._outputData.add(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -196,7 +196,7 @@ class PositionAutoCorrelationFunction(IJob):
             units="nm2",
             main_result=True,
         )
-        self._outputData[f"pacf_total"].scaling_factor = fact
+        self._outputData["pacf_total"].scaling_factor = fact
 
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -179,7 +179,7 @@ class PositionAutoCorrelationFunction(IJob):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            1
+            1,
         )
         assign_weights(self._outputData, weight_dict, "pacf_%s", self.labels)
         pacfTotal = weighted_sum(self._outputData, "pacf_%s", self.labels)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -182,7 +182,12 @@ class PositionAutoCorrelationFunction(IJob):
             1,
         )
         assign_weights(self._outputData, weight_dict, "pacf_%s", self.labels)
-        pacfTotal = weighted_sum(self._outputData, "pacf_%s", self.labels)
+
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
+        pacfTotal = weighted_sum(self._outputData, "pacf_%s", self.labels) / fact
         self._outputData.add(
             "pacf_total",
             "LineOutputVariable",
@@ -191,6 +196,7 @@ class PositionAutoCorrelationFunction(IJob):
             units="nm2",
             main_result=True,
         )
+        self._outputData[f"pacf_total"].scaling_factor = fact
 
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
@@ -259,8 +259,14 @@ class PositionPowerSpectrum(IJob):
                     fft="rfft",
                 )
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1
+        )
         assign_weights(self._outputData, weight_dict, "pacf_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "pps_%s", self.labels)
         if self.add_ideal_results:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
@@ -265,7 +265,7 @@ class PositionPowerSpectrum(IJob):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            1
+            1,
         )
         assign_weights(self._outputData, weight_dict, "pacf_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "pps_%s", self.labels)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
@@ -271,16 +271,30 @@ class PositionPowerSpectrum(IJob):
         assign_weights(self._outputData, weight_dict, "pps_%s", self.labels)
         if self.add_ideal_results:
             assign_weights(self._outputData, weight_dict, "pps_ideal_%s", self.labels)
-        self._outputData["pacf_total"][:] = weighted_sum(
-            self._outputData,
-            "pacf_%s",
-            self.labels,
+
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
+        self._outputData["pacf_total"][:] = (
+            weighted_sum(
+                self._outputData,
+                "pacf_%s",
+                self.labels,
+            )
+            / fact
         )
-        self._outputData["pps_total"][:] = weighted_sum(
-            self._outputData,
-            "pps_%s",
-            self.labels,
+        self._outputData["pacf_total"].scaling_factor = fact
+        self._outputData["pps_total"][:] = (
+            weighted_sum(
+                self._outputData,
+                "pps_%s",
+                self.labels,
+            )
+            / fact
         )
+        self._outputData["pps_total"].scaling_factor = fact
+
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,
             "pacf",
@@ -298,11 +312,15 @@ class PositionPowerSpectrum(IJob):
             partial_result=True,
         )
         if self.add_ideal_results:
-            self._outputData["pps_ideal_total"][:] = weighted_sum(
-                self._outputData,
-                "pps_ideal_%s",
-                self.labels,
+            self._outputData["pps_ideal_total"][:] = (
+                weighted_sum(
+                    self._outputData,
+                    "pps_ideal_%s",
+                    self.labels,
+                )
+                / fact
             )
+            self._outputData["pps_ideal_total"].scaling_factor = fact
             self.configuration["grouping_level"].add_grouped_totals(
                 self._outputData,
                 "pps_ideal",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
@@ -269,6 +269,11 @@ class StaticStructureFactor(DistanceHistogram):
             self.configuration["atom_selection"].get_all_natoms(),
             2,
         )
+
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = (n_selected / n_total) ** 2
+
         if self.intra:
             assign_weights(
                 self._outputData, weight_dict, "ssf_intra_%s", self.labels_intra
@@ -276,10 +281,13 @@ class StaticStructureFactor(DistanceHistogram):
             assign_weights(self._outputData, weight_dict, "ssf_inter_%s", self.labels)
             assign_weights(self._outputData, weight_dict, "ssf_%s", self.labels)
             ssfIntra = weighted_sum(self._outputData, "ssf_intra_%s", self.labels_intra)
-            self._outputData["ssf_intra_total"][:] = ssfIntra
+            self._outputData["ssf_intra_total"][:] = ssfIntra / fact
             ssfInter = weighted_sum(self._outputData, "ssf_inter_%s", self.labels)
-            self._outputData["ssf_inter_total"][:] = ssfInter
-            self._outputData["ssf_total"][:] = ssfIntra + ssfInter
+            self._outputData["ssf_inter_total"][:] = ssfInter / fact
+            self._outputData["ssf_total"][:] = (ssfIntra + ssfInter) / fact
+            self._outputData["ssf_intra_total"].scaling_factor = fact
+            self._outputData["ssf_inter_total"].scaling_factor = fact
+            self._outputData["ssf_total"].scaling_factor = fact
             for i in ["_intra", "_inter", ""]:
                 self.configuration["grouping_level"].add_grouped_totals(
                     self._outputData,
@@ -294,9 +302,10 @@ class StaticStructureFactor(DistanceHistogram):
                 )
         else:
             assign_weights(self._outputData, weight_dict, "ssf_%s", self.labels)
-            self._outputData["ssf_total"][:] = weighted_sum(
-                self._outputData, "ssf_%s", self.labels
+            self._outputData["ssf_total"][:] = (
+                weighted_sum(self._outputData, "ssf_%s", self.labels) / fact
             )
+            self._outputData["ssf_total"].scaling_factor = fact
 
         self._outputData.write(
             self.configuration["output_files"]["root"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
@@ -261,8 +261,14 @@ class StaticStructureFactor(DistanceHistogram):
             calc_func, self._outputData
         )
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 2)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            2
+        )
         if self.intra:
             assign_weights(
                 self._outputData, weight_dict, "ssf_intra_%s", self.labels_intra

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
@@ -267,7 +267,7 @@ class StaticStructureFactor(DistanceHistogram):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            2
+            2,
         )
         if self.intra:
             assign_weights(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StructureFactorFromScatteringFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StructureFactorFromScatteringFunction.py
@@ -127,7 +127,10 @@ class StructureFactorFromScatteringFunction(IJob):
         scattering function.
         """
         nAtomsPerElement = self.configuration["atom_selection"].get_natoms()
-        norm_natoms = 1.0 / sum(nAtomsPerElement.values())
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = (n_selected / n_total) ** 2
+        norm_natoms = 1.0 / n_total
 
         for pair_str, (label_i, label_j) in self.labels:
             fqt = self.configuration["dcsf_input_file"]["instance"][
@@ -147,14 +150,16 @@ class StructureFactorFromScatteringFunction(IJob):
             self._outputData["ssf_total"][:] += (
                 self._outputData[f"ssf_{pair_str}"][:]
                 * self._outputData[f"ssf_{pair_str}"].scaling_factor
+                / fact
             )
+
+        self._outputData["ssf_total"].scaling_factor = fact
 
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,
             "ssf",
             "LineOutputVariable",
             dim=2,
-            conc_exp=0.5,
             axis="q",
             units="au",
             main_result=True,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
@@ -696,7 +696,7 @@ class VanHoveFunctionDistinct(IJob):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            2
+            2,
         )
         if self.intra:
             for i in ["_intra", "_inter", ""]:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
@@ -690,8 +690,14 @@ class VanHoveFunctionDistinct(IJob):
         )
 
         nAtomsPerElement = self.configuration["atom_selection"].get_natoms()
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 2)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            2
+        )
         if self.intra:
             for i in ["_intra", "_inter", ""]:
                 if i == "_intra":

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
@@ -698,6 +698,11 @@ class VanHoveFunctionDistinct(IJob):
             self.configuration["atom_selection"].get_all_natoms(),
             2,
         )
+
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = (n_selected / n_total) ** 2
+
         if self.intra:
             for i in ["_intra", "_inter", ""]:
                 if i == "_intra":
@@ -706,7 +711,8 @@ class VanHoveFunctionDistinct(IJob):
                     labels = self.labels
                 assign_weights(self._outputData, weight_dict, f"g(r,t){i}_%s", labels)
                 vhs = weighted_sum(self._outputData, f"g(r,t){i}_%s", labels)
-                self._outputData[f"g(r,t){i}_total"][...] = vhs
+                self._outputData[f"g(r,t){i}_total"][...] = vhs / fact
+                self._outputData[f"g(r,t){i}_total"].scaling_factor = fact
                 self.configuration["grouping_level"].add_grouped_totals(
                     self._outputData,
                     f"g(r,t){i}",
@@ -721,7 +727,8 @@ class VanHoveFunctionDistinct(IJob):
         else:
             assign_weights(self._outputData, weight_dict, "g(r,t)_%s", self.labels)
             vhs = weighted_sum(self._outputData, "g(r,t)_%s", self.labels)
-            self._outputData["g(r,t)_total"][...] = vhs
+            self._outputData["g(r,t)_total"][...] = vhs / fact
+            self._outputData["g(r,t)_total"].scaling_factor = fact
 
         self._outputData.write(
             self.configuration["output_files"]["root"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
@@ -327,12 +327,19 @@ class VanHoveFunctionSelf(IJob):
         )
         assign_weights(self._outputData, weight_dict, "g(r,t)_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "4_pi_r2_g(r,t)_%s", self.labels)
-        self._outputData["g(r,t)_total"][:] = weighted_sum(
-            self._outputData, "g(r,t)_%s", self.labels
+
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
+        self._outputData["g(r,t)_total"][:] = (
+            weighted_sum(self._outputData, "g(r,t)_%s", self.labels) / fact
         )
-        self._outputData["4_pi_r2_g(r,t)_total"][:] = weighted_sum(
-            self._outputData, "4_pi_r2_g(r,t)_%s", self.labels
+        self._outputData["g(r,t)_total"].scaling_factor = fact
+        self._outputData["4_pi_r2_g(r,t)_total"][:] = (
+            weighted_sum(self._outputData, "4_pi_r2_g(r,t)_%s", self.labels) / fact
         )
+        self._outputData["4_pi_r2_g(r,t)_total"].scaling_factor = fact
 
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
@@ -317,8 +317,14 @@ class VanHoveFunctionSelf(IJob):
                 number**2 * self.n_configs * self.configuration["r_values"]["step"]
             )
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1
+        )
         assign_weights(self._outputData, weight_dict, "g(r,t)_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "4_pi_r2_g(r,t)_%s", self.labels)
         self._outputData["g(r,t)_total"][:] = weighted_sum(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
@@ -323,7 +323,7 @@ class VanHoveFunctionSelf(IJob):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            1
+            1,
         )
         assign_weights(self._outputData, weight_dict, "g(r,t)_%s", self.labels)
         assign_weights(self._outputData, weight_dict, "4_pi_r2_g(r,t)_%s", self.labels)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -227,8 +227,14 @@ class VelocityAutoCorrelationFunction(IJob):
         for element, number in nAtomsPerElement.items():
             self._outputData[f"vacf_{element}"] /= number
 
-        weights = self.configuration["weights"].get_weights()
-        weight_dict = get_weights(weights, nAtomsPerElement, 1)
+        selected_weights, all_weights = self.configuration["weights"].get_weights()
+        weight_dict = get_weights(
+            selected_weights,
+            all_weights,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            1
+        )
         assign_weights(self._outputData, weight_dict, "vacf_%s", self.labels)
         vacfTotal = weighted_sum(self._outputData, "vacf_%s", self.labels)
         self._outputData["vacf_total"][:] = vacfTotal

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -236,8 +236,14 @@ class VelocityAutoCorrelationFunction(IJob):
             1,
         )
         assign_weights(self._outputData, weight_dict, "vacf_%s", self.labels)
+
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = n_selected / n_total
+
         vacfTotal = weighted_sum(self._outputData, "vacf_%s", self.labels)
-        self._outputData["vacf_total"][:] = vacfTotal
+        self._outputData["vacf_total"][:] = vacfTotal / fact
+        self._outputData["vacf_total"].scaling_factor = fact
 
         self.configuration["grouping_level"].add_grouped_totals(
             self._outputData,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -233,7 +233,7 @@ class VelocityAutoCorrelationFunction(IJob):
             all_weights,
             nAtomsPerElement,
             self.configuration["atom_selection"].get_all_natoms(),
-            1
+            1,
         )
         assign_weights(self._outputData, weight_dict, "vacf_%s", self.labels)
         vacfTotal = weighted_sum(self._outputData, "vacf_%s", self.labels)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
@@ -286,6 +286,11 @@ class XRayStaticStructureFactor(DistanceHistogram):
             self.configuration["atom_selection"].get_all_natoms(),
             2,
         )
+
+        n_selected = sum(nAtomsPerElement.values())
+        n_total = sum(self.configuration["atom_selection"].get_all_natoms().values())
+        fact = (n_selected / n_total) ** 2
+
         if self.intra:
             assign_weights(
                 self._outputData, weight_dict, "xssf_intra_%s", self.labels_intra
@@ -296,11 +301,13 @@ class XRayStaticStructureFactor(DistanceHistogram):
             xssfIntra = weighted_sum(
                 self._outputData, "xssf_intra_%s", self.labels_intra
             )
-            self._outputData["xssf_intra_total"][:] = xssfIntra
+            self._outputData["xssf_intra_total"][:] = xssfIntra / fact
             xssfInter = weighted_sum(self._outputData, "xssf_inter_%s", self.labels)
-            self._outputData["xssf_inter_total"][:] = xssfInter
-            self._outputData["xssf_total"][:] = xssfIntra + xssfInter
-
+            self._outputData["xssf_inter_total"][:] = xssfInter / fact
+            self._outputData["xssf_total"][:] = (xssfIntra + xssfInter) / fact
+            self._outputData["xssf_intra_total"].scaling_factor = fact
+            self._outputData["xssf_inter_total"].scaling_factor = fact
+            self._outputData["xssf_total"].scaling_factor = fact
             for i in ["_intra", "_inter", ""]:
                 self.configuration["grouping_level"].add_grouped_totals(
                     self._outputData,
@@ -316,9 +323,10 @@ class XRayStaticStructureFactor(DistanceHistogram):
 
         else:
             assign_weights(self._outputData, weight_dict, "xssf_%s", self.labels)
-            self._outputData["xssf_total"][:] = weighted_sum(
-                self._outputData, "xssf_%s", self.labels
+            self._outputData["xssf_total"][:] = (
+                weighted_sum(self._outputData, "xssf_%s", self.labels) / fact
             )
+            self._outputData["xssf_total"].scaling_factor = fact
 
         self._outputData.write(
             self.configuration["output_files"]["root"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
@@ -268,7 +268,24 @@ class XRayStaticStructureFactor(DistanceHistogram):
                 self.configuration["atom_selection"]["elements"],
             )
         }
-        weight_dict = get_weights(asf, nAtomsPerElement, 2)
+        all_asf = {
+            name: atomic_scattering_factor(
+                ele[0],
+                self._outputData["q"],
+                self.configuration["trajectory"]["instance"],
+            )
+            for name, ele in zip(
+                self.configuration["atom_selection"]["all_names"],
+                self.configuration["atom_selection"]["all_elements"],
+            )
+        }
+        weight_dict = get_weights(
+            asf,
+            all_asf,
+            nAtomsPerElement,
+            self.configuration["atom_selection"].get_all_natoms(),
+            2,
+        )
         if self.intra:
             assign_weights(
                 self._outputData, weight_dict, "xssf_intra_%s", self.labels_intra

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -15,12 +15,18 @@
 #
 import itertools
 from collections.abc import Iterable
+from typing import Union
 
 import numpy as np
 
 
 def get_weights(
-    props: dict[str, float], contents: dict[str, int], dim: int, conc_exp: float = 1.0
+    selected_props: dict[str, float],
+    all_props: dict[str, float],
+    selected_contents: dict[str, int],
+    all_contents: dict[str, int],
+    dim: int,
+    conc_exp: float = 1.0,
 ) -> dict[str, float]:
     """Calculate the scaling factors to be applied to output datasets.
 
@@ -29,10 +35,14 @@ def get_weights(
 
     Parameters
     ----------
-    props : dict[str, float]
-        Dictionary of values of an atom property for a selected object, averaged over atoms in that object
-    contents : dict[str, int]
-        Dictionary of numbers of atoms in an object
+    selected_props : dict[str, float]
+        Dictionary of values of an atom property for the selected subset of the trajectory, averaged over atoms in that object
+    all_props : dict[str, float]
+        Dictionary of values of an atom property for the trajectory, averaged over atoms in that object
+    selected_contents : dict[str, int]
+        Dictionary of numbers of atoms in the selected subset of the trajectory
+    all_contents : dict[str, int]
+        Dictionary of numbers of atoms of the trajectory
     dim : int
         number of atom types in the label of the output datasets (e.g. 1 for "O", 2 for "CuCu")
     conc_exp : float
@@ -44,22 +54,11 @@ def get_weights(
     Tuple(Dict[Tuple[str], float], float)
         Dictionary of scaling factors per dataset key, and a sum of all the factors
     """
-    normFactor = 0.0
-
-    weights = {}
-
-    n_atms = sum(contents[el] for el in props)
-    cartesianProduct = itertools.product(props, repeat=dim)
-    for elements in cartesianProduct:
-        atom_conc_product = np.prod([contents[el] / n_atms for el in elements])
-        property_product = np.prod(np.array([props[el] for el in elements]), axis=0)
-
-        factor = atom_conc_product**conc_exp * property_product
-        # E.g. for property b_coh, 5 Cu atoms, 100 total atoms, and dim=2
-        # factor = (5*5/(100*100))**conc_exp * b_coh(Cu)*b_coh(Cu)
-
-        weights[elements] = np.float64(np.copy(factor))
-        normFactor += atom_conc_product * property_product
+    n_atms = sum(all_contents[el] for el in all_props)
+    weights, _ = adjust_weights(
+        selected_props, selected_contents, n_atms, dim, conc_exp
+    )
+    _, normFactor = adjust_weights(all_props, all_contents, n_atms, dim, conc_exp)
 
     normalise = True
     try:
@@ -73,6 +72,54 @@ def get_weights(
     weights["sum"] = normFactor
 
     return weights
+
+
+def adjust_weights(
+    props: dict[str, float],
+    contents: dict[str, int],
+    n_atms: int,
+    dim: int,
+    conc_exp: float = 1.0,
+) -> tuple[dict[Union[str, tuple[str]], float], float]:
+    """Combine the weights based on whether they will be used for nth-body
+    property and adjust them based on their atom concentrations.
+
+    Parameters
+    ----------
+    props : dict[str, float]
+        Dictionary of values of an atom property for the selected subset of the trajectory, averaged over atoms in that object
+    contents : dict[str, int]
+        Dictionary of numbers of atoms in the selected subset of the trajectory
+    n_atms : int
+        Total number of atoms of the trajectory.
+    dim : int
+        number of atom types in the label of the output datasets (e.g. 1 for "O", 2 for "CuCu")
+    conc_exp : float
+        The exponent the at the product of the concentrations are taken
+        to (e.g. (c_i * c_j)**0.5 which is used for DCSF jobs).
+
+    Returns
+    -------
+    tuple[dict[Union[str, tuple[str]], float], float]
+        The dictionary of weights and a normalisation factor.
+    """
+    normFactor = 0.0
+
+    weights = {}
+
+    cartesianProduct = itertools.product(props, repeat=dim)
+    for elements in cartesianProduct:
+        atom_conc_product = np.prod([contents[el] / n_atms for el in elements])
+        property_product = np.prod(np.array([props[el] for el in elements]), axis=0)
+
+        factor = atom_conc_product**conc_exp * property_product
+        # E.g. for property b_coh, 5 Cu atoms, 100 total atoms, and dim=2
+        # factor = (5*5/(100*100))**conc_exp * b_coh(Cu)*b_coh(Cu)
+
+        weights[elements] = np.float64(np.copy(factor))
+        normFactor += atom_conc_product * property_product
+
+    return weights, normFactor
 
 
 def assign_weights(

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -66,7 +66,7 @@ def get_weights(
     except TypeError:
         normalise = abs(normFactor) > 0.0  # if normFactor is 0, all weights are 0 too.
     if normalise:
-        for k in list(weights.keys()):
+        for k in weights:
             weights[k] /= np.float64(normFactor)
 
     weights["sum"] = normFactor

--- a/MDANSE/Tests/UnitTests/Analysis/test_selection.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_selection.py
@@ -51,6 +51,6 @@ def test_disf_selection_plus_inverse_results_equal_to_all_selection_results(tmp_
     with h5py.File(result_all) as all, h5py.File(result_select) as select, h5py.File(result_inv) as inv:
         for key in ["/f(q,t)_total", "/s(q,f)_total"]:
             all_results = np.array(all[key])
-            select_results = np.array(select[key])
-            inv_results = np.array(inv[key])
+            select_results = np.array(select[key]) * select[key].attrs["scaling_factor"]
+            inv_results = np.array(inv[key]) * inv[key].attrs["scaling_factor"]
             np.testing.assert_allclose(all_results, select_results + inv_results)

--- a/MDANSE/Tests/UnitTests/Analysis/test_selection.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_selection.py
@@ -1,0 +1,56 @@
+import numpy as np
+import h5py
+
+from MDANSE.Framework.Jobs.IJob import IJob
+from test_helpers.paths import CONV_DIR, RESULTS_DIR
+
+
+mdmc_traj = CONV_DIR / "Ar_mdmc_h5md.h5"
+
+
+def test_disf_selection_plus_inverse_results_equal_to_all_selection_results(tmp_path):
+
+    parameters = {
+        "atom_selection": None,
+        "atom_transmutation": None,
+        "frames": (0, 10, 1, 5),
+        "instrument_resolution": ("Ideal", {}),
+        "q_vectors": (
+            "GridQVectors",
+            {"hrange": [0, 3, 1], "krange": [0, 3, 1], "lrange": [0, 3, 1], "qstep": 1}
+        ),
+        "running_mode": ("single-core",),
+        "trajectory": mdmc_traj,
+        "weights": "b_incoherent2",
+    }
+
+    disf = IJob.create("DynamicIncoherentStructureFactor")
+    result_all = tmp_path / f"disf_all_selection.mda"
+    parameters["output_files"] = (result_all, ("MDAFormat", ), "INFO")
+    disf.run(parameters, status=True)
+
+    disf = IJob.create("DynamicIncoherentStructureFactor")
+    result_select = tmp_path / f"disf_sphere_selection.mda"
+    parameters["output_files"] = (result_select, ("MDAFormat", ), "INFO")
+    parameters["atom_selection"] = \
+        ('{"0": {"function_name": "select_all", "operation_type": "union"}, '
+         '"1": {"function_name": "invert_selection"}, '
+         '"2": {"function_name": "select_sphere", "frame_number": 0, "sphere_centre": [1.73, 1.73, 1.73], "sphere_radius": 1.5, "operation_type": "union"}}')
+    disf.run(parameters, status=True)
+
+    disf = IJob.create("DynamicIncoherentStructureFactor")
+    result_inv = tmp_path / f"disf_sphere_selection_inverse.mda"
+    parameters["output_files"] = (result_inv, ("MDAFormat", ), "INFO")
+    parameters["atom_selection"] = \
+        ('{"0": {"function_name": "select_all", "operation_type": "union"}, '
+         '"1": {"function_name": "invert_selection"}, '
+         '"2": {"function_name": "select_sphere", "frame_number": 0, "sphere_centre": [1.73, 1.73, 1.73], "sphere_radius": 1.5, "operation_type": "union"}, '
+         '"3": {"function_name": "invert_selection"}}')
+    disf.run(parameters, status=True)
+
+    with h5py.File(result_all) as all, h5py.File(result_select) as select, h5py.File(result_inv) as inv:
+        for key in ["/f(q,t)_total", "/s(q,f)_total"]:
+            all_results = np.array(all[key])
+            select_results = np.array(select[key])
+            inv_results = np.array(inv[key])
+            np.testing.assert_allclose(all_results, select_results + inv_results)

--- a/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
+++ b/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
@@ -513,9 +513,7 @@ def test_convolution(
     assert len(fw) == len(uw)
 
     # Calculate differences between U(w)H(w) and F(w)
-    error = mean_absolute_error(
-        normalise(model, numerator=100), normalise(fw, model, numerator=100)
-    )
+    error = mean_absolute_error(model, fw)
     assert np.isclose(error, 0, atol=TOLERANCE)
 
 


### PR DESCRIPTION
**Description of work**
PR #810 should be merged before this one. Atom selection has now been updated so that it is always a fraction of the results when all atoms are selected.

**Explanation**
Currently in MDANSE 

```math
F_{\mathrm{inc}, \mathrm{selected}}(q, t) = \frac{1}{N_{\text{selected}}} \sum_{j}^{N} n_{j}w_j \langle \exp[-iq \cdot r_{j}(0)]\exp[iq \cdot r_{j}(t)] \rangle 
```

where $N$ is the number of atoms in the trajectory, $n_j$ is 0 or 1 depending on whether the atom has been selected or not. Additionally, the weights $w_j$ are normalised and are also dependent on the selection.

```math
w_j = \frac{u_j}{ \sum_{j}^{N} n_{j} u_j}
```

This update changes MDANSE so that the weights are no longer dependent on the selection and the selected results are always a fraction of the fully selected results

```math
F_{\mathrm{inc}, \mathrm{selected}}(q, t) = \frac{1}{N}\sum_{j}^{N} n_{j}w_j \langle \exp[-iq \cdot r_{j}(0)]\exp[iq \cdot r_{j}(t)] \rangle 
```
and the weight are now.

```math
w_j = \frac{u_j}{ \sum_{j}^{N} u_j}
```



**Examples**
- Running calculations by selecting all atoms of one type is now equivalent to the results of that element but with all atoms selected. Here I used this H2O and H2S trajectory.
<img width="413" alt="image" src="https://github.com/user-attachments/assets/e85e00ed-55c3-4d21-a564-14215baba788" />

<img width="647" alt="image" src="https://github.com/user-attachments/assets/d63f8b00-e1ae-40fb-98fe-1aab122d1762" />

- Similarly, the total H2O results with group and the total results with only H2O selected with atom grouping are the same.

<img width="653" alt="image" src="https://github.com/user-attachments/assets/70d9b2cf-c0b0-4d40-b218-39ea424d9ff7" />

- The sum of the results of a selection and its inverse is now equal to the total.

<img width="259" alt="image" src="https://github.com/user-attachments/assets/7bf63ea7-ce3c-41d2-9fd0-34281fc2f0aa" />
<img width="260" alt="image" src="https://github.com/user-attachments/assets/265bbaf5-d37d-4c11-a5ab-b08fa1e277d6" />

<img width="647" alt="image" src="https://github.com/user-attachments/assets/9f75b4b9-c7fb-4373-a99d-c62119d89d7a" />


- Selected results are a fraction of the results with all atoms selected. The `Apply weights?` can be used on total results to obtain results scaled so that it is as if the system contained only those atoms. This is most useful for calculations like PDF. The normalization of the weights is maintained. Here I have the PDF but with only water selected.

<img width="867" alt="image" src="https://github.com/user-attachments/assets/8c838c92-0c69-4ba1-a860-6f44b7eb4e09" />

The large r-values are less than one because they are a fraction of the total. I can use `Apply weights?` so that they are normalized.

<img width="656" alt="image" src="https://github.com/user-attachments/assets/1aca8187-386c-4c12-9817-7882ec35a816" />

Similarly with DISF, with `Apply weights?`, the sum of the partials is equal to the total. The total is selected so its a fraction of the total with all selected. 

<img width="839" alt="image" src="https://github.com/user-attachments/assets/a0695ce7-5266-4ec3-9e14-250815712f7b" />

We can uncheck `Apply weights?` so that they are normalized with f(q,t=0)=1.

<img width="835" alt="image" src="https://github.com/user-attachments/assets/3cfac78e-c900-43b8-aa5d-6de99104a8d0" />


**Fixes**
Fixes #438

**To test**
Run calculations with atom selection and without atom selection, and compare the results. Calculations with the selection should always be a fraction of the total with all atoms selected. 
