### PR TITLE
Add widgets back into widget lookup

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -120,6 +120,11 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "InstrumentResolutionConfigurator": InstrumentResolutionWidget,
     "PartialChargeConfigurator": PartialChargeWidget,
     "TrajectoryFilterConfigurator": TrajectoryFilterWidget,
+    "UnitCellConfigurator": UnitCellWidget,
+    "MDAnalysisTimeStepConfigurator": MDAnalysisMDTrajTimeStepWidget,
+    "MDTrajTimeStepConfigurator": MDAnalysisMDTrajTimeStepWidget,
+    "MDTrajTrajectoryFileConfigurator": MultiInputFileWidget,
+    "MDTrajTopologyFileConfigurator": MDTrajTopologyFileWidget,
 }
 
 


### PR DESCRIPTION
**Description of work**
Add widget which were removed by accident back into the widget lookup.

**Fixes**
Closes #836.

**To test**
Check that the trajectory editor, mdtraj and mdanalysis job/converters work as expected.
