### PR TITLE
Add missing get_widget_value in transmutation and charge widgets

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -520,6 +520,9 @@ class AtomSelectionWidget(WidgetBase):
             load_button.clicked.connect(self.load_selection_from_file_dialog)
         else:
             self._field = QLineEdit(self._base)
+            default_text = str(self._configurator.default)
+            self._field.setPlaceholderText(default_text)
+            self._field.setText(default_text)
         traj_config = self._configurator._configurable[
             self._configurator._dependencies["trajectory"]
         ]

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomTransmutationWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomTransmutationWidget.py
@@ -210,3 +210,14 @@ class AtomTransmutationWidget(AtomSelectionWidget):
         """
         transmuter = self._configurator.get_transmuter()
         return TransmutationHelper(transmuter, traj_data, self._field, self._base)
+
+    def get_widget_value(self) -> str:
+        """Return the current text in the input field.
+
+        Returns
+        -------
+        str
+            The JSON selector setting.
+
+        """
+        return self._field.text()

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomTransmutationWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomTransmutationWidget.py
@@ -193,6 +193,7 @@ class AtomTransmutationWidget(AtomSelectionWidget):
         if kwargs.get("use_list_view", False):
             raise TypeError(f"Cannot use list view with {type(self).__name__}.")
         super().__init__(*args, use_list_view=False, **kwargs)
+        self._field.textChanged.connect(self.updateValue)
 
     def create_helper(self, traj_data: tuple[str, Trajectory]) -> TransmutationHelper:
         """Create a helper dialog for selecting and transmuting atoms.

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomTransmutationWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomTransmutationWidget.py
@@ -221,4 +221,5 @@ class AtomTransmutationWidget(AtomSelectionWidget):
             The JSON selector setting.
 
         """
-        return self._field.text()
+        text = self._field.text()
+        return text if text else self._default_value

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/PartialChargeWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/PartialChargeWidget.py
@@ -187,6 +187,7 @@ class PartialChargeWidget(AtomSelectionWidget):
         if kwargs.get("use_list_view", False):
             raise TypeError(f"Cannot use list view with {type(self).__name__}.")
         super().__init__(*args, use_list_view=False, **kwargs)
+        self._field.textChanged.connect(self.updateValue)
 
     def create_helper(self, traj_data: tuple[str, Trajectory]) -> ChargeHelper:
         """Create the dialog for selecting atoms and setting their charges.

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/PartialChargeWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/PartialChargeWidget.py
@@ -215,4 +215,5 @@ class PartialChargeWidget(AtomSelectionWidget):
             The JSON selector setting.
 
         """
-        return self._field.text()
+        text = self._field.text()
+        return text if text else self._default_value

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/PartialChargeWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/PartialChargeWidget.py
@@ -204,3 +204,14 @@ class PartialChargeWidget(AtomSelectionWidget):
         """
         mapper = self._configurator.get_charge_mapper()
         return ChargeHelper(mapper, traj_data, self._field, self._base)
+
+    def get_widget_value(self) -> str:
+        """Return the current text in the input field.
+
+        Returns
+        -------
+        str
+            The JSON selector setting.
+
+        """
+        return self._field.text()


### PR DESCRIPTION
**Description of work**
Brings back the missing `get_widget_value` for the widgets that inherit from `AtomSelectionWidget`, to make transmutation and charge setting work in the GUI.

closes #833 

**Fixes**
Implemented `get_widget_value` for the atom transmutation and partial charge setting widgets.

**To test**
Run a TrajectoryEditor with transmutation and charge setting. The changes should be written into the output trajectory.
