### PR TITLE
Plot all files

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
@@ -58,8 +58,21 @@ class BasicPlotDataItem(QStandardItem):
             return f"{self.data_parent.child_path}/{self.text()}"
 
     def recursive_children(self, recursion_limit: int = 1) -> list[BasicPlotDataItem]:
-        """Return a list composed of this node and all its children."""
+        """Return a list composed of this node and all its children.
+
+        Parameters
+        ----------
+        recursion_limit : int, optional
+            Number of levels of nesting to search, unlimited on negative values, by default 1
+
+        Returns
+        -------
+        list[BasicPlotDataItem]
+            list of this node and all the children nodes within the recursion (depth) limit
+        """
         result = [self]
+        if recursion_limit == 0:
+            return result
         for child_row in range(self.rowCount()):
             child = self.child(child_row, 0)
             if recursion_limit and child:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
@@ -57,13 +57,13 @@ class BasicPlotDataItem(QStandardItem):
         else:
             return f"{self.data_parent.child_path}/{self.text()}"
 
-    def recursive_children(self) -> list[BasicPlotDataItem]:
+    def recursive_children(self, recursion_limit: int = 1) -> list[BasicPlotDataItem]:
         """Return a list composed of this node and all its children."""
         result = [self]
         for child_row in range(self.rowCount()):
             child = self.child(child_row, 0)
-            if child:
-                result += child.recursive_children()
+            if recursion_limit and child:
+                result += child.recursive_children(recursion_limit - 1)
         return result
 
     def populate(self, data: h5py.File | h5py.Group):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -59,9 +59,15 @@ class PlotDataView(QTreeView):
         model = self.model()
         inner_node = model.inner_object(index)
         if isinstance(inner_node, MDADataStructure):
-            self.quick_plot_file(inner_node)
+            data_nodes = model.itemFromIndex(index).recursive_children(
+                recursion_limit=10
+            )
+            file_node = model.parent_object(index)
+            self.quick_plot_data(data_nodes, file_node, main_only=True)
         else:
-            data_nodes = model.itemFromIndex(index).recursive_children()
+            data_nodes = model.itemFromIndex(index).recursive_children(
+                recursion_limit=1
+            )
             file_node = model.parent_object(index)
             self.quick_plot_data(data_nodes, file_node)
 
@@ -136,35 +142,12 @@ class PlotDataView(QTreeView):
             except Exception:
                 self.item_details.emit("No additional information included.")
 
-    def quick_plot_file(self, mda_data_structure: MDADataStructure):
-        """Automatically select, format and plot datasets from one file.
-
-        Parameters
-        ----------
-        mda_data_structure : MDADataStructure
-            Object containing and MDA data file.
-
-        """
-        model = PlottingContext()
-        for key in mda_data_structure._file:
-            try:
-                if "main" in mda_data_structure._file[key].attrs["tags"]:
-                    if "partial" in mda_data_structure._file[key].attrs["tags"]:
-                        dataset = SingleDataset(
-                            key, mda_data_structure._file, linestyle="--"
-                        )
-                    else:
-                        dataset = SingleDataset(key, mda_data_structure._file)
-
-                    model.add_dataset(dataset)
-            except KeyError:
-                LOG.error(f"No attribute called Tag found in {key}, skipping")
-        self.fast_plotting_data.emit(model)
-
     def quick_plot_data(
         self,
         data_nodes: list[BasicPlotDataItem],
         mda_data_structure: MDADataStructure,
+        *,
+        main_only: bool = False,
     ):
         """Plot several datasets in a new plot instance.
 
@@ -174,12 +157,28 @@ class PlotDataView(QTreeView):
             Data model items collected for plotting.
         mda_data_structure : MDADataStructure
             The common HDF5 file from which the datasets originate.
+        main_only: bool
+            if True, only plot datasets with the 'main' tag
 
         """
         model = PlottingContext()
         file = mda_data_structure._file
         for data_node in data_nodes:
-            dataset = SingleDataset(data_node.child_path, file)
+            if not data_node.child_path:
+                continue
+            if main_only:
+                try:
+                    tags = file[data_node.child_path].attrs["tags"]
+                except KeyError:
+                    continue
+                if "main" not in tags:
+                    continue
+                if "partial" in tags:
+                    dataset = SingleDataset(data_node.child_path, file, linestyle="--")
+                else:
+                    dataset = SingleDataset(data_node.child_path, file)
+            else:
+                dataset = SingleDataset(data_node.child_path, file)
             model.add_dataset(dataset)
         self.fast_plotting_data.emit(model)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -173,10 +173,11 @@ class PlotDataView(QTreeView):
                     continue
                 if "main" not in tags:
                     continue
-                if "partial" in tags:
-                    dataset = SingleDataset(data_node.child_path, file, linestyle="--")
-                else:
-                    dataset = SingleDataset(data_node.child_path, file)
+                dataset = SingleDataset(
+                    data_node.child_path,
+                    file,
+                    linestyle="--" if "partial" in tags else "-",
+                )
             else:
                 dataset = SingleDataset(data_node.child_path, file)
             model.add_dataset(dataset)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -60,7 +60,7 @@ class PlotDataView(QTreeView):
         inner_node = model.inner_object(index)
         if isinstance(inner_node, MDADataStructure):
             data_nodes = model.itemFromIndex(index).recursive_children(
-                recursion_limit=10
+                recursion_limit=-1
             )
             file_node = model.parent_object(index)
             self.quick_plot_data(data_nodes, file_node, main_only=True)


### PR DESCRIPTION
**Description of work**
In connection with PR #854, changes to the MDANSE_GUI plotter are proposed here that would make it possible to apply quick plotting to both the old (flat) and new (nested) MDA files.

**Fixes**
1. Add optional limit to the recursion depth when searching the data file.
2. Modify the `quick_plot_data` function to optionally filter out the datasets without the main tag.

**To test**
The expected behaviour for both old (protos branch) and new (PR #854) MDA files is:
1. When the file name is double-clicked, only the "main" datasets are plotted.
2. When a dataset is double-clicked, this dataset is plotted.
Additionally, for the new files:
3. If a group is double-clicked, only its direct children are plotted.

