### PR TITLE
Test benchmark auto-generation

### DIFF
--- a/MDANSE/Tests/UnitTests/Analysis/test_average_structure.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_average_structure.py
@@ -1,8 +1,8 @@
 import pytest
-from MDANSE.MolecularDynamics.Trajectory import \
-    Trajectory
-from MDANSE.Framework.Jobs.IJob import IJob
 from test_helpers.paths import CONV_DIR
+
+from MDANSE.Framework.Jobs.IJob import IJob
+from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
 short_traj = CONV_DIR / "short_trajectory_after_changes.mdt"
 
@@ -11,6 +11,7 @@ short_traj = CONV_DIR / "short_trajectory_after_changes.mdt"
 def trajectory():
     trajectory = Trajectory(short_traj)
     yield trajectory
+
 
 @pytest.mark.parametrize("output_unit", ["Angstrom", "Bohr", "nm", "pm"])
 @pytest.mark.parametrize("output_format", ["vasp", "xyz", "turbomole", "abinit-in"])

--- a/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_dynamics.py
@@ -1,19 +1,23 @@
 import numpy as np
 import pytest
-from MDANSE.Framework.Jobs.IJob import IJob
 from test_helpers.compare_hdf5 import compare_hdf5
 from test_helpers.paths import CONV_DIR, RESULTS_DIR
+
+from MDANSE.Framework.Jobs.IJob import IJob
 
 short_traj = CONV_DIR / "short_trajectory_after_changes.mdt"
 mdmc_traj = CONV_DIR / "Ar_mdmc_h5md.h5"
 com_traj = CONV_DIR / "com_trajectory.mdt"
 
-
 @pytest.mark.parametrize("interp_order", [1, 2, 3])
-def test_vacf(tmp_path, interp_order):
+def test_vacf(generate_benchmarks, tmp_path, interp_order):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / f"vacf_{interp_order}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "frames": (0, 10, 1, 5),
@@ -26,39 +30,55 @@ def test_vacf(tmp_path, interp_order):
     vacf = IJob.create("VelocityAutoCorrelationFunction")
     vacf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
 
-    fname = f"vacf_{interp_order}.mda"
+    compare_hdf5(
+        out_file,
+        result_file,
+        [f"vacf_{elem}" for elem in ("Cu", "S", "Sb", "total")],
+        scale_result=False,
+    )
 
-    result_file = RESULTS_DIR / fname
 
-    compare_hdf5(out_file, result_file, [f"/vacf_{elem}" for elem in ("Cu", "S", "Sb", "total")], scale_result=False)
-
-
-def test_pps(tmp_path):
+def test_pps(generate_benchmarks, tmp_path):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / "pps.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "frames": (0, 10, 1, 5),
         "output_files": (temp_name, ("MDAFormat",), "INFO"),
         "running_mode": ("single-core",),
-        "trajectory": short_traj
+        "trajectory": short_traj,
     }
 
     pps = IJob.create("PositionPowerSpectrum")
     pps.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
 
-    result_file = RESULTS_DIR / "pps.mda"
-
-    compare_hdf5(out_file, result_file,
-                [f"/{fn}_{elem}" for elem in ("Cu", "S", "Sb", "total") for fn in ("pacf", "pps")],
-                scale_result=True)
+    compare_hdf5(
+        out_file,
+        result_file,
+        [
+            f"{fn}_{elem}"
+            for elem in ("Cu", "S", "Sb", "total")
+            for fn in ("pacf", "pps")
+        ],
+        scale_result=True,
+    )
 
 
 ################################################################
@@ -94,45 +114,62 @@ def parameters():
     return parameters
 
 
-@pytest.mark.parametrize("traj_info", [("short_traj", short_traj), ("mdmc_traj", mdmc_traj), ("com_traj", com_traj)],
-                         ids=lambda x: x[0])
-@pytest.mark.parametrize("job_info", [
-    # "AngularCorrelation",
-    # "GeneralAutoCorrelationFunction",
-    ("DensityOfStates", ["dos", "vacf"], False),
-    ("MeanSquareDisplacement", ["msd"], False),
-    ("VelocityAutoCorrelationFunction", ["vacf"], False),
-    ("VanHoveFunctionDistinct", ["g(r,t)"], False),
-    ("VanHoveFunctionSelf", ["g(r,t)"], False),
-    # "OrderParameter",
-    ("PositionAutoCorrelationFunction", ["pacf"], False),
-    ("PositionPowerSpectrum", ["pacf", "pps"], False),
-], ids=lambda x: x[0])
-@pytest.mark.parametrize("running_mode", [("single-core", 1), ("multicore", -4)], ids=lambda x: x[0])
+@pytest.mark.parametrize(
+    "traj_info",
+    [("short_traj", short_traj), ("mdmc_traj", mdmc_traj), ("com_traj", com_traj)],
+    ids=lambda x: x[0],
+)
+@pytest.mark.parametrize(
+    "job_info",
+    [
+        # "AngularCorrelation",
+        # "GeneralAutoCorrelationFunction",
+        ("DensityOfStates", ["dos", "vacf"], False),
+        ("MeanSquareDisplacement", ["msd"], False),
+        ("VelocityAutoCorrelationFunction", ["vacf"], False),
+        ("VanHoveFunctionDistinct", ["g(r,t)"], False),
+        ("VanHoveFunctionSelf", ["g(r,t)"], False),
+        # "OrderParameter",
+        ("PositionAutoCorrelationFunction", ["pacf"], False),
+        ("PositionPowerSpectrum", ["pacf", "pps"], False),
+    ],
+    ids=lambda x: x[0],
+)
+@pytest.mark.parametrize(
+    "running_mode", [("single-core", 1), ("multicore", -4)], ids=lambda x: x[0]
+)
 @pytest.mark.parametrize("output_format", ["MDAFormat", "TextFormat"])
 def test_dynamics_analysis(
-        tmp_path, parameters, traj_info, job_info, running_mode, output_format
+    generate_benchmarks, tmp_path, parameters, traj_info, job_info, running_mode, output_format
 ):
+    job_type, outputs, normalised = job_info
+    outputs = tuple(outputs)
+
     temp_name = tmp_path / "output"
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / f"dynamics_analysis_{traj_info[0]}_{job_type}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters["trajectory"] = traj_info[1]
     parameters["running_mode"] = running_mode
     parameters["output_files"] = (temp_name, (output_format,), "INFO")
 
-    job_type, outputs, normalised = job_info
-    outputs = tuple(outputs)
-
     job = IJob.create(job_type)
     job.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     if output_format == "MDAFormat":
         out_file = temp_name.with_suffix(".mda")
-        result_file = RESULTS_DIR / f"dynamics_analysis_{traj_info[0]}_{job_type}.mda"
 
         assert out_file.is_file()
 
-        compare_hdf5(out_file, result_file, outputs, startswith=True, scale_result=normalised)
+        compare_hdf5(
+            out_file, result_file, outputs, startswith=True, scale_result=normalised
+        )
 
     elif output_format == "TextFormat":
         out_file = temp_name.parent / (temp_name.stem + "_text.tar")

--- a/MDANSE/Tests/UnitTests/Analysis/test_grouping.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_grouping.py
@@ -1,8 +1,8 @@
 import pytest
-from MDANSE.Framework.Jobs.IJob import IJob
 from test_helpers.compare_hdf5 import compare_hdf5
 from test_helpers.paths import CONV_DIR, RESULTS_DIR
 
+from MDANSE.Framework.Jobs.IJob import IJob
 
 named_mols = CONV_DIR / "named_molecules.mdt"
 
@@ -41,7 +41,7 @@ def dcsf(tmp_path_factory):
     out_file = temp_name.with_suffix(".mda")
 
     parameters = {
-        "output_files": (temp_name, ("MDAFormat", ), "INFO"),
+        "output_files": (temp_name, ("MDAFormat",), "INFO"),
         "q_vectors": (
             "GridQVectors",
             {"hrange": [0, 3, 1], "krange": [0, 3, 1], "lrange": [0, 3, 1], "qstep": 1},
@@ -63,7 +63,7 @@ def disf(tmp_path_factory):
     out_file = temp_name.with_suffix(".mda")
 
     parameters = {
-        "output_files": (temp_name, ("MDAFormat", ), "INFO"),
+        "output_files": (temp_name, ("MDAFormat",), "INFO"),
         "q_vectors": (
             "GridQVectors",
             {"hrange": [0, 3, 1], "krange": [0, 3, 1], "lrange": [0, 3, 1], "qstep": 1},
@@ -79,49 +79,81 @@ def disf(tmp_path_factory):
     yield out_file
 
 
-@pytest.mark.parametrize("job_info", [
-    ("DensityOfStates", ["dos", "vacf"], "equal", 1e-10, 1e-7),
-    ("MeanSquareDisplacement", ["msd"], "equal", 1e-10, 1e-7),
-    ("VelocityAutoCorrelationFunction", ["vacf"], "equal", 1e-10, 1e-7),
-    ("VanHoveFunctionDistinct", ["g(r,t)"], "equal", 1e-10, 1e-7),
-    ("VanHoveFunctionSelf", ["g(r,t)"], "equal", 1e-10, 1e-7),
-    ("PositionAutoCorrelationFunction", ["pacf"], "equal", 1e-10, 1e-7),
-    ("PositionPowerSpectrum", ["pacf", "pps"], "equal", 1e-10, 1e-7),
-    ("RootMeanSquareDeviation", ["rmsd"], "equal", 1e-10, 1e-7),
-    ("CoordinationNumber", ["cn"], "equal", 1e-10, 1e-7),
-    ("PairDistributionFunction", ["pdf", "rdf", "tcf"], "equal", 1e-10, 1e-7),
-    ("StaticStructureFactor", ["ssf"], "equal", 1e-10, 1e-7),
-    ("XRayStaticStructureFactor", ["xssf"], "equal", 1e-10, 1e-7),
-    ("DynamicCoherentStructureFactor", ["f(q,t)", "s(q,f)"], "b_coherent", 1e-6, 1e-6),
-    ("CurrentCorrelationFunction", ["J(q,f)", "j(q,t)"], "b_coherent", 1e-6, 1e-7),
-    ("DynamicIncoherentStructureFactor", ["f(q,t)", "s(q,f)"], "b_incoherent", 1e-10, 1e-7),
-    ("ElasticIncoherentStructureFactor", ["eisf"], "b_incoherent", 1e-10, 1e-7),
-    ("GaussianDynamicIncoherentStructureFactor", ["f(q,t)", "s(q,f)", "msd"], "b_incoherent", 1e-10, 1e-7),
-], ids=lambda x: x[0])
-def test_analysis(
-        tmp_path, parameters, job_info
-):
+@pytest.mark.parametrize(
+    "job_info",
+    [
+        ("DensityOfStates", ["dos", "vacf"], "equal", 1e-10, 1e-7),
+        ("MeanSquareDisplacement", ["msd"], "equal", 1e-10, 1e-7),
+        ("VelocityAutoCorrelationFunction", ["vacf"], "equal", 1e-10, 1e-7),
+        ("VanHoveFunctionDistinct", ["g(r,t)"], "equal", 1e-10, 1e-7),
+        ("VanHoveFunctionSelf", ["g(r,t)"], "equal", 1e-10, 1e-7),
+        ("PositionAutoCorrelationFunction", ["pacf"], "equal", 1e-10, 1e-7),
+        ("PositionPowerSpectrum", ["pacf", "pps"], "equal", 1e-10, 1e-7),
+        ("RootMeanSquareDeviation", ["rmsd"], "equal", 1e-10, 1e-7),
+        ("CoordinationNumber", ["cn"], "equal", 1e-10, 1e-7),
+        ("PairDistributionFunction", ["pdf", "rdf", "tcf"], "equal", 1e-10, 1e-7),
+        ("StaticStructureFactor", ["ssf"], "equal", 1e-10, 1e-7),
+        ("XRayStaticStructureFactor", ["xssf"], "equal", 1e-10, 1e-7),
+        (
+            "DynamicCoherentStructureFactor",
+            ["f(q,t)", "s(q,f)"],
+            "b_coherent",
+            1e-6,
+            1e-6,
+        ),
+        ("CurrentCorrelationFunction", ["J(q,f)", "j(q,t)"], "b_coherent", 1e-6, 1e-7),
+        (
+            "DynamicIncoherentStructureFactor",
+            ["f(q,t)", "s(q,f)"],
+            "b_incoherent",
+            1e-10,
+            1e-7,
+        ),
+        ("ElasticIncoherentStructureFactor", ["eisf"], "b_incoherent", 1e-10, 1e-7),
+        (
+            "GaussianDynamicIncoherentStructureFactor",
+            ["f(q,t)", "s(q,f)", "msd"],
+            "b_incoherent",
+            1e-10,
+            1e-7,
+        ),
+    ],
+    ids=lambda x: x[0],
+)
+def test_analysis(generate_benchmarks, tmp_path, parameters, job_info):
+    job_type, outputs, weights, atol, rtol = job_info
     temp_name = tmp_path / "output"
     log_file = temp_name.with_suffix(".log")
+    out_file = temp_name.with_suffix(".mda")
+    result_file = RESULTS_DIR / f"grouping_molecule_{job_type}.mda"
 
-    job_type, outputs, weights, atol, rtol = job_info
-    parameters["output_files"] = (temp_name, ("MDAFormat", ), "INFO")
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
+
+    parameters["output_files"] = (temp_name, ("MDAFormat",), "INFO")
     parameters["weights"] = weights
 
     job = IJob.create(job_type)
     job.run(parameters, status=True)
 
-    out_file = temp_name.with_suffix(".mda")
-    result_file = RESULTS_DIR / f"grouping_molecule_{job_type}.mda"
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
-    compare_hdf5(out_file, result_file, tuple(outputs), startswith=True, atol=atol, rtol=rtol)
+    compare_hdf5(
+        out_file, result_file, tuple(outputs), startswith=True, atol=atol, rtol=rtol
+    )
     assert log_file.is_file()
 
 
-def test_rmsf(tmp_path, parameters):
+def test_rmsf(generate_benchmarks, tmp_path, parameters):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / "grouping_each_molecule_RootMeanSquareFluctuation.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters["grouping_level"] = "each molecule"
     parameters["output_files"] = (temp_name, ("MDAFormat",), "INFO")
@@ -129,16 +161,23 @@ def test_rmsf(tmp_path, parameters):
     rmsf = IJob.create("RootMeanSquareFluctuation")
     rmsf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
-    result_file = RESULTS_DIR / "grouping_each_molecule_RootMeanSquareFluctuation.mda"
+
     compare_hdf5(out_file, result_file, "rmsf", startswith=True)
 
 
-def test_ndtsf(tmp_path, disf, dcsf, qvector_grid):
+def test_ndtsf(generate_benchmarks, tmp_path, disf, dcsf, qvector_grid):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / "grouping_molecule_ndtsf.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "atom_selection": None,
@@ -147,36 +186,46 @@ def test_ndtsf(tmp_path, disf, dcsf, qvector_grid):
         "disf_input_file": disf,
         "dcsf_input_file": dcsf,
         "trajectory": named_mols,
-        "output_files": (temp_name, ("MDAFormat", ), "INFO"),
+        "output_files": (temp_name, ("MDAFormat",), "INFO"),
     }
 
     ndtsf = IJob.create("NeutronDynamicTotalStructureFactor")
     ndtsf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
-    result_file = RESULTS_DIR / "grouping_molecule_ndtsf.mda"
-    compare_hdf5(out_file, result_file, ("f(q,t)", "s(q,f)"),
-                 startswith=True, atol=1e-6)
+
+    compare_hdf5(
+        out_file, result_file, ("f(q,t)", "s(q,f)"), startswith=True, atol=1e-6
+    )
 
 
-def test_ssfsf(tmp_path, dcsf):
+def test_ssfsf(generate_benchmarks, tmp_path, dcsf):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / "grouping_molecule_sffsf.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "dcsf_input_file": dcsf,
         "trajectory": named_mols,
         "grouping_level": "molecule",
-        "output_files": (temp_name, ("MDAFormat", ), "INFO"),
+        "output_files": (temp_name, ("MDAFormat",), "INFO"),
     }
 
     ssfsf = IJob.create("StructureFactorFromScatteringFunction")
     ssfsf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
-    result_file = RESULTS_DIR / "grouping_molecule_sffsf.mda"
-    compare_hdf5(out_file, result_file, "ssf_total", startswith=True,
-                 atol=1e-6)
+
+    compare_hdf5(out_file, result_file, "ssf_total", startswith=True, atol=1e-6)

--- a/MDANSE/Tests/UnitTests/Analysis/test_infrared.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_infrared.py
@@ -1,15 +1,20 @@
 import numpy as np
-from MDANSE.Framework.Jobs.IJob import IJob
 from test_helpers.compare_hdf5 import compare_hdf5
 from test_helpers.paths import CONV_DIR, RESULTS_DIR
+
+from MDANSE.Framework.Jobs.IJob import IJob
 
 short_traj = CONV_DIR / "named_molecules.mdt"
 
 
-def test_dacf_analysis(tmp_path):
+def test_dacf_analysis(generate_benchmarks, tmp_path):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / "dacf_analysis.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "frames": (0, 100, 1, 51),
@@ -36,18 +41,23 @@ def test_dacf_analysis(tmp_path):
     job = IJob.create("DipoleAutoCorrelationFunction")
     job.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
-
-    result_file = RESULTS_DIR / "dacf_analysis.mda"
 
     compare_hdf5(out_file, result_file, ("/dacf",), scale_result=True)
 
 
-def test_ir_analysis(tmp_path):
+def test_ir_analysis(generate_benchmarks, tmp_path):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / "ir_analysis.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "frames": (0, 100, 1, 51),
@@ -76,9 +86,10 @@ def test_ir_analysis(tmp_path):
     job = IJob.create("Infrared")
     job.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
-
-    result_file = RESULTS_DIR / "ir_analysis.mda"
 
     compare_hdf5(out_file, result_file, ("/ddacf", "/ir"), scale_result=True)

--- a/MDANSE/Tests/UnitTests/Analysis/test_mdmc_h5md.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_mdmc_h5md.py
@@ -1,15 +1,17 @@
-import tempfile
 import os
-import pytest
+import tempfile
 
-import numpy as np
 import h5py
-from MDANSE.MolecularDynamics.Trajectory import Trajectory
-from MDANSE.Framework.Jobs.IJob import IJob
-from test_helpers.paths import RESULTS_DIR, CONV_DIR
+import numpy as np
+import pytest
 from test_helpers.compare_hdf5 import compare_hdf5
+from test_helpers.paths import CONV_DIR, RESULTS_DIR
+
+from MDANSE.Framework.Jobs.IJob import IJob
+from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
 short_traj = CONV_DIR / "Ar_mdmc_h5md.h5"
+
 
 @pytest.fixture(scope="module")
 def trajectory():
@@ -18,8 +20,9 @@ def trajectory():
 
 
 @pytest.mark.parametrize("interp_order", [1, 3])
-def test_h5md_temperature(tmp_path, trajectory, interp_order):
+def test_h5md_temperature(generate_benchmarks, tmp_path, trajectory, interp_order):
     pos = trajectory.coordinates(0)
+    result_file = RESULTS_DIR / f"h5md_temperature_{interp_order}.mda"
 
     print(f"Coordinates span: {pos.min()}, {pos.max()}")
     print(f"Trajectory length: {len(trajectory)}")
@@ -28,6 +31,9 @@ def test_h5md_temperature(tmp_path, trajectory, interp_order):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "frames": (0, 39, 1),
@@ -40,10 +46,14 @@ def test_h5md_temperature(tmp_path, trajectory, interp_order):
     temp = IJob.create("Temperature")
     temp.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
 
-    result_file = RESULTS_DIR / f"h5md_temperature_{interp_order}.mda"
-
-    compare_hdf5(out_file, result_file, ("/kinetic_energy", "/temperature",
-                                        "/avg_kinetic_energy", "/avg_temperature"))
+    compare_hdf5(
+        out_file,
+        result_file,
+        ("/kinetic_energy", "/temperature", "/avg_kinetic_energy", "/avg_temperature"),
+    )

--- a/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_meansquare.py
@@ -23,10 +23,14 @@ short_traj = CONV_DIR / "short_trajectory_after_changes.mdt"
 
 @pytest.mark.parametrize("running_mode", [("single-core",), ("multicore", -4)],
                          ids=lambda x: x[0])
-def test_basic_meansquare(tmp_path, running_mode):
+def test_basic_meansquare(generate_benchmarks, tmp_path, running_mode):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / "basic_meansquare.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "frames": (0, 10, 1, 5),
@@ -38,10 +42,11 @@ def test_basic_meansquare(tmp_path, running_mode):
     msd = IJob.create("MeanSquareDisplacement")
     msd.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
-
-    result_file = RESULTS_DIR / "basic_meansquare.mda"
 
     compare_hdf5(out_file, result_file,
                 [f"/msd_{elem}" for elem in ("Cu", "S", "Sb", "total")])

--- a/MDANSE/Tests/UnitTests/Analysis/test_mock_dynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_mock_dynamics.py
@@ -7,10 +7,14 @@ mock_json = DATA_DIR / "mock.json"
 
 
 @pytest.mark.parametrize("interp_order", [1, 2, 3])
-def test_vacf(tmp_path, interp_order):
+def test_vacf(generate_benchmarks, tmp_path, interp_order):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / f"mock_traj_vacf_{interp_order}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "frames": (0, 10, 1, 5),
@@ -23,12 +27,11 @@ def test_vacf(tmp_path, interp_order):
     vacf = IJob.create("VelocityAutoCorrelationFunction", trajectory_input="mock")
     vacf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
-
-    fname = f"mock_traj_vacf_{interp_order}.mda"
-
-    result_file = RESULTS_DIR / fname
 
     compare_hdf5(out_file, result_file,
                 [f"vacf_{elem}" for elem in ("H", "O", "Si", "total")],

--- a/MDANSE/Tests/UnitTests/Analysis/test_molecule_names.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_molecule_names.py
@@ -47,19 +47,24 @@ def parameters():
         ("AngularCorrelation", ["ac"]),
     ], ids=lambda x: x[0],
 )
-def test_structure_analysis(tmp_path, parameters, job_info):
+def test_structure_analysis(generate_benchmarks, tmp_path, parameters, job_info):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / f"structure_analysis_{job_info[0]}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters["output_files"] = (temp_name, ("MDAFormat",), "INFO")
 
     job = IJob.create(job_info[0])
     job.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
-
-    result_file = RESULTS_DIR / f"structure_analysis_{job_info[0]}.mda"
 
     compare_hdf5(out_file, result_file, job_info[1])

--- a/MDANSE/Tests/UnitTests/Analysis/test_resolutions.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_resolutions.py
@@ -57,11 +57,15 @@ def test_disf(tmp_path, trajectory, resolution_generator):
 
 
 @pytest.mark.parametrize("resolution_generator", IInstrumentResolution.subclasses())
-def test_dos(tmp_path, trajectory, resolution_generator):
+def test_dos(generate_benchmarks, tmp_path, trajectory, resolution_generator):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
     text_file = tmp_path / "output_text.tar"
+    result_file = RESULTS_DIR / f"dos_{resolution_generator}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "atom_selection": None,
@@ -91,11 +95,12 @@ def test_dos(tmp_path, trajectory, resolution_generator):
     disf = IJob.create("DensityOfStates")
     disf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
     assert text_file.is_file()
-
-    result_file = RESULTS_DIR / f"dos_{resolution_generator}.mda"
 
     keys = [f"{fn}_{elem}"
             for fn in ("dos", "vacf")

--- a/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_scattering.py
@@ -1,18 +1,19 @@
-import tempfile
 import os
+import tempfile
 from os import path
 
-import numpy as np
 import h5py
+import numpy as np
 import pytest
+from test_helpers.compare_hdf5 import compare_hdf5
+from test_helpers.paths import CONV_DIR, RESULTS_DIR
 
 from MDANSE.Framework.Jobs.IJob import IJob
-from test_helpers.paths import CONV_DIR, RESULTS_DIR
-from test_helpers.compare_hdf5 import compare_hdf5
 
 short_traj = CONV_DIR / "short_trajectory_after_changes.mdt"
 mdmc_traj = CONV_DIR / "Ar_mdmc_h5md.h5"
 com_traj = CONV_DIR / "com_trajectory.mdt"
+
 
 @pytest.fixture(scope="module")
 def qvector_grid():
@@ -79,11 +80,15 @@ def disf(tmp_path_factory):
     [("short_traj", short_traj), ("mdmc_traj", mdmc_traj), ("com_traj", com_traj)],
     ids=lambda x: x[0],
 )
-def test_dcsf(tmp_path, traj_info, qvector_grid):
+def test_dcsf(generate_benchmarks, tmp_path, traj_info, qvector_grid):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
     text_file = tmp_path / "output_text.tar"
+    result_file = RESULTS_DIR / f"dcsf_{traj_info[0]}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "atom_selection": None,
@@ -100,15 +105,22 @@ def test_dcsf(tmp_path, traj_info, qvector_grid):
     dcsf = IJob.create("DynamicCoherentStructureFactor")
     dcsf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
     assert text_file.is_file()
 
-    result_file = RESULTS_DIR / f"dcsf_{traj_info[0]}.mda"
-
-    compare_hdf5(out_file, result_file, ("f(q,t)", "s(q,f)"),
-                 startswith=True, scale_result=True, scale_benchmark=True,
-                 atol=1e-8)
+    compare_hdf5(
+        out_file,
+        result_file,
+        ("f(q,t)", "s(q,f)"),
+        startswith=True,
+        scale_result=True,
+        scale_benchmark=True,
+        atol=1e-8,
+    )
 
 
 @pytest.mark.parametrize(
@@ -116,11 +128,15 @@ def test_dcsf(tmp_path, traj_info, qvector_grid):
     [("short_traj", short_traj), ("mdmc_traj", mdmc_traj), ("com_traj", com_traj)],
     ids=lambda x: x[0],
 )
-def test_ccf(tmp_path, traj_info, qvector_grid):
+def test_ccf(generate_benchmarks, tmp_path, traj_info, qvector_grid):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
     text_file = tmp_path / "output_text.tar"
+    result_file = RESULTS_DIR / f"ccf_{traj_info[0]}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "atom_selection": None,
@@ -137,15 +153,22 @@ def test_ccf(tmp_path, traj_info, qvector_grid):
     ccf = IJob.create("CurrentCorrelationFunction")
     ccf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
     assert text_file.is_file()
 
-    result_file = RESULTS_DIR / f"ccf_{traj_info[0]}.mda"
-
-    compare_hdf5(out_file, result_file, ("J(q,f)", "j(q,t)"),
-                 startswith=True, scale_result=True, scale_benchmark=True,
-                 atol=1e-6)
+    compare_hdf5(
+        out_file,
+        result_file,
+        ("J(q,f)", "j(q,t)"),
+        startswith=True,
+        scale_result=True,
+        scale_benchmark=True,
+        atol=1e-6,
+    )
 
 
 def test_output_axis_preview(tmp_path, qvector_grid):
@@ -176,11 +199,15 @@ def test_output_axis_preview(tmp_path, qvector_grid):
     [("short_traj", short_traj), ("mdmc_traj", mdmc_traj), ("com_traj", com_traj)],
     ids=lambda x: x[0],
 )
-def test_disf(tmp_path, traj_info, qvector_grid):
+def test_disf(generate_benchmarks, tmp_path, traj_info, qvector_grid):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
     text_file = tmp_path / "output_text.tar"
+    result_file = RESULTS_DIR / f"disf_{traj_info[0]}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "atom_selection": None,
@@ -197,14 +224,21 @@ def test_disf(tmp_path, traj_info, qvector_grid):
     disf = IJob.create("DynamicIncoherentStructureFactor")
     disf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
     assert text_file.is_file()
 
-    result_file = RESULTS_DIR / f"disf_{traj_info[0]}.mda"
-
-    compare_hdf5(out_file, result_file, ("f(q,t)", "s(q,f)"),
-                 startswith=True, scale_result=True, scale_benchmark=True)
+    compare_hdf5(
+        out_file,
+        result_file,
+        ("f(q,t)", "s(q,f)"),
+        startswith=True,
+        scale_result=True,
+        scale_benchmark=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -212,11 +246,15 @@ def test_disf(tmp_path, traj_info, qvector_grid):
     [("short_traj", short_traj), ("mdmc_traj", mdmc_traj), ("com_traj", com_traj)],
     ids=lambda x: x[0],
 )
-def test_eisf(tmp_path, traj_info, qvector_grid):
+def test_eisf(generate_benchmarks, tmp_path, traj_info, qvector_grid):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
     text_file = tmp_path / "output_text.tar"
+    result_file = RESULTS_DIR / f"eisf_{traj_info[0]}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "atom_selection": None,
@@ -232,17 +270,21 @@ def test_eisf(tmp_path, traj_info, qvector_grid):
     eisf = IJob.create("ElasticIncoherentStructureFactor")
     eisf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
     assert text_file.is_file()
 
-    result_file = RESULTS_DIR / f"eisf_{traj_info[0]}.mda"
-    compare_hdf5(out_file,
-                 result_file,
-                 ("eisf",),
-                 startswith=True,
-                 scale_result=True,
-                 scale_benchmark=True)
+    compare_hdf5(
+        out_file,
+        result_file,
+        ("eisf",),
+        startswith=True,
+        scale_result=True,
+        scale_benchmark=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -250,11 +292,15 @@ def test_eisf(tmp_path, traj_info, qvector_grid):
     [("short_traj", short_traj), ("mdmc_traj", mdmc_traj), ("com_traj", com_traj)],
     ids=lambda x: x[0],
 )
-def test_gdisf(tmp_path, traj_info):
+def test_gdisf(generate_benchmarks, tmp_path, traj_info):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
     text_file = tmp_path / "output_text.tar"
+    result_file = RESULTS_DIR / f"gdisf_{traj_info[0]}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "atom_selection": None,
@@ -271,21 +317,25 @@ def test_gdisf(tmp_path, traj_info):
     gdisf = IJob.create("GaussianDynamicIncoherentStructureFactor")
     gdisf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
     assert text_file.is_file()
 
-    result_file = RESULTS_DIR / f"gdisf_{traj_info[0]}.mda"
-
-    compare_hdf5(out_file, result_file, ("f(q,t)", "s(q,f)", "msd"),
-                 startswith=True)
+    compare_hdf5(out_file, result_file, ("f(q,t)", "s(q,f)", "msd"), startswith=True)
 
 
-def test_ndtsf(tmp_path, disf, dcsf, qvector_grid):
+def test_ndtsf(generate_benchmarks, tmp_path, disf, dcsf, qvector_grid):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
     text_file = tmp_path / "output_text.tar"
+    result_file = RESULTS_DIR / "ndtsf.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "atom_selection": None,
@@ -299,21 +349,27 @@ def test_ndtsf(tmp_path, disf, dcsf, qvector_grid):
     ndtsf = IJob.create("NeutronDynamicTotalStructureFactor")
     ndtsf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
     assert text_file.is_file()
 
-    result_file = RESULTS_DIR / "ndtsf.mda"
+    compare_hdf5(
+        out_file, result_file, ("f(q,t)", "s(q,f)"), startswith=True, atol=1e-6
+    )
 
-    compare_hdf5(out_file, result_file, ("f(q,t)", "s(q,f)"),
-                 startswith=True, atol=1e-6)
 
-
-def test_ssfsf(tmp_path, dcsf):
+def test_ssfsf(generate_benchmarks, tmp_path, dcsf):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
     text_file = tmp_path / "output_text.tar"
+    result_file = RESULTS_DIR / "sffsf_short_traj.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "dcsf_input_file": dcsf,
@@ -324,25 +380,30 @@ def test_ssfsf(tmp_path, dcsf):
     ssfsf = IJob.create("StructureFactorFromScatteringFunction")
     ssfsf.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
     assert text_file.is_file()
 
-    result_file = RESULTS_DIR / "sffsf_short_traj.mda"
+    compare_hdf5(out_file, result_file, ("ssf_total"), startswith=True, atol=1e-6)
 
-    compare_hdf5(out_file, result_file, ("ssf_total"), startswith=True,
-                 atol=1e-6)
 
 @pytest.mark.parametrize(
     "traj_info",
     [("short_traj", short_traj), ("mdmc_traj", mdmc_traj), ("com_traj", com_traj)],
     ids=lambda x: x[0],
 )
-def test_sldp(tmp_path, traj_info):
+def test_sldp(generate_benchmarks, tmp_path, traj_info):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
     text_file = tmp_path / "output_text.tar"
+    result_file = RESULTS_DIR / f"sldp_{traj_info[0]}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "atom_selection": None,
@@ -358,11 +419,16 @@ def test_sldp(tmp_path, traj_info):
     sldp = IJob.create("ScatteringLengthDensityProfile")
     sldp.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
     assert text_file.is_file()
 
-    result_file = RESULTS_DIR / f"sldp_{traj_info[0]}.mda"
-
-    compare_hdf5(out_file, result_file, ("sldp", "sldp_incoherent", "sldp_total", "dp_total"),
-                 startswith=True)
+    compare_hdf5(
+        out_file,
+        result_file,
+        ("sldp", "sldp_incoherent", "sldp_total", "dp_total"),
+        startswith=True,
+    )

--- a/MDANSE/Tests/UnitTests/Analysis/test_structure.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_structure.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pytest
-from MDANSE.MolecularDynamics.UnitCell import UnitCell
-from MDANSE.Framework.Jobs.VanHoveFunctionDistinct import van_hove_distinct
-from MDANSE.Framework.Jobs.IJob import IJob
 from test_helpers.compare_hdf5 import compare_hdf5
 from test_helpers.paths import CONV_DIR, RESULTS_DIR
+
+from MDANSE.Framework.Jobs.IJob import IJob
+from MDANSE.Framework.Jobs.VanHoveFunctionDistinct import van_hove_distinct
+from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 short_traj = CONV_DIR / "short_trajectory_after_changes.mdt"
 mdmc_traj = CONV_DIR / "Ar_mdmc_h5md.h5"
@@ -12,6 +13,7 @@ com_traj = CONV_DIR / "com_trajectory.mdt"
 nonorth_traj = CONV_DIR / "nonorthogonal_cell.mdt"
 molecule_traj = CONV_DIR / "named_molecules.mdt"
 cubane_traj = CONV_DIR / "four_molecules.mdt"
+
 
 ################################################################
 # Job parameters                                               #
@@ -43,13 +45,20 @@ def parameters():
     parameters["weights"] = "equal"
     return parameters
 
-@pytest.mark.parametrize("traj_info", [
-    ("short_traj", short_traj),
-    ("mdmc_traj", mdmc_traj),
-    ("com_traj", com_traj),
-    ("mol_traj", molecule_traj),
-], ids=lambda x: x[0])
-@pytest.mark.parametrize("job_info", [
+
+@pytest.mark.parametrize(
+    "traj_info",
+    [
+        ("short_traj", short_traj),
+        ("mdmc_traj", mdmc_traj),
+        ("com_traj", com_traj),
+        ("mol_traj", molecule_traj),
+    ],
+    ids=lambda x: x[0],
+)
+@pytest.mark.parametrize(
+    "job_info",
+    [
         ("SolventAccessibleSurface", ["sas"]),
         ("RootMeanSquareDeviation", ["rmsd"]),
         ("RootMeanSquareFluctuation", ["rmsf"]),
@@ -58,17 +67,22 @@ def parameters():
         ("PairDistributionFunction", ["pdf", "rdf", "tcf"]),
         ("StaticStructureFactor", ["ssf"]),
         ("XRayStaticStructureFactor", ["xssf"]),
-], ids=lambda x: x[0])
+    ],
+    ids=lambda x: x[0],
+)
 @pytest.mark.parametrize("running_mode", [("single-core", 1)], ids=lambda x: x[0])
 @pytest.mark.parametrize("output_format", ["MDAFormat"])
 def test_structure_analysis(
-        tmp_path, parameters, traj_info, job_info, running_mode, output_format
+    generate_benchmarks, tmp_path, parameters, traj_info, job_info, running_mode, output_format
 ):
+    job_type, outputs = job_info
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / f"structure_analysis_{traj_info[0]}_{job_type}.mda"
 
-    job_type, outputs = job_info
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters["trajectory"] = traj_info[1]
     parameters["running_mode"] = running_mode
@@ -77,9 +91,11 @@ def test_structure_analysis(
     job = IJob.create(job_info[0])
     job.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     if output_format == "MDAFormat":
         out_file = temp_name.with_suffix(".mda")
-        result_file = RESULTS_DIR / f"structure_analysis_{traj_info[0]}_{job_type}.mda"
 
         assert out_file.is_file()
 
@@ -91,14 +107,21 @@ def test_structure_analysis(
 
     assert log_file.is_file()
 
-@pytest.mark.parametrize("traj_info", [
-    ("short_traj", short_traj),
-    ("mdmc_traj", mdmc_traj),
-    ("com_traj", com_traj),
-    ("nonorthogonal_cell", nonorth_traj)
-], ids=lambda x: x[0])
+
+@pytest.mark.parametrize(
+    "traj_info",
+    [
+        ("short_traj", short_traj),
+        ("mdmc_traj", mdmc_traj),
+        ("com_traj", com_traj),
+        ("nonorthogonal_cell", nonorth_traj),
+    ],
+    ids=lambda x: x[0],
+)
 def test_pdf_is_zero_at_low_distances(
-        tmp_path, parameters, traj_info,
+    tmp_path,
+    parameters,
+    traj_info,
 ):
     temp_name = tmp_path / "output"
 
@@ -112,45 +135,121 @@ def test_pdf_is_zero_at_low_distances(
     job = IJob.create(job_type)
     job.run(parameters, status=True)
     results = job.results
-    
+
     print(results.keys())
 
     assert "pdf_total" in results
-    x_axis = results['r'][:]
-    y_axis = results['pdf_total'][:]
-    banned_range = y_axis[np.where(x_axis<0.05)]
+    x_axis = results["r"][:]
+    y_axis = results["pdf_total"][:]
+    banned_range = y_axis[np.where(x_axis < 0.05)]
     assert np.allclose(banned_range, 0.0)
 
 
 def test_vhd():
-    temp_cell = UnitCell(2*np.eye(3))
-    coords1 = np.array([[0.1, 0.1, 0.1],
-                        [0.0,0.0,0.0],
-                        [0.2,0.0,0.0],
-                        [0.1,0.2,0.0],
-                        [0.2,0.2,0.2],
-                        [0.0,0.0,0.2]])
+    temp_cell = UnitCell(2 * np.eye(3))
+    coords1 = np.array(
+        [
+            [0.1, 0.1, 0.1],
+            [0.0, 0.0, 0.0],
+            [0.2, 0.0, 0.0],
+            [0.1, 0.2, 0.0],
+            [0.2, 0.2, 0.2],
+            [0.0, 0.0, 0.2],
+        ]
+    )
     coords2 = coords1 + np.array([0.0, 0.5, 0.0])
     frac_coords1 = coords1 @ temp_cell.inverse
     frac_coords2 = coords2 @ temp_cell.inverse
-    intra, total = van_hove_distinct(2*np.eye(3),
-                      np.array([0, 1, 1, -3, 1, -5], dtype=int),
-                      np.array([0,0,0,0,0,0], dtype=int),
-                      np.zeros((1,1,30)),
-                      np.zeros((1,1,30)),
-                      frac_coords1,
-                      frac_coords2,
-                      0.0,
-                      0.05,)
-    expected_intra = np.array([0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,1.0,0.0,2.0,
-                               0.0,0.0,0.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,
-                               0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.])
-    expected_inter = np.array([0.0,0.0,0.0,0.0,0.0,0.0,2.0,2.0,5.0,0.0,4.0,
-                               2.0,5.0,0.0,4.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
-                               0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.])
-    np.testing.assert_almost_equal(intra[0,0,:], expected_intra, decimal=3, err_msg="Failed at intra")
-    np.testing.assert_almost_equal(total[0,0,:]-intra[0,0,:], expected_inter, decimal=3, err_msg="Failed at inter")
-    
+    intra, total = van_hove_distinct(
+        2 * np.eye(3),
+        np.array([0, 1, 1, -3, 1, -5], dtype=int),
+        np.array([0, 0, 0, 0, 0, 0], dtype=int),
+        np.zeros((1, 1, 30)),
+        np.zeros((1, 1, 30)),
+        frac_coords1,
+        frac_coords2,
+        0.0,
+        0.05,
+    )
+    expected_intra = np.array(
+        [
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            0.0,
+            2.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+    )
+    expected_inter = np.array(
+        [
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.0,
+            2.0,
+            5.0,
+            0.0,
+            4.0,
+            2.0,
+            5.0,
+            0.0,
+            4.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+    )
+    np.testing.assert_almost_equal(
+        intra[0, 0, :], expected_intra, decimal=3, err_msg="Failed at intra"
+    )
+    np.testing.assert_almost_equal(
+        total[0, 0, :] - intra[0, 0, :],
+        expected_inter,
+        decimal=3,
+        err_msg="Failed at inter",
+    )
+
+
 def test_intermolecular_part_is_zero_for_single_molecule(tmp_path, parameters):
     temp_name = tmp_path / "output"
 
@@ -158,16 +257,17 @@ def test_intermolecular_part_is_zero_for_single_molecule(tmp_path, parameters):
 
     parameters["trajectory"] = cubane_traj
     parameters["r_values"] = (0.0, 0.5, 0.01)
-    parameters['atom_selection'] = '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_sphere", "frame_number": 0, "sphere_centre": [1.5, 1.5, 1.5], "sphere_radius": 0.5, "operation_type": "intersection"}}'
+    parameters["atom_selection"] = (
+        '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_sphere", "frame_number": 0, "sphere_centre": [1.5, 1.5, 1.5], "sphere_radius": 0.5, "operation_type": "intersection"}}'
+    )
     parameters["output_files"] = (temp_name, ("FileInMemory",), "no logs")
 
     job = IJob.create(job_type)
     job.run(parameters, status=True)
     results = job.results
-    
+
     print(results.keys())
 
     assert "pdf_inter_total" in results
     assert "pdf_intra_total" in results
     np.testing.assert_allclose(results["pdf_inter_total"], 0.0, equal_nan=True)
-

--- a/MDANSE/Tests/UnitTests/Analysis/test_thermodynamics.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_thermodynamics.py
@@ -16,10 +16,14 @@ mdmc_traj = CONV_DIR / "Ar_mdmc_h5md.h5"
     ("com_traj", com_traj),
 ], ids=lambda x: x[0],
 )
-def test_temperature(tmp_path, traj_info, interp_order):
+def test_temperature(generate_benchmarks, tmp_path, traj_info, interp_order):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / f"temperature_{traj_info[0]}_{interp_order}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "frames": (0, 10, 1),
@@ -32,14 +36,14 @@ def test_temperature(tmp_path, traj_info, interp_order):
     temp = IJob.create("Temperature")
     temp.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     assert out_file.is_file()
     assert log_file.is_file()
 
-    result_file = RESULTS_DIR / f"temperature_{traj_info[0]}_{interp_order}.mda"
-
     compare_hdf5(out_file, result_file, ("/kinetic_energy", "/temperature",
                                         "/avg_kinetic_energy", "avg_temperature"))
-
 
 
 @pytest.mark.parametrize("traj_info", [
@@ -49,10 +53,14 @@ def test_temperature(tmp_path, traj_info, interp_order):
 ], ids=lambda x: x[0],
 )
 @pytest.mark.parametrize("output_format", ["MDAFormat", "TextFormat", "FileInMemory"])
-def test_density(tmp_path, traj_info, output_format):
+def test_density(generate_benchmarks, tmp_path, traj_info, output_format):
     temp_name = tmp_path / "output"
     out_file = temp_name.with_suffix(".mda")
     log_file = temp_name.with_suffix(".log")
+    result_file = RESULTS_DIR / f"density_{traj_info[0]}.mda"
+
+    if generate_benchmarks:
+        temp_name = result_file.with_suffix("")
 
     parameters = {
         "frames": (0, 10, 1),
@@ -63,9 +71,11 @@ def test_density(tmp_path, traj_info, output_format):
     den = IJob.create("Density")
     den.run(parameters, status=True)
 
+    if generate_benchmarks:
+        return
+
     if output_format == "MDAFormat":
         out_file = temp_name.with_suffix(".mda")
-        result_file = RESULTS_DIR / f"density_{traj_info[0]}.mda"
 
         assert out_file.is_file()
 

--- a/MDANSE/Tests/UnitTests/Analysis/test_trajectory.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_trajectory.py
@@ -59,38 +59,42 @@ def test_trajectory(tmp_path, parameters, traj_type):
     job = IJob.create(traj_type)
     job.run(parameters, status=True)
 
-    assert out_file.exists()
-    assert log_file.exists()
+    assert out_file.is_file()
+    assert log_file.is_file()
 
-def test_CenterOfMassesTrajectory(parameters):
+def test_CenterOfMassesTrajectory(tmp_path, parameters):
     """This will need to detect molecules before it can
     find the centre of each one of them."""
-    temp_name = tempfile.mktemp()
+    temp_name = tmp_path / "output"
+    out_file = temp_name.with_suffix(".mdt")
+    log_file = temp_name.with_suffix(".log")
+
     parameters["output_files"] = (temp_name, 64, 128, "gzip", "INFO")
     job = IJob.create("CenterOfMassesTrajectory")
     job.run(parameters, status=True)
-    assert path.exists(temp_name + ".mdt")
-    assert path.isfile(temp_name + ".mdt")
-    os.remove(temp_name + ".mdt")
-    assert path.exists(temp_name + ".log")
-    assert path.isfile(temp_name + ".log")
-    os.remove(temp_name + ".log")
+
+    assert out_file.is_file()
+    assert log_file.is_file()
 
 
-def test_UnfoldedTrajectory(parameters):
-    temp_name = tempfile.mktemp()
+def test_UnfoldedTrajectory(tmp_path, parameters):
+    temp_name = tmp_path / "output"
+    out_file = temp_name.with_suffix(".mdt")
+    log_file = temp_name.with_suffix(".log")
+
     parameters["output_files"] = (temp_name, 64, 128, "gzip", "INFO")
     job = IJob.create("UnfoldedTrajectory")
     job.run(parameters, status=True)
-    assert path.exists(temp_name + ".mdt")
-    assert path.isfile(temp_name + ".mdt")
-    os.remove(temp_name + ".mdt")
-    assert path.exists(temp_name + ".log")
-    assert path.isfile(temp_name + ".log")
-    os.remove(temp_name + ".log")
+
+    assert out_file.is_file()
+    assert log_file.is_file()
 
 
 def test_SelectedTrajectoryFilter(tmp_path):
+    temp_name = tmp_path / "filtered_trajectory"
+    out_file = temp_name.with_suffix(".mdt")
+    log_file = temp_name.with_suffix(".log")
+
     parameters = {
         "atom_selection": '{"0": {"function_name": "select_atoms", "index_range": [0, 10], "operation_type": "union"}}',
         "frames": [0, 10, 1, 5],
@@ -101,18 +105,19 @@ def test_SelectedTrajectoryFilter(tmp_path):
         "weights": "atomic_weight",
     }
     parameters["trajectory"] = short_traj
-    temp_name = str(tmp_path / "filtered_trajectory")
     parameters["output_files"] = (temp_name, 64, 128, "gzip", "INFO")
+
     job = IJob.create("TrajectoryFilter")
     job.run(parameters, status=True)
-    assert path.exists(temp_name + ".mdt")
-    assert path.isfile(temp_name + ".mdt")
-    os.remove(temp_name + ".mdt")
-    assert path.exists(temp_name + ".log")
-    assert path.isfile(temp_name + ".log")
-    os.remove(temp_name + ".log")
+
+    assert out_file.is_file()
+    assert log_file.is_file()
 
 def test_TrajectoryFilter(tmp_path):
+    temp_name = tmp_path / "filtered_trajectory"
+    out_file = temp_name.with_suffix(".mdt")
+    log_file = temp_name.with_suffix(".log")
+
     parameters = {
         "frames": [0, 10, 1, 5],
         "instrument_resolution": ("ideal", {}),
@@ -122,13 +127,10 @@ def test_TrajectoryFilter(tmp_path):
         "weights": "atomic_weight",
     }
     parameters["trajectory"] = short_traj
-    temp_name = str(tmp_path / "filtered_trajectory")
     parameters["output_files"] = (temp_name, 64, 128, "gzip", "INFO")
+
     job = IJob.create("TrajectoryFilter")
     job.run(parameters, status=True)
-    assert path.exists(temp_name + ".mdt")
-    assert path.isfile(temp_name + ".mdt")
-    os.remove(temp_name + ".mdt")
-    assert path.exists(temp_name + ".log")
-    assert path.isfile(temp_name + ".log")
-    os.remove(temp_name + ".log")
+
+    assert out_file.is_file()
+    assert log_file.is_file()

--- a/MDANSE/Tests/conftest.py
+++ b/MDANSE/Tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "-G",
+        "--generate",
+        action="store_true",
+        help="Generate testing data.",
+    )
+
+@pytest.fixture(scope="session")
+def generate_benchmarks(request):
+    """Whether generating benchmarks."""
+    return request.config.getoption("--generate", False)


### PR DESCRIPTION
**Description of work**
Add feature to enable `-G` flag to regenerate tests with static files.

Run `ruff format` in some of the test files.

Currently, it generates in-place overwriting existing test file. Could generate instead with the original temporary name and copy only the needed file to the result file.

**Fixes**
Relieves frustration at manually copying test data back?

**To test**
1. Change a test
2. Run `pytest -G <test you changed>` and see there are newly generated `.mda` files.
