### PR TITLE
Add GUI warnings for the trajectory widget

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -70,3 +70,5 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
             self["md_time_step"] = 1.0
 
         self["has_velocities"] = "velocities" in self["instance"].variables()
+
+        self.warning_status = trajectory_instance.unit_cell_warning()

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
@@ -155,6 +155,7 @@ class IConfigurator(dict, metaclass=SubclassFactory):
         self._valid = True
 
         self._error_status = "OK"
+        self.warning_status = ""
 
         self._original_input = ""
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
@@ -13,16 +13,26 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from __future__ import annotations
 
 import abc
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
+from warnings import warn
 
 import numpy as np
 from more_itertools import value_chain
 
 from MDANSE.Core.Error import Error
 from MDANSE.Core.SubclassFactory import SubclassFactory
+from MDANSE.MLogging import LOG
+
+if TYPE_CHECKING:
+    from MDANSE.Framework.Configurable import Configurable
+
+
+ERROR_LENGTH_MIN = len("OK")
 
 
 class CustomEncoder(json.JSONEncoder):
@@ -36,61 +46,58 @@ class CustomEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
+class ConfiguratorWarning(Warning):
+    """Reports a problem with one of the job inputs.
+
+    This warning is produced when the job is still able to execute,
+    but there are reasons to believe that the results may be scientifically
+    incorrect.
+    """
+
+
 class ConfiguratorError(Error):
-    """
-    This class handles any exception related to Configurator-derived object
-    """
+    """Error raised by a job input parser."""
 
-    def __init__(self, message, configurator=None):
+    def __init__(self, message: str, configurator: IConfigurator = None):
+        """Store the error message and configurator reference.
+
+        Parameters
+        ----------
+        message : str
+            Error message related to one of the job inputs
+        configurator : IConfigurator, optional
+            Reference to the input parser producing the error, by default None
+
         """
-        Initializes the the object.
-
-        :param message: the exception message
-        :type message: str
-        :param configurator: the configurator in which the exception was raised
-        :type configurator: an instance or derived instance of a MDANSE.Framework.Configurators.Configurator object
-        """
-
         self._message = message
-        self._configurator = configurator
+        self.configurator = configurator
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """Return a readable summary of the error as string.
+
+        Returns
+        -------
+        str
+            Text and source of the error.
+
         """
-        Returns the informal string representation of this object.
-
-        :return: the informal string representation of this object
-        :rtype: str
-        """
-
-        if self._configurator is not None:
+        if self.configurator is not None:
             self._message = (
-                f"Configurator: {self._configurator.name!r} --> {self._message}"
+                f"Configurator: {self.configurator.name!r} --> {self._message}"
             )
 
         return self._message
 
-    @property
-    def configurator(self):
-        """
-        Returns the configurator in which the exception was raised
-
-        :return: the configurator in which the exception was raised
-        :rtype: an instance or derived instance of a MDANSE.Framework.Configurators.Configurator object
-        """
-        return self._configurator
-
 
 class IConfigurator(dict, metaclass=SubclassFactory):
-    """
-    This class implements the base class for configurator objects. A configurator object is a dictionary-derived object that is used
-    to configure one item of a given configuration. Once the input value given for that item is configured, the dictionary is updated
-    with keys/values providing information about this item.
+    """The base class for configurator objects.
 
-    A configurator is not designed to be used as a stand-alone object. It should be used within the scope of a Configurable object that
-    will store a complete configuration for a given task (e.g. job, Q vectors, instrument resolution ...).
+    A configurator is an input parser for a variable required by any subclass
+    of Configurable.
 
-    Usually, configurator objects are self-consistent but for complex ones, it can happen that they depends on other configurators of the
-    configuration.
+    In some cases, a configurator may depend on another configurator.
+    A 'dependencies' keyword argument can be used to list the other
+    configurators that the current one will need to access.
     """
 
     _default = None
@@ -100,24 +107,15 @@ class IConfigurator(dict, metaclass=SubclassFactory):
 
     _doc_ = "undocumented"
 
-    def __init__(self, name, **kwargs):
-        """
-        Initializes a configurator object.
+    def __init__(self, name: str, **kwargs):
+        """Create an input parser for an MDANSE job input parameter.
 
-        :param name: the name of this configurator.
-        :type name: str
-        :param dependencies: the other configurators on which this configurator depends on to be configured. \
-        This has to be input as a dictionary that maps the name under which the dependency will be used within \
-        the configurator implementation to the actual name of the configurator on which this configurator is depending on.
-        :type dependencies: (str,str)-dict
-        :param default: the default value of this configurator.
-        :type default: any python object
-        :param label: the label of the panel in which this configurator will be inserted in the MDANSE GUI.
-        :type label: str
-        :param widget: the configurator widget that corresponds to this configurator.
-        :type widget: str
-        """
+        Parameters
+        ----------
+        name : str
+            the key of this object in the Configurable dictionary
 
+        """
         self._name = name
 
         self._printable_attributes = [
@@ -155,16 +153,17 @@ class IConfigurator(dict, metaclass=SubclassFactory):
         self._valid = True
 
         self._error_status = "OK"
-        self.warning_status = ""
+        self._warning_status = ""
 
         self._original_input = ""
 
     def __str__(self) -> str:
+        """Output all the configurator attributes and dict entries as text."""
         return "\n".join(
             value_chain(
                 "",
                 (
-                    f"{label}={str(getattr(self, label, 'Not set'))}"
+                    f"{label}={getattr(self, label, 'Not set')!s}"
                     for label in self._printable_attributes
                 ),
                 (f"{key}={str(self.get(key, 'Not set'))}" for key in self),
@@ -236,26 +235,50 @@ class IConfigurator(dict, metaclass=SubclassFactory):
 
     @property
     def error_status(self):
+        """Details of the configuration error.
+
+        It is set to 'OK' if no errors occurred.
+        """
         return self._error_status
 
     @error_status.setter
     def error_status(self, error_text: str):
-        """Sets the string explaining why the current input
-        cannot be accepted.
+        """Set the error description string.
 
-        If the string is longer than 'OK', the self._valid
+        If the string is longer than 'OK', the self.valid
         flag is set to False.
 
         Parameters
         ----------
         error_text : str
             Text explaining why the current input is invalid
+
         """
         self._error_status = error_text
-        if len(self._error_status) > 2:
+        if len(self._error_status) > ERROR_LENGTH_MIN:
             self._valid = False
         else:
             self._valid = True
+
+    @property
+    def warning_status(self):
+        """Text describing the potential problems with this input value."""
+        return self._warning_status
+
+    @warning_status.setter
+    def warning_status(self, warning_text: str):
+        """Store the warning text and emit a Python warning.
+
+        Parameters
+        ----------
+        warning_text : str
+            Short summary of the problem with this job input.
+
+        """
+        self._warning_status = warning_text
+        if warning_text:
+            LOG.warning(warning_text)
+            warn(warning_text, ConfiguratorWarning)
 
     @property
     def optional(self):

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
@@ -163,7 +163,7 @@ class IConfigurator(dict, metaclass=SubclassFactory):
             value_chain(
                 "",
                 (
-                    f"{label}={getattr(self, label, 'Not set')!s}"
+                    f"{label}={getattr(self, label, 'Not set')}"
                     for label in self._printable_attributes
                 ),
                 (f"{key}={str(self.get(key, 'Not set'))}" for key in self),
@@ -255,10 +255,7 @@ class IConfigurator(dict, metaclass=SubclassFactory):
 
         """
         self._error_status = error_text
-        if len(self._error_status) > ERROR_LENGTH_MIN:
-            self._valid = False
-        else:
-            self._valid = True
+        self._valid = error_text == "OK"
 
     @property
     def warning_status(self):

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -150,6 +150,9 @@ class Trajectory:
         """
 
         return self._trajectory.unit_cell(frame)
+    
+    def unit_cell_warning(self) -> str:
+        return self._trajectory.unit_cell_warning
 
     def calculate_coordinate_span(self) -> None:
         min_span = np.array(3 * [1e11])

--- a/MDANSE/Src/MDANSE/MolecularDynamics/UnitCell.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/UnitCell.py
@@ -17,6 +17,12 @@ import numpy as np
 from numpy.typing import ArrayLike
 
 
+CELL_SIZE_LIMIT = 1e-9
+NO_CELL = "Unit cell definition is missing. Add it using TrajectoryEditor."
+BAD_CELL = "Unit cell definition is invalid. Correct it using TrajectoryEditor."
+CHANGING_CELL = "Unit cell definition changes during the simulation. MANY ANALYSIS TYPES WILL PRODUCE WRONG RESULTS."
+
+
 class UnitCell:
     """
     This class stores a unit cell, which is stored row-wise i.e. the a, b and c vectors are

--- a/MDANSE/Src/MDANSE/MolecularDynamics/UnitCell.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/UnitCell.py
@@ -16,7 +16,6 @@
 import numpy as np
 from numpy.typing import ArrayLike
 
-
 CELL_SIZE_LIMIT = 1e-9
 NO_CELL = "Unit cell definition is missing. Add it using TrajectoryEditor."
 BAD_CELL = "Unit cell definition is invalid. Correct it using TrajectoryEditor."

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -33,7 +33,13 @@ from MDANSE.MolecularDynamics.Configuration import (
 from MDANSE.MolecularDynamics.TrajectoryUtils import (
     atomic_trajectory,
 )
-from MDANSE.MolecularDynamics.UnitCell import UnitCell
+from MDANSE.MolecularDynamics.UnitCell import (
+    UnitCell,
+    NO_CELL,
+    BAD_CELL,
+    CHANGING_CELL,
+    CELL_SIZE_LIMIT,
+)
 
 
 class H5MDTrajectory:
@@ -48,6 +54,7 @@ class H5MDTrajectory:
         :param h5_filename: the trajectory filename
         :type h5_filename: str
         """
+        self.unit_cell_warning = ""
 
         self._h5_filename = Path(h5_filename)
 
@@ -270,6 +277,7 @@ class H5MDTrajectory:
             cells = self._h5_file["/particles/all/box/edges/value"][:] * conv_factor
         except KeyError:
             self._unit_cells = None
+            self.unit_cell_warning = NO_CELL
         else:
             if cells.ndim > 1:
                 for cell in cells:
@@ -283,9 +291,18 @@ class H5MDTrajectory:
                         )
                     uc = UnitCell(temp_array)
                     self._unit_cells.append(uc)
+                    if not self.unit_cell_warning:
+                        if abs(uc.volume) < CELL_SIZE_LIMIT:
+                            self.unit_cell_warning = BAD_CELL
             else:
                 temp_array = np.diag(cells)
                 self._unit_cells.append(UnitCell(temp_array))
+        if not self.unit_cell_warning:
+            reference_array = self._unit_cells[0].direct
+            for uc in self._unit_cells[1:]:
+                if not np.allclose(reference_array, uc.direct):
+                    self.unit_cell_warning = CHANGING_CELL
+                    return
 
     def time(self):
         try:

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -291,9 +291,8 @@ class H5MDTrajectory:
                         )
                     uc = UnitCell(temp_array)
                     self._unit_cells.append(uc)
-                    if not self.unit_cell_warning:
-                        if abs(uc.volume) < CELL_SIZE_LIMIT:
-                            self.unit_cell_warning = BAD_CELL
+                    if not self.unit_cell_warning and uc.volume < CELL_SIZE_LIMIT:
+                        self.unit_cell_warning = BAD_CELL
             else:
                 temp_array = np.diag(cells)
                 self._unit_cells.append(UnitCell(temp_array))

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -34,11 +34,11 @@ from MDANSE.MolecularDynamics.TrajectoryUtils import (
     atomic_trajectory,
 )
 from MDANSE.MolecularDynamics.UnitCell import (
-    UnitCell,
-    NO_CELL,
     BAD_CELL,
-    CHANGING_CELL,
     CELL_SIZE_LIMIT,
+    CHANGING_CELL,
+    NO_CELL,
+    UnitCell,
 )
 
 

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -32,7 +32,13 @@ from MDANSE.MolecularDynamics.Configuration import (
 from MDANSE.MolecularDynamics.TrajectoryUtils import (
     atomic_trajectory,
 )
-from MDANSE.MolecularDynamics.UnitCell import UnitCell
+from MDANSE.MolecularDynamics.UnitCell import (
+    UnitCell,
+    NO_CELL,
+    BAD_CELL,
+    CHANGING_CELL,
+    CELL_SIZE_LIMIT,
+)
 
 
 class MdanseTrajectory:
@@ -56,6 +62,7 @@ class MdanseTrajectory:
         self._data_types = {}
         self._property_cache = {}
 
+        self.unit_cell_warning = ""
         self._h5_filename = Path(h5_filename)
 
         self._h5_file = h5py.File(self._h5_filename, "r")
@@ -253,6 +260,16 @@ class MdanseTrajectory:
             self._unit_cells = [UnitCell(uc) for uc in self._h5_file["unit_cell"][:]]
         else:
             self._unit_cells = None
+            self.unit_cell_warning = NO_CELL
+        if not self.unit_cell_warning:
+            if abs(self._unit_cells[0].volume) < CELL_SIZE_LIMIT:
+                self.unit_cell_warning = BAD_CELL
+                return
+            reference_array = self._unit_cells[0].direct
+            for uc in self._unit_cells[1:]:
+                if not np.allclose(reference_array, uc.direct):
+                    self.unit_cell_warning = CHANGING_CELL
+                    return
 
     def time(self):
         """Return the time array for all the frames."""

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -33,11 +33,11 @@ from MDANSE.MolecularDynamics.TrajectoryUtils import (
     atomic_trajectory,
 )
 from MDANSE.MolecularDynamics.UnitCell import (
-    UnitCell,
-    NO_CELL,
     BAD_CELL,
-    CHANGING_CELL,
     CELL_SIZE_LIMIT,
+    CHANGING_CELL,
+    NO_CELL,
+    UnitCell,
 )
 
 

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -262,7 +262,7 @@ class MdanseTrajectory:
             self._unit_cells = None
             self.unit_cell_warning = NO_CELL
         if not self.unit_cell_warning:
-            if abs(self._unit_cells[0].volume) < CELL_SIZE_LIMIT:
+            if self._unit_cells[0].volume < CELL_SIZE_LIMIT:
                 self.unit_cell_warning = BAD_CELL
                 return
             reference_array = self._unit_cells[0].direct

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
@@ -45,6 +45,7 @@ class HDFTrajectoryWidget(WidgetBase):
         else:
             tooltip_text = "A single logical value that can be True of False"
         label.setToolTip(tooltip_text)
+        self._label = label
 
     def configure_using_default(self):
         """This is too static to have a default value"""
@@ -63,4 +64,14 @@ class HDFTrajectoryWidget(WidgetBase):
         return self._configurator["value"]
 
     def get_widget_value(self):
-        return self.get_value()
+        result = self.get_value()
+        if not self._configurator.valid:
+            self.mark_error(self._configurator.error_status)
+        else:
+            self.mark_warning(self._configurator.warning_status)
+            if self._configurator.warning_status:
+                self._label.setToolTip(self._configurator.warning_status)
+            else:
+                self._label.setToolTip(self._tooltip)
+            self.value_updated.emit()
+        return result

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
@@ -36,6 +36,13 @@ if TYPE_CHECKING:
 Layouts = Literal["QHBoxLayout", "QVBoxLayout", "QGridLayout"]
 Bases = Literal["QWidget", "QGroupBox"]
 
+WARNING_STYLE = (
+    "QWidget#InputWidget { background-color:rgb(220,210,30); font-weight: bold }"
+)
+ERROR_STYLE = (
+    "QWidget#InputWidget { background-color:rgb(180,20,180); font-weight: bold }"
+)
+
 
 class WidgetBase(QObject):
     """Object to serve as an ABC to GUI widgets in MDANSE.
@@ -169,9 +176,7 @@ class WidgetBase(QObject):
             If True, update the widget's error without sending signals
 
         """
-        self._base.setStyleSheet(
-            "QWidget#InputWidget { background-color:rgb(180,20,180); font-weight: bold }"
-        )
+        self._base.setStyleSheet(ERROR_STYLE)
         self._base.setToolTip(error_text)
         if not silent:
             self.valid_changed.emit()
@@ -188,9 +193,7 @@ class WidgetBase(QObject):
         """
         if warning_text:
             self.has_warning = True
-            self._base.setStyleSheet(
-                "QWidget#InputWidget { background-color:rgb(220,210,30); font-weight: bold }"
-            )
+            self._base.setStyleSheet(WARNING_STYLE)
             self._base.setToolTip(warning_text)
             self.valid_changed.emit()
             return

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
@@ -171,6 +171,16 @@ class WidgetBase(QObject):
         self._base.setToolTip(error_text)
         self.valid_changed.emit()
 
+    def mark_warning(self, warning_text: str):
+        if warning_text:
+            self._base.setStyleSheet(
+                "QWidget#InputWidget { background-color:rgb(220,210,30); font-weight: bold }"
+            )
+            self._base.setToolTip(warning_text)
+            self.valid_changed.emit()
+            return
+        self.clear_error()
+
     def clear_error(self):
         """Remove error highlighting."""
         self._base.setStyleSheet("")
@@ -190,11 +200,11 @@ class WidgetBase(QObject):
                 "COULD NOT SET THIS VALUE - you may need to change the values in other widgets"
             )
         self.value_changed.emit()
-        if self._configurator.valid:
-            self.clear_error()
-            self.value_updated.emit()
-        else:
+        if not self._configurator.valid:
             self.mark_error(self._configurator.error_status)
+        else:
+            self.mark_warning(self._configurator.warning_status)
+            self.value_updated.emit()
 
     @abstractmethod
     def get_value(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
@@ -111,6 +111,7 @@ class WidgetBase(QObject):
         self._configurator = configurator
         self._parent_dialog = parent
         self._empty = False
+        self.has_warning = False
 
     def update_labels(self):
         """Update contained labels (dependent on base_type)."""
@@ -172,13 +173,24 @@ class WidgetBase(QObject):
         self.valid_changed.emit()
 
     def mark_warning(self, warning_text: str):
+        """If the input caused a warning, display warning_text and highlight the widget.
+
+        If warning_text is an empty string, this method will clear errors instead.
+
+        Parameters
+        ----------
+        warning_text : str
+            Message displayed on hover-over.
+        """
         if warning_text:
+            self.has_warning = True
             self._base.setStyleSheet(
                 "QWidget#InputWidget { background-color:rgb(220,210,30); font-weight: bold }"
             )
             self._base.setToolTip(warning_text)
             self.valid_changed.emit()
             return
+        self.has_warning = False
         self.clear_error()
 
     def clear_error(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
@@ -158,19 +158,23 @@ class WidgetBase(QObject):
         self._field.setPlaceholderText(str(default))
         self._configurator.configure(default)
 
-    def mark_error(self, error_text: str):
+    def mark_error(self, error_text: str, *, silent: bool = False):
         """Highlight an erroneous entry and display given error_text.
 
         Parameters
         ----------
         error_text : str
             Message displayed on hover-over.
+        silent : bool
+            If True, update the widget's error without sending signals
+
         """
         self._base.setStyleSheet(
             "QWidget#InputWidget { background-color:rgb(180,20,180); font-weight: bold }"
         )
         self._base.setToolTip(error_text)
-        self.valid_changed.emit()
+        if not silent:
+            self.valid_changed.emit()
 
     def mark_warning(self, warning_text: str):
         """If the input caused a warning, display warning_text and highlight the widget.

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -415,6 +415,7 @@ class Action(QWidget):
         for widget in self._widgets:
             if not widget._configurator.valid:
                 allow = False
+                widget.mark_error(widget._configurator.error_status, silent=True)
             if widget.has_warning:
                 has_warning = True
         if self.execute_button is not None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -410,14 +410,29 @@ class Action(QWidget):
     @Slot()
     def allow_execution(self):
         allow = True
+        has_warning = False
         for widget in self._widgets:
             if not widget._configurator.valid:
                 allow = False
+            if widget.has_warning:
+                has_warning = True
         if self.execute_button is not None:
             if allow:
                 self.execute_button.setEnabled(True)
             else:
                 self.execute_button.setEnabled(False)
+            if has_warning:
+                self.execute_button.setStyleSheet(
+                    "QWidget { background-color:rgb(220,210,30); font-weight: bold }"
+                )
+                self.execute_button.setToolTip(
+                    "Warning(s) found in input widgets above."
+                )
+            else:
+                self.execute_button.setStyleSheet("QWidget { }")
+                self.execute_button.setToolTip(
+                    "Launch the job using the current parameters."
+                )
         if self.post_execute_checkbox is not None:
             if self._job_name == "AverageStructure":
                 self.post_execute_checkbox.setEnabled(False)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -416,13 +416,9 @@ class Action(QWidget):
             if not widget._configurator.valid:
                 allow = False
                 widget.mark_error(widget._configurator.error_status, silent=True)
-            if widget.has_warning:
-                has_warning = True
+            has_warning = has_warning or widget.has_warning
         if self.execute_button is not None:
-            if allow:
-                self.execute_button.setEnabled(True)
-            else:
-                self.execute_button.setEnabled(False)
+            self.execute_button.setEnabled(allow)
             if has_warning:
                 self.execute_button.setStyleSheet(
                     "QWidget { background-color:rgb(220,210,30); font-weight: bold }"

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -328,6 +328,7 @@ class Action(QWidget):
             self.layout.addWidget(buttonbase)
             self._widgets_in_layout["button_base"] = buttonbase
         self.apply_instrument()
+        self.allow_execution()
 
     def check_inputs(self):
         configured = False


### PR DESCRIPTION
**Description of work**
Highlights the trajectory widget and the run button if the input trajectory does not have a usable unit cell definition.

This PR is a subset of changes from PR #780.

closes #764

**Fixes**
- `IConfigurator` stores a warning status that can be checked by GUI widgets,
- trajectory widget and the run button both show a warning if the trajectory does not have a usable unit cell,
- Both error and warning checks are now performed when the job is first being set up (which was not the case before), as well as after parameter changes.

**To test**
Load a trajectory without a unit cell, or with unit cell set to all zeros. Pick an analysis type. The warning should be highlighted in the GUI.
