### PR TITLE
Improve input of partial charges

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/PartialChargeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/PartialChargeConfigurator.py
@@ -113,7 +113,7 @@ class PartialChargeMapper:
         for charge in unique_charges:
             charge_indices = set(np.where(np.isclose(new_charges, charge))[0])
             key = charge_indices.intersection(valid_indices[0])
-            groups[charge] = list(key)
+            groups[charge] = [int(x) for x in key]
         return groups
 
     def get_json_setting(self) -> str:
@@ -169,6 +169,7 @@ class PartialChargeConfigurator(IConfigurator):
                 else:
                     for index in v:
                         processed_values[index] = charge
+                continue
             try:
                 index = int(k)
                 charge = float(v)
@@ -185,16 +186,17 @@ class PartialChargeConfigurator(IConfigurator):
         traj_indices = system._atom_indices
         charge_indices = set(processed_values.keys())
 
+        for index in charge_indices.intersection(traj_indices):
+            self["charges"][index] = processed_values[index]
+
         if not charge_indices.issubset(traj_indices):
             self.warning_status = (
                 "At least one atom index not found in the current system."
             )
             return
 
-        for index in charge_indices.intersection(traj_indices):
-            self["charges"][index] = processed_values[index]
-
         self.error_status = "OK"
+        self.warning_status = ""
 
     def get_charge_mapper(self) -> PartialChargeMapper:
         """

--- a/MDANSE/Src/MDANSE/Framework/Configurators/PartialChargeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/PartialChargeConfigurator.py
@@ -16,6 +16,8 @@
 import json
 from typing import Union
 
+import numpy as np
+
 from MDANSE.Framework.AtomSelector.selector import ReusableSelection
 from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
 from MDANSE.MolecularDynamics.Trajectory import Trajectory
@@ -34,12 +36,12 @@ class PartialChargeMapper:
             The chemical system object.
         """
         system = trajectory.chemical_system
-        charges = trajectory.charges(0)
+        self._traj_charges = trajectory.charges(0)[:]
         self._current_trajectory = trajectory
         self._original_map = {}
         for at_num, at in enumerate(system.atom_list):
             try:
-                self._original_map[at_num] = charges[at_num]
+                self._original_map[at_num] = self._traj_charges[at_num]
             except Exception:
                 self._original_map[at_num] = 0.0
         self._new_map = {}
@@ -92,6 +94,28 @@ class PartialChargeMapper:
                 minimal_map[k] = self._new_map[k]
         return minimal_map
 
+    def get_grouped_setting(self) -> dict[tuple[int], float]:
+        """Return a dict of groups of indices with the same charge.
+
+        Returns
+        -------
+        dict[tuple[int], float]
+            The minimal partial charge setting.
+        """
+        groups = {}
+        new_charges = self._traj_charges.copy()
+        for k, v in self._new_map.items():
+            new_charges[k] = v
+        valid_indices = np.where(
+            np.logical_not(np.isclose(new_charges - self._traj_charges, 0.0))
+        )
+        unique_charges = np.unique(new_charges[valid_indices])
+        for charge in unique_charges:
+            charge_indices = set(np.where(np.isclose(new_charges, charge))[0])
+            key = charge_indices.intersection(valid_indices[0])
+            groups[charge] = list(key)
+        return groups
+
     def get_json_setting(self) -> str:
         """
         Returns
@@ -99,7 +123,7 @@ class PartialChargeMapper:
         str
             A json string of the minimal partial charge setting.
         """
-        return json.dumps(self.get_setting())
+        return json.dumps(self.get_grouped_setting())
 
     def reset_setting(self) -> None:
         """Resets the partial charge setting."""
@@ -134,26 +158,41 @@ class PartialChargeConfigurator(IConfigurator):
             self.error_status = "Unable to load JSON string."
             return
 
-        for k in value.keys():
+        processed_values = {}
+        for k, v in value.items():
+            if isinstance(v, list):
+                try:
+                    charge = float(k)
+                except (TypeError, ValueError):
+                    self.error_status = f"Wrong charge {k} in the charge dictionary"
+                    return
+                else:
+                    for index in v:
+                        processed_values[index] = charge
             try:
-                int(k)
-            except ValueError:
+                index = int(k)
+                charge = float(v)
+            except (TypeError, ValueError):
                 self.error_status = (
-                    "Setting not valid - keys should be castable to an int."
+                    f"Index/charge pair {k}/{v} is not a valid int/float pair."
                 )
                 return
+            else:
+                processed_values[index] = charge
 
         traj_config = self.configurable[self.dependencies["trajectory"]]
         system = traj_config["instance"].chemical_system
-        idxs = system._atom_indices
+        traj_indices = system._atom_indices
+        charge_indices = set(processed_values.keys())
 
-        if any([int(i) not in idxs for i in value.keys()]):
-            self.error_status = "Inputted setting not valid - atom index not found in the current system."
+        if not charge_indices.issubset(traj_indices):
+            self.warning_status = (
+                "At least one atom index not found in the current system."
+            )
             return
 
-        for idx in idxs:
-            if str(idx) in value:
-                self["charges"][idx] = value[str(idx)]
+        for index in charge_indices.intersection(traj_indices):
+            self["charges"][index] = processed_values[index]
 
         self.error_status = "OK"
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -548,6 +548,7 @@ class AtomSelectionWidget(WidgetBase):
             default_text = str(self._configurator.default)
             self._field.setPlaceholderText(default_text)
             self._field.setText(default_text)
+            self._field.setMaxLength(2147483647)
         traj_config = self._configurator.configurable[
             self._configurator.dependencies["trajectory"]
         ]


### PR DESCRIPTION
**Description of work**
In order to deal with #877, changes have been made to the partial charge input.

This PR does not completely remove the limitations on the number of atoms in a trajectory. However, it makes it possible to use larger trajectories than before.

**Fixes**
1. Changed the input length limit of the partial charge QLineEdit to 2147483647.
2. Enabled new format of partial charges, where dictionary keys are charges, and dictionary values are lists of atom indices:
`{"charge1": [ind1, ind2, ...], "charge2": [indx, indx+1, ...]}`

**To test**
Unit tests must pass.
Try setting charges for a trajectory containing molecules. Check that running from GUI and saving to script both work.

