### PR TITLE
Skip key splitting for dummy index axes

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -161,7 +161,9 @@ class SingleDataset:
 
     @staticmethod
     def axis_true_name(axis_key: str) -> str:
-        return axis_key.rsplit("/", 1)[1].strip()
+        if "/" in axis_key:
+            return axis_key.rsplit("/", 1)[1].strip()
+        return axis_key
 
     def x_axis_label(self, axis_key: str) -> str:
         """Get the axis label to be used as matplotlib label.


### PR DESCRIPTION
**Description of work**
This should prevent an error from occurring if a dataset has no matching x axis in the file, and is plotted against "index".

**Fixes**
1. In `axis_true_name`, don't split the axis key if no `/` is present in the key.

**To test**
In an MDA file, it should be possible to plot any datasets, even those without their own x axis (plotted against index).
