### PR TITLE
Updated to GUI so that the 3D viewer side panel can be hidden.

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -31,6 +31,7 @@ from qtpy.QtWidgets import (
     QTreeView,
     QVBoxLayout,
     QWidget,
+    QSplitter
 )
 
 from MDANSE_GUI.MolecularViewer.MolecularViewer import MolecularViewer
@@ -94,6 +95,8 @@ class ViewerControls(QWidget):
     def __init__(self, *args, **kwargs):
         super(QWidget, self).__init__(*args, **kwargs)
         _ = QGridLayout(self)
+        self._splitter = QSplitter()
+        self.layout().addWidget(self._splitter, 0, 0, 1, 1)  # row, column, rowSpan, columnSpan
         self._viewer = None
         self._buttons = {}
         self._delegates = {}
@@ -106,7 +109,6 @@ class ViewerControls(QWidget):
         self._visibility = [True, True, True, True]
         self.createSlider()
         self.createButtons(Qt.Orientation.Horizontal)
-        self.createSidePanel()
         self._bkg_dialog = QColorDialog()
         self._projection = True
 
@@ -130,20 +132,17 @@ class ViewerControls(QWidget):
         frame_selector.valueChanged.connect(frame_slider.setValue)
         frame_slider.valueChanged.connect(frame_selector.setValue)
         self._frame_selector = frame_selector
-        self.layout().addWidget(base, 2, 0, 1, 3)  # row, column, rowSpan, columnSpan
+        self.layout().addWidget(base, 1, 0, 1, 1)  # row, column, rowSpan, columnSpan
 
     def setViewer(self, viewer: MolecularViewer):
         self._viewer = viewer
-        self.layout().addWidget(viewer, 0, 0, 2, 2)  # row, column, rowSpan, columnSpan
+        self._splitter.addWidget(viewer)
         self._frame_slider.valueChanged.connect(viewer.set_coordinates)
         viewer.new_max_frames.connect(self._frame_slider.setMaximum)
         viewer.new_max_frames.connect(self._frame_selector.setMaximum)
         viewer.new_max_frames.connect(self.stop_animation)
         # self._database.setViewer(viewer)
         # viewer.setDataModel(viewer._colour_manager)
-        self._atom_details.setModel(viewer._colour_manager)
-        for column_number in range(3):
-            self._atom_details.resizeColumnToContents(column_number)
         viewer._colour_manager.new_atom_properties.connect(viewer.take_atom_properties)
 
     def createButtons(self, orientation: Qt.Orientation):
@@ -155,12 +154,12 @@ class ViewerControls(QWidget):
         if orientation == Qt.Orientation.Horizontal:
             layout = QHBoxLayout(base)
             self.layout().addWidget(
-                base, 3, 0, 1, 3
+                base, 2, 0, 1, 1
             )  # row, column, rowSpan, columnSpan
         elif orientation == Qt.Orientation.Vertical:
             layout = QVBoxLayout(base)
             self.layout().addWidget(
-                base, 0, 2, 2, 1
+                base, 0, 1, 2, 1
             )  # row, column, rowSpan, columnSpan
         for button_name, button_role in button_lookup.items():
             temp = QPushButton(base)
@@ -266,9 +265,10 @@ class ViewerControls(QWidget):
             layout5.addWidget(box)
         layout.addWidget(wrapper5)
         # the database of atom types
-        self.layout().addWidget(
-            absolute_base, 0, 2, 2, 1
-        )  # row, column, rowSpan, columnSpan
+        self._atom_details.setModel(self._viewer._colour_manager)
+        for column_number in range(3):
+            self._atom_details.resizeColumnToContents(column_number)
+        self._splitter.addWidget(absolute_base)
 
     def createTracePanel(self, viewer):
         """Adds widgets for finer control of the playback"""

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -31,7 +31,7 @@ from qtpy.QtWidgets import (
     QTreeView,
     QVBoxLayout,
     QWidget,
-    QSplitter
+    QSplitter,
 )
 
 from MDANSE_GUI.MolecularViewer.MolecularViewer import MolecularViewer
@@ -96,7 +96,9 @@ class ViewerControls(QWidget):
         super(QWidget, self).__init__(*args, **kwargs)
         _ = QGridLayout(self)
         self._splitter = QSplitter()
-        self.layout().addWidget(self._splitter, 0, 0, 1, 1)  # row, column, rowSpan, columnSpan
+        self.layout().addWidget(
+            self._splitter, 0, 0, 1, 1
+        )  # row, column, rowSpan, columnSpan
         self._viewer = None
         self._buttons = {}
         self._delegates = {}

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -26,12 +26,12 @@ from qtpy.QtWidgets import (
     QSizePolicy,
     QSlider,
     QSpinBox,
+    QSplitter,
     QStyle,
     QTabWidget,
     QTreeView,
     QVBoxLayout,
     QWidget,
-    QSplitter,
 )
 
 from MDANSE_GUI.MolecularViewer.MolecularViewer import MolecularViewer

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/View3D.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/View3D.py
@@ -32,6 +32,7 @@ class View3D(QWidget):
         controls = ViewerControls(self)
         viewer.setParent(controls)
         controls.setViewer(viewer)
+        controls.createSidePanel()
         viewer.create_trace_dialog(controls)
         if hasattr(viewer, "clicked_atom_index"):
             viewer.clicked_atom_index.connect(controls._trace_widget.accept_atom_index)


### PR DESCRIPTION
**Description of work**
Updated to GUI so that the 3D viewer side panel can be hidden. This should be helpful in the atom selection and related helper dialogs where a larger 3D view might be needed. 

![Peek 2025-07-15 15-24](https://github.com/user-attachments/assets/6c7c597a-e20f-44a5-b069-e99b18da7903)
![Peek 2025-07-15 15-25](https://github.com/user-attachments/assets/3b9cb52e-de3a-40c1-ac2c-fd4b5a4328a6)


**To test**
Check that 3D view and viewer side panel continue to work in the trajectory tab and the selection and related helpers.
