### PR TITLE
Correct AtomSelectionWidget

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
@@ -119,12 +119,13 @@ class IConfigurator(dict, metaclass=SubclassFactory):
         self.name = name
 
         self._printable_attributes = [
-            "_name",
+            "name",
             "_original_input",
-            "_configured",
-            "_valid",
-            "_default",
+            "configured",
+            "valid",
+            "default",
             "_error_status",
+            "_warning_status",
         ]
 
         self.configurable = kwargs.get("configurable")

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
@@ -292,7 +292,7 @@ class IConfigurator(dict, metaclass=SubclassFactory):
         if configured is None:
             configured = [
                 str(name)
-                for name, prop in self.configurable._configuration.values()
+                for name, prop in self.configurable._configuration.items()
                 if prop.is_configured()
             ]
         return all(c in configured for c in self.dependencies.values())

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -526,8 +526,8 @@ class AtomSelectionWidget(WidgetBase):
             default_text = str(self._configurator.default)
             self._field.setPlaceholderText(default_text)
             self._field.setText(default_text)
-        traj_config = self._configurator._configurable[
-            self._configurator._dependencies["trajectory"]
+        traj_config = self._configurator.configurable[
+            self._configurator.dependencies["trajectory"]
         ]
         traj_filename = traj_config["filename"]
         trajectory = traj_config["instance"]


### PR DESCRIPTION
**Description of work**
Changes merged today are causing an error in AtomSelectionWidget. This PR should correct it.

**Fixes**
1. Removed the underscores from configurator attribute names in AtomSelectionWidget.
2. Updated the list of printable configurator attributes.

**To test**
Load a trajectory in the GUI. All the job widgets should be created correctly.
