### PR TITLE
Make COM trajectory use real cluster composition

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -84,11 +84,17 @@ class CenterOfMassesTrajectory(IJob):
         self.numberOfSteps = self.configuration["frames"]["number"]
         chemical_system = self.configuration["trajectory"]["instance"].chemical_system
 
+        self.cluster_composition = {}
+        original_atom_list = chemical_system.atom_list
         new_element_list = []
         used_up_atoms = set()
         new_chemical_system = ChemicalSystem()
         for cluster_name in chemical_system._clusters.keys():
             for cluster in chemical_system._clusters[cluster_name]:
+                if cluster_name not in self.cluster_composition:
+                    self.cluster_composition[cluster_name] = [
+                        original_atom_list[ind] for ind in cluster
+                    ]
                 new_element_list.append(cluster_name)
                 used_up_atoms.update(set(cluster))
         for index in chemical_system._atom_indices:
@@ -201,6 +207,7 @@ class CenterOfMassesTrajectory(IJob):
         self._output_trajectory.write_atom_database(
             self._unique_atoms,
             self.configuration["trajectory"]["instance"],
+            self.cluster_composition,
             time_averaged_radii,
         )
         # The input trajectory is closed.

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from MDANSE.Chemistry.Databases import AtomsDatabase
 
+from collections import Counter
 import copy
 import math
 from pathlib import Path
@@ -643,7 +644,8 @@ class TrajectoryWriter:
         self,
         symbols: list[str],
         database: "AtomsDatabase",
-        optional_molecule_radii: dict[str, float] = None,
+        composition_lookup: dict[str, list[str]],
+        optional_molecule_radii: dict[str, float] | None = None,
     ):
         """Write atom properties into the trajectory file.
         
@@ -665,22 +667,7 @@ class TrajectoryWriter:
             if database.has_atom(atom_symbol):
                 property_dict = database.get_property_dict(atom_symbol)
             else:
-                atom_dict = {}
-                molecule_radius = 0.0
-                for token in atom_symbol.split("_"):
-                    symbol = ""
-                    number = ""
-                    noletters = True
-                    for char in token:
-                        if char.isnumeric():
-                            if noletters:
-                                symbol += char
-                            else:
-                                number += char
-                        else:
-                            symbol += char
-                            noletters = False
-                    atom_dict[symbol] = int(number)
+                atom_dict = Counter(composition_lookup[atom_symbol])
                 if optional_molecule_radii is not None:
                     molecule_radius = optional_molecule_radii.get(atom_symbol, 0.0)
                 property_dict = create_average_atom(


### PR DESCRIPTION
**Description of work**
To determine the atomic composition of a cluster/molecule, we look up the atom types of all the component atoms in the original trajectory's ChemicalSystem. The old mechanism was trying to read it by parsing the cluster label.

closes #861

**Fixes**
1. Create a `self.composition_lookup` dictionary in CentreOfMassesTrajectory.
2. Use the composition dictionary in `TrajectoryWriter.write_atom_database`.

**To test**
Take a trajectory containing molecules.
Use TrajectoryEditor to replace one of the elements in the molecules with an isotope.
Run CentreOfMassesTrajectory on the trajectory with the isotope. It should work correctly (and fail on the main branch).

