### PR TITLE
Adjust 3D view side panel size policy

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -179,9 +179,7 @@ class ViewerControls(QWidget):
     def createSidePanel(self):
         """Adds widgets for finer control of the playback"""
         absolute_base = QTabWidget(self)
-        absolute_base.setSizePolicy(
-            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum
-        )
+        absolute_base.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
         self._side_base = absolute_base
         base = QWidget(self)
         layout = QVBoxLayout(base)


### PR DESCRIPTION
**Description of work**
Adjusted 3D view side panel size policy. This should ensure that the 3D view expands to fill the GUI.

<img width="1594" height="1061" alt="image" src="https://github.com/user-attachments/assets/417850d9-a22a-4283-bbae-084dcbc329a9" />

**To test**
Check 3D view and controls.
