### PR TITLE
Remove initial underscore from forbidden_files in configurators

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputFilesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputFilesConfigurator.py
@@ -69,7 +69,7 @@ class OutputFilesConfigurator(IConfigurator):
         self.formats = (
             formats if formats is not None else OutputFilesConfigurator._default[1]
         )
-        self._forbidden_files = []
+        self.forbidden_files = []
 
     def configure(self, value):
         """Configure a set of output files for an analysis.
@@ -117,7 +117,7 @@ class OutputFilesConfigurator(IConfigurator):
             for ext in (IFormat.create(f).extension for f in formats)
         ]
         for file in self["files"]:
-            if file.absolute() in self._forbidden_files:
+            if file.absolute() in self.forbidden_files:
                 self.error_status = f"File {file} is either open or being written into. Please pick another name."
                 return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputStructureConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputStructureConfigurator.py
@@ -50,7 +50,7 @@ class OutputStructureConfigurator(IConfigurator):
         IConfigurator.__init__(self, name, **kwargs)
 
         self.formats = [fmt for fmt in ioformats if ioformats[fmt].can_write]
-        self._forbidden_files = []
+        self.forbidden_files = []
 
     def configure(self, value):
         """
@@ -84,7 +84,7 @@ class OutputStructureConfigurator(IConfigurator):
         self["root"] = root
         self["format"] = format
         self["file"] = root
-        if self["file"].absolute() in self._forbidden_files:
+        if self["file"].absolute() in self.forbidden_files:
             self.error_status = f"File {self['file']} is either open or being written into. Please pick another name."
             return
         self["log_level"] = logs

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
@@ -54,7 +54,7 @@ class OutputTrajectoryConfigurator(IConfigurator):
         self.format = "MDTFormat"
         self._dtype = np.float64
         self._compression = "none"
-        self._forbidden_files = []
+        self.forbidden_files = []
         self._chunk_limit = 128
 
     def configure(self, value: tuple):
@@ -97,7 +97,7 @@ class OutputTrajectoryConfigurator(IConfigurator):
             temp_name = root.with_suffix(root.suffix + self["extension"])
         self["file"] = temp_name
 
-        if self["file"].absolute() in self._forbidden_files:
+        if self["file"].absolute() in self.forbidden_files:
             self.error_status = f"File {self['file']} is either open or being written into. Please pick another name."
             return
 


### PR DESCRIPTION
**Description of work**
A mismatch in the naming of `forbidden_files` in MDANSE configurators and MDANSE_GUI widgets caused the open file overwrite protection to stop working.

**Fixes**
1. Consistently use `forbidden_files` in configurators, since this attribute is accessed directly by the widgets.

**To test**
Run any analysis. It should be impossible to run the same analysis again with the same output file name, except if the first analysis finished and the output file has been removed from the GUI.
