### PR TITLE
Extend fast plotting to datasets and groups

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
@@ -40,20 +40,33 @@ class BasicPlotDataItem(QStandardItem):
 
     @abstractmethod
     def data_path(self):
+        """Return the path to the object inside the HDF5 file."""
         pass
 
     @abstractmethod
     def file_number(self):
+        """Return the model index of the source HDF5 file."""
         pass
 
     @property
     def child_path(self):
+        """Recursively build the HDF5 path to this object."""
         if self.data_parent is None:
             return ""
         else:
             return f"{self.data_parent.child_path}/{self.text()}"
 
+    def recursive_children(self) -> list[BasicPlotDataItem]:
+        """Return a list composed of this node and all its children."""
+        result = [self]
+        for child_row in range(self.rowCount()):
+            child = self.takeRow(child_row)
+            if child:
+                result += child[0].recursive_children()
+        return result
+
     def populate(self, data: h5py.File | h5py.Group):
+        """Create model items for the children datasets from the HDF5 file."""
         for key in data.keys() - EXCLUDE:
             try:
                 data[key]
@@ -74,51 +87,57 @@ class BasicPlotDataItem(QStandardItem):
 
 
 class DataSetItem(BasicPlotDataItem):
+    """A specialised model item for an end node (dataset)."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._item_type = "dataset"
 
     def data_path(self) -> str:
+        """Recursively build the HDF5 path to this dataset."""
         parent_path = self.parent().data_path()
         own_path = self.data(role=Qt.ItemDataRole.UserRole)
         return f"{parent_path}/{own_path}"
 
     def file_number(self) -> int:
+        """Return the model index of the source data file."""
         return self.parent().file_number()
 
 
 class DataFileItem(BasicPlotDataItem):
+    """A specialised item for a top-level node (data file) in the model."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._item_type = "file"
 
     def data_path(self) -> str:
+        """Return an empty string, since this item is not a dataset."""
         return ""
 
     def file_number(self) -> int:
+        """Return the inner model index of the data file from _nodes dictionary."""
         return self.data(role=Qt.ItemDataRole.UserRole)
 
 
 class MDADataStructure:
+    """Loads plotting-related information from an MDA file."""
+
     def __init__(self, filename: str):
         self._file = h5py.File(filename)
         self._metadata = check_metadata(self._file)
-        self.find_information()
 
     def close(self):
+        """Close the HDF5 file."""
         self._file.close()
-
-    def find_information(self):
-        self._main_dataset = ""
-        self._components = []
-        self._axis_datasets = []
-        self._supporting_datasets = []
 
 
 class PlotDataModel(QStandardItemModel):
-    """Meant to be used with DoublePanel, GeneralView
-    and ItemVisualiser. It stores elements and emits
-    them to the ItemVisualiser."""
+    """Stores plottable items from an MDA file.
+
+    Meant to be used with DoublePanel, GeneralView and ItemVisualiser.
+    It stores elements and emits them to the ItemVisualiser.
+    """
 
     error = Signal(str)
     all_elements = Signal(object)
@@ -131,10 +150,18 @@ class PlotDataModel(QStandardItemModel):
 
     @Slot(str)
     def add_file(self, filename: str):
+        """Add to the model all the plottable datasets from a file.
+
+        Parameters
+        ----------
+        filename : str
+            path to an MDA file
+
+        """
         try:
             new_datafile = MDADataStructure(filename)
         except Exception as e:
-            LOG.error(f"Invalid: {str(e)}")
+            LOG.error(f"Invalid: {e!s}")
         else:
             self._nodes[self._next_number] = new_datafile
             new_item = DataFileItem()
@@ -144,7 +171,20 @@ class PlotDataModel(QStandardItemModel):
             self.appendRow(new_item)
             new_item.populate(new_datafile._file)
 
-    def inner_object(self, index: QModelIndex) -> MDADataStructure:
+    def inner_object(self, index: QModelIndex) -> MDADataStructure | h5py.Dataset:
+        """For a Qt model index, return its corresponding HDF5 object.
+
+        Parameters
+        ----------
+        index : QModelIndex
+            Index of the model item from the Qt model.
+
+        Returns
+        -------
+        MDADataStructure | h5py.Dataset
+            Either a wrapper around the MDA file, or a dataset from the file.
+
+        """
         model_item = self.itemFromIndex(index)
         number = model_item.file_number()
         data_path = model_item.data_path()
@@ -153,7 +193,26 @@ class PlotDataModel(QStandardItemModel):
             return data_structure._file[data_path]
         return data_structure
 
+    def parent_object(self, index: QModelIndex) -> MDADataStructure:
+        """For a Qt index of a dataset, return the wrapper object of the HDF5 file.
+
+        Parameters
+        ----------
+        index : QModelIndex
+            Index of the model item from the Qt model.
+
+        Returns
+        -------
+        MDADataStructure
+            A wrapper around the MDA file.
+
+        """
+        model_item = self.itemFromIndex(index)
+        number = model_item.file_number()
+        return self._nodes[number]
+
     def removeRow(self, row: int, parent: QModelIndex = None):
+        """Delete a row from the model."""
         self.mutex.lock()
         try:
             node_number = self.item(row).data(role=Qt.ItemDataRole.UserRole)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
@@ -60,9 +60,9 @@ class BasicPlotDataItem(QStandardItem):
         """Return a list composed of this node and all its children."""
         result = [self]
         for child_row in range(self.rowCount()):
-            child = self.takeRow(child_row)
+            child = self.child(child_row, 0)
             if child:
-                result += child[0].recursive_children()
+                result += child.recursive_children()
         return result
 
     def populate(self, data: h5py.File | h5py.Group):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -282,7 +282,7 @@ class SingleDataset:
             picked_value = axis_values[index_tuple[axis_index]]
             if len(axis_values) > 1:
                 significant_digit = np.floor(
-                    np.log10(abs(np.mean(axis_values[1:] - axis_values[:-1])))
+                    np.log10(abs(np.mean(axis_values[1:] - axis_values[:-1]))),
                 ).astype(int)
             elif len(axis_values) == 1:
                 significant_digit = np.floor(np.log10(abs(axis_values[0]))).astype(int)
@@ -562,34 +562,34 @@ class PlottingContext(QStandardItemModel):
         result = {}
         for ds_num, row in enumerate(range(self.rowCount())):
             key = self.index(row, plotting_column_index["Dataset"]).data(
-                role=Qt.ItemDataRole.UserRole
+                role=Qt.ItemDataRole.UserRole,
             )
             useit = (
                 self.itemFromIndex(
-                    self.index(row, plotting_column_index["Use it?"])
+                    self.index(row, plotting_column_index["Use it?"]),
                 ).checkState()
                 == Qt.CheckState.Checked
             )
             set_scaling = (
                 self.itemFromIndex(
-                    self.index(row, plotting_column_index["Apply weights?"])
+                    self.index(row, plotting_column_index["Apply weights?"]),
                 ).checkState()
                 == Qt.CheckState.Checked
             )
             data_number_string = self.itemFromIndex(
-                self.index(row, plotting_column_index["Use it?"])
+                self.index(row, plotting_column_index["Use it?"]),
             ).text()
             colour = self.itemFromIndex(
-                self.index(row, plotting_column_index["Colour"])
+                self.index(row, plotting_column_index["Colour"]),
             ).text()
             style = self.itemFromIndex(
-                self.index(row, plotting_column_index["Line style"])
+                self.index(row, plotting_column_index["Line style"]),
             ).text()
             marker = self.itemFromIndex(
-                self.index(row, plotting_column_index["Marker"])
+                self.index(row, plotting_column_index["Marker"]),
             ).text()
             axis = self.itemFromIndex(
-                self.index(row, plotting_column_index["Main axis"])
+                self.index(row, plotting_column_index["Main axis"]),
             ).text()
             if useit:
                 self._datasets[key].set_data_limits(data_number_string)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -13,14 +13,14 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-import time
-from typing import Union
+from __future__ import annotations
 
 from qtpy.QtCore import QMimeData, QModelIndex, Qt, Signal, Slot
 from qtpy.QtGui import QContextMenuEvent, QDrag, QMouseEvent, QStandardItem
 from qtpy.QtWidgets import QAbstractItemView, QApplication, QMenu, QTreeView
 
 from MDANSE.MLogging import LOG
+from MDANSE_GUI.Tabs.Models.PlotDataModel import BasicPlotDataItem, MDADataStructure
 from MDANSE_GUI.Tabs.Models.PlottingContext import PlottingContext, SingleDataset
 from MDANSE_GUI.Tabs.Visualisers.DataPlotter import DataPlotter
 from MDANSE_GUI.Tabs.Visualisers.PlotDataInfo import PlotDataInfo
@@ -28,6 +28,12 @@ from MDANSE_GUI.Widgets.DataDialog import DataDialog
 
 
 class PlotDataView(QTreeView):
+    """Viewer of the MDA file contents.
+
+    It is used for selecting data from different MDA files that
+    will be plotted together.
+    """
+
     dataset_selected = Signal(object)
     execute_action = Signal(object)
     item_details = Signal(object)
@@ -51,22 +57,13 @@ class PlotDataView(QTreeView):
             return None
         index = self.indexAt(e.pos())
         model = self.model()
-        mda_data_structure = model.inner_object(index)
-        model = PlottingContext()
-        for key in mda_data_structure._file.keys():
-            try:
-                if "main" in mda_data_structure._file[key].attrs["tags"]:
-                    if "partial" in mda_data_structure._file[key].attrs["tags"]:
-                        dataset = SingleDataset(
-                            key, mda_data_structure._file, linestyle="--"
-                        )
-                    else:
-                        dataset = SingleDataset(key, mda_data_structure._file)
-
-                    model.add_dataset(dataset)
-            except KeyError:
-                LOG.error(f"No attribute called Tag found in {key}, skipping")
-        self.fast_plotting_data.emit(model)
+        inner_node = model.inner_object(index)
+        if isinstance(inner_node, MDADataStructure):
+            self.quick_plot_file(inner_node)
+        else:
+            data_nodes = model.itemFromIndex(index).recursive_children()
+            file_node = model.parent_object(index)
+            self.quick_plot_data(data_nodes, file_node)
 
     def mousePressEvent(self, e: QMouseEvent) -> None:
         self.click_position = e.position()
@@ -78,6 +75,8 @@ class PlotDataView(QTreeView):
         index = self.indexAt(event.pos())
         if index.row() == -1:
             # block right click when it's not on a trajectory
+            return
+        if index.parent().data() is not None:
             return
         model = self.model()
         qitem = model.itemFromIndex(index)
@@ -92,11 +91,10 @@ class PlotDataView(QTreeView):
                 packet = text, mda_data_structure.file
             self._data_packet = packet
         menu = QMenu()
-        item = model.itemData(index)
-        self.populateMenu(menu, item)
+        self.populateMenu(menu, index)
         menu.exec_(event.globalPos())
 
-    def populateMenu(self, menu: QMenu, item: QStandardItem):
+    def populateMenu(self, menu: QMenu, index: QModelIndex):
         for action, method in [("Delete", self.deleteNode)]:
             temp_action = menu.addAction(action)
             temp_action.triggered.connect(method)
@@ -105,13 +103,16 @@ class PlotDataView(QTreeView):
     def deleteNode(self):
         model = self.model()
         index = self.currentIndex()
-        mda_data_structure = model.inner_object(index)
+        mda_data_structure = model.parent_object(index)
         try:
             filename = mda_data_structure._file.filename
         except AttributeError:
             filename = mda_data_structure.file
         self.free_name.emit(str(filename))
-        model.removeRow(index.row())
+        parent_node = self.currentIndex()
+        while parent_node.column() > 1:
+            parent_node = parent_node.parent()
+        model.removeRow(parent_node.row())
         self.item_details.emit("")
 
     def on_select_dataset(self, index):
@@ -135,8 +136,65 @@ class PlotDataView(QTreeView):
             except Exception:
                 self.item_details.emit("No additional information included.")
 
+    def quick_plot_file(self, mda_data_structure: MDADataStructure):
+        """Automatically select, format and plot datasets from one file.
+
+        Parameters
+        ----------
+        mda_data_structure : MDADataStructure
+            Object containing and MDA data file.
+
+        """
+        model = PlottingContext()
+        for key in mda_data_structure._file:
+            try:
+                if "main" in mda_data_structure._file[key].attrs["tags"]:
+                    if "partial" in mda_data_structure._file[key].attrs["tags"]:
+                        dataset = SingleDataset(
+                            key, mda_data_structure._file, linestyle="--"
+                        )
+                    else:
+                        dataset = SingleDataset(key, mda_data_structure._file)
+
+                    model.add_dataset(dataset)
+            except KeyError:
+                LOG.error(f"No attribute called Tag found in {key}, skipping")
+        self.fast_plotting_data.emit(model)
+
+    def quick_plot_data(
+        self,
+        data_nodes: list[BasicPlotDataItem],
+        mda_data_structure: MDADataStructure,
+    ):
+        """Plot several datasets in a new plot instance.
+
+        Parameters
+        ----------
+        data_nodes : list[BasicPlotDataItem]
+            Data model items collected for plotting.
+        mda_data_structure : MDADataStructure
+            The common HDF5 file from which the datasets originate.
+
+        """
+        model = PlottingContext()
+        file = mda_data_structure._file
+        for data_node in data_nodes:
+            dataset = SingleDataset(data_node.child_path, file)
+            model.add_dataset(dataset)
+        self.fast_plotting_data.emit(model)
+
     @Slot(QModelIndex)
     def item_picked(self, index: QModelIndex):
+        """Respond to an item receiving a click in the view.
+
+        Here it will send the dataset to the DataPlotter model.
+
+        Parameters
+        ----------
+        index : QModelIndex
+            _description_
+
+        """
         model = self.model()
         model_item = model.itemFromIndex(index)
         item_type = model_item._item_type
@@ -161,7 +219,8 @@ class PlotDataView(QTreeView):
         self.item_details.emit(description)  # this should emit the job name
 
     def connect_to_visualiser(
-        self, visualiser: Union[DataPlotter, PlotDataInfo]
+        self,
+        visualiser: DataPlotter | PlotDataInfo,
     ) -> None:
         """Connect to a visualiser.
 
@@ -169,6 +228,7 @@ class PlotDataView(QTreeView):
         ----------
         visualiser : Action or TextInfo
             A visualiser to connect to this view.
+
         """
         if isinstance(visualiser, DataPlotter):
             self.dataset_selected.connect(visualiser.accept_data)
@@ -176,5 +236,5 @@ class PlotDataView(QTreeView):
             self.item_details.connect(visualiser.update_panel)
         else:
             raise NotImplementedError(
-                f"Unable to connect view {type(self)} to visualiser {type(visualiser)}"
+                f"Unable to connect view {type(self)} to visualiser {type(visualiser)}",
             )

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
@@ -33,8 +33,11 @@ from MDANSE_GUI.Tabs.Models.PlottingContext import (
 
 
 class DataPlotter(QWidget):
-    """This part of the interface will show the selection of datasets
-    created by the user, and allow the creation of a plot."""
+    """Part of PlotCreator which sends datasets to the plotter.
+
+    This part of the interface will show the selection of datasets
+    created by the user, and allow the creation of a plot.
+    """
 
     error = Signal(str)
     data_for_plotting = Signal(object)
@@ -71,6 +74,7 @@ class DataPlotter(QWidget):
 
     @Slot(object)
     def add_dataset(self, dataset: SingleDataset):
+        """Append a dataset to the current model."""
         if not dataset._valid:
             return
         self._model.add_dataset(dataset)
@@ -84,6 +88,7 @@ class DataPlotter(QWidget):
 
     @Slot()
     def new_plot(self):
+        """Trigger the creation of a new plot in the plotting tab."""
         self.create_new_plot.emit("")
         group = self._settings.group("dialogs")
         try:
@@ -105,6 +110,7 @@ class DataPlotter(QWidget):
 
     @Slot()
     def new_text(self):
+        """Trigger the creation of a new text view in the plotting tab."""
         self.create_new_text.emit("Text view")
         group = self._settings.group("dialogs")
         try:
@@ -126,6 +132,7 @@ class DataPlotter(QWidget):
 
     @Slot()
     def plot_data(self):
+        """Send the data from the internal model to the plotting tab."""
         if len(self._model.datasets()) == 0:
             return
         self.data_for_plotting.emit(self._model)
@@ -149,12 +156,14 @@ class DataPlotter(QWidget):
 
     @Slot(object)
     def accept_data(self, data_set):
+        """Append the incoming data to the inner model."""
         LOG.info(f"Received {data_set}")
         dataset = SingleDataset(data_set[0], data_set[1])
         self.add_dataset(dataset)
 
     @Slot()
     def clear(self):
+        """Remove all the entries from the model."""
         if self._model is None:
             return
         self._model.clear()


### PR DESCRIPTION
**Description of work**
Fast plotting is now possible by double-clicking any dataset in the Plot Creator tab. If the selected item is a group, all the datasets in that group will be plotted.

Double-clicking a file name still results in only the "main" datasets being plotted.

closes #843

**Fixes**
1. Added recursive search for children in the plotting data model,
2. Extended the double-click action to datasets and groups,
3. Disabled the context menu (with the "Delete") option for items which are not files.

**To test**
Load an MDA file.
Double clicking the file in the table should produce a plot the same as in the protos branch.
Double clicking a dataset will produce a new plot of this dataset.
Double clicking a group (e.g. a q-vector shell) will produce a new plot of all the items in the group.

