### PR TITLE
User can not run IJob instance more than once in MDANSE script

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -141,6 +141,8 @@ class IJob(Configurable, metaclass=SubclassFactory):
         self.outputQueue = Queue()
         self.log_queue = Queue()
 
+        self.run_count = 0
+
     def __getstate__(self):
         d = self.__dict__.copy()
         del d["_processes"]
@@ -412,6 +414,11 @@ class IJob(Configurable, metaclass=SubclassFactory):
         """
         Run the job.
         """
+        self.run_count += 1
+        if self.run_count > 1:
+            raise RuntimeError(
+                f"Unable to run an instance of {(type).__name__} with name {self._name} more than once."
+            )
 
         try:
             self._name = f"{self.__class__.__name__}_{IJob.define_unique_name()}"

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -414,7 +414,7 @@ class IJob(Configurable, metaclass=SubclassFactory):
         """
         if hasattr(self._status, "state"):
             raise RuntimeError(
-                f"Unable to run an instance of {(type).__name__} with name {self._name} more than once."
+                f"Unable to run an instance of job with name {self._name} more than once."
             )
 
         try:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -141,8 +141,6 @@ class IJob(Configurable, metaclass=SubclassFactory):
         self.outputQueue = Queue()
         self.log_queue = Queue()
 
-        self.run_count = 0
-
     def __getstate__(self):
         d = self.__dict__.copy()
         del d["_processes"]
@@ -414,8 +412,7 @@ class IJob(Configurable, metaclass=SubclassFactory):
         """
         Run the job.
         """
-        self.run_count += 1
-        if self.run_count > 1:
+        if hasattr(self._status, "state"):
             raise RuntimeError(
                 f"Unable to run an instance of {(type).__name__} with name {self._name} more than once."
             )

--- a/MDANSE/Tests/UnitTests/test_converter.py
+++ b/MDANSE/Tests/UnitTests/test_converter.py
@@ -524,6 +524,7 @@ def test_lammps_ix_unwrap(tmp_path, files):
 
     parameters["trajectory_file"] = DATA_DIR / files[1]
     parameters["output_files"] = (out_2, 64, 128, "none", "INFO")
+    converter = Converter.create("LAMMPS")
     converter.run(parameters, status=True)
 
     compare_hdf5(out_1_name, out_2_name, ("/configuration/coordinates",), atol=1e-4)


### PR DESCRIPTION
**Description of work**
This PR implements a simple run counter for `IJob` instances which cannot exceed 1. Effectively, attempting to run the same instance twice with raise an error.

**Fixes**
Closes #755

**To test**
None
