### PR TITLE
Limit IJob test to the CLI case

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -412,7 +412,7 @@ class IJob(Configurable, metaclass=SubclassFactory):
         """
         Run the job.
         """
-        if hasattr(self._status, "state"):
+        if isinstance(self._status, JobStatus) and hasattr(self._status, "state"):
             raise RuntimeError(
                 f"Unable to run an instance of job with name {self._name} more than once."
             )


### PR DESCRIPTION
**Description of work**
Only check if a job has run twice for jobs using JobStatus (i.e. running from a script).

closes #848 

**Fixes**
Added `if isinstance(self._status, JobStatus)` to `IJob.run`

**To test**
All tests must pass.
GUI runs should be possible again.

