### PR TITLE
Add the missing character in IJob.save

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -250,7 +250,7 @@ parameters = {{
 ########################################################
 
 if __name__ == "__main__":
-    {cls.__name__.lower()} = IJob.create({cls.__name__!r}
+    {cls.__name__.lower()} = IJob.create({cls.__name__!r})
     {cls.__name__.lower()}.run(parameters, status=True)
 """)
 


### PR DESCRIPTION
**Description of work**
Corrects the typo causing scripts to fail.

closes #880 

**Fixes**
1. Close the bracket in the `IJob.create(...` part of the script template.

**To test**
Save a script from the GUI and run it. It should run the same as when started from the GUI.
