### PR TITLE
Add new axes options to 3d viewer

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -18,10 +18,12 @@ from qtpy.QtCore import QMutex, Qt, QTimer, Slot
 from qtpy.QtWidgets import (
     QCheckBox,
     QColorDialog,
+    QComboBox,
     QDoubleSpinBox,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
+    QLabel,
     QPushButton,
     QSizePolicy,
     QSlider,
@@ -247,22 +249,33 @@ class ViewerControls(QWidget):
         wrapper4.setLayout(layout4)
         layout.addWidget(wrapper4)
         wrapper5 = QGroupBox("Visible Objects", base)
-        layout5 = QHBoxLayout(wrapper5)
-        atoms_visible = QCheckBox("atoms", wrapper5)
-        bonds_visible = QCheckBox("bonds", wrapper5)
-        axes_visible = QCheckBox("axes", wrapper5)
-        cell_visible = QCheckBox("cell", wrapper5)
+        layout5 = QGridLayout(wrapper5)
+        atoms_visible = QCheckBox("atoms:")
+        atoms_visible.setLayoutDirection(Qt.RightToLeft)
+        bonds_visible = QCheckBox("bonds:")
+        bonds_visible.setLayoutDirection(Qt.RightToLeft)
+        cell_visible = QCheckBox("cell:")
+        cell_visible.setLayoutDirection(Qt.RightToLeft)
+        self.axes_combo = QComboBox()
+        self.axes_combo.addItems(["none", "cartesian", "direct", "reciprocal"])
+        self.axes_combo.setCurrentIndex(1)
+        layout5.addWidget(atoms_visible, 0, 0, 1, 1)
+        layout5.addWidget(bonds_visible, 0, 1, 1, 1)
+        layout5.addWidget(cell_visible, 0, 2, 1, 1)
+        label = QLabel("axes:")
+        label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        layout5.addWidget(label, 1, 0, 1, 1)
+        layout5.addWidget(self.axes_combo, 1, 1, 1, 2)
         self._visibility_checkboxes = [
             atoms_visible,
             bonds_visible,
-            axes_visible,
             cell_visible,
         ]
         for nw, box in enumerate(self._visibility_checkboxes):
             box.setTristate(False)
             box.setChecked(self._visibility[nw])
             box.stateChanged.connect(self.setVisibility)
-            layout5.addWidget(box)
+        self.axes_combo.currentIndexChanged.connect(self.changeAxes)
         layout.addWidget(wrapper5)
         # the database of atom types
         self._atom_details.setModel(self._viewer._colour_manager)
@@ -314,6 +327,10 @@ class ViewerControls(QWidget):
         for nw, box in enumerate(self._visibility_checkboxes):
             self._visibility[nw] = box.isChecked()
         self._viewer._new_visibility(self._visibility)
+
+    @Slot()
+    def changeAxes(self):
+        self._viewer._change_axes(self.axes_combo.currentText())
 
     @Slot(int)
     def setTimeStep(self, new_value: int):

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -120,7 +120,9 @@ class MolecularViewer(QtWidgets.QWidget):
 
         self._iren.GetRenderWindow()
 
-        self.arrow_actors, self.arrow_widgets = self.create_arrow_widgets()
+        self.axes_assembly, self.label_actor, self.axes_widgets = (
+            self.create_arrow_widgets()
+        )
 
         self.atom_actor = None
         self._last_coords = None
@@ -172,9 +174,10 @@ class MolecularViewer(QtWidgets.QWidget):
         apply a non-orthogonal transform to it but this causes the
         arrows to become distorted.
         """
-        axes_arrows = []
         axes_widgets = []
+
         labels = ["X", "Y", "Z"]
+        assembly = vtk.vtkAssembly()
         for axes in labels:
             axes_actor = vtkAxesActor()
             axes_actor.AxisLabelsOn()
@@ -184,16 +187,33 @@ class MolecularViewer(QtWidgets.QWidget):
             for label in others:
                 getattr(axes_actor, f"Get{label}AxisShaftProperty")().SetOpacity(0.0)
                 getattr(axes_actor, f"Get{label}AxisTipProperty")().SetOpacity(0.0)
-                getattr(axes_actor, f"Set{label}AxisLabelText")("")
-            axes_widget = vtk.vtkOrientationMarkerWidget()
-            axes_widget.SetOrientationMarker(axes_actor)
-            axes_widget.SetInteractor(self._iren.GetRenderWindow().GetInteractor())
-            axes_widget.SetViewport(0.0, 0.0, 0.25, 0.25)
-            axes_widget.SetEnabled(True)
-            axes_widget.InteractiveOff()
-            axes_arrows.append(axes_actor)
-            axes_widgets.append(axes_widget)
-        return axes_arrows, axes_widgets
+            assembly.AddPart(axes_actor)
+
+        axes_widget = vtk.vtkOrientationMarkerWidget()
+        axes_widget.SetOrientationMarker(assembly)
+        axes_widget.SetInteractor(self._iren.GetRenderWindow().GetInteractor())
+        axes_widget.SetViewport(0.0, 0.0, 0.25, 0.25)
+        axes_widget.SetEnabled(True)
+        axes_widget.InteractiveOff()
+        axes_widgets.append(axes_widget)
+
+        label_actor = vtkAxesActor()
+        label_actor.AxisLabelsOn()
+        label_actor.GetXAxisShaftProperty().SetOpacity(0.0)
+        label_actor.GetYAxisShaftProperty().SetOpacity(0.0)
+        label_actor.GetZAxisShaftProperty().SetOpacity(0.0)
+        label_actor.GetXAxisTipProperty().SetOpacity(0.0)
+        label_actor.GetYAxisTipProperty().SetOpacity(0.0)
+        label_actor.GetZAxisTipProperty().SetOpacity(0.0)
+        axes_widget = vtk.vtkOrientationMarkerWidget()
+        axes_widget.SetOrientationMarker(label_actor)
+        axes_widget.SetInteractor(self._iren.GetRenderWindow().GetInteractor())
+        axes_widget.SetViewport(0.0, 0.0, 0.25, 0.25)
+        axes_widget.SetEnabled(True)
+        axes_widget.InteractiveOff()
+        axes_widgets.append(axes_widget)
+
+        return assembly, label_actor, axes_widgets
 
     def _new_trajectory_object(self, fname: str, trajectory: Trajectory):
         """Creates and sets a new trajectory reader for the input trajectory.
@@ -568,30 +588,23 @@ class MolecularViewer(QtWidgets.QWidget):
 
     def update_axes(self):
         """Updates the axes depending on the axes type used."""
-        for widget in self.arrow_widgets:
+        for widget in self.axes_widgets:
             widget.SetEnabled(False)
         if self.current_axes_type == "none":
             return
 
-        identity = vtk.vtkTransform()
-        identity.Identity()
-        for arrow in self.arrow_actors:
-            arrow.SetUserTransform(identity)
-
-        if self.current_axes_type == "direct":
-            self.arrow_actors[0].SetXAxisLabelText("a")
-            self.arrow_actors[1].SetYAxisLabelText("b")
-            self.arrow_actors[2].SetZAxisLabelText("c")
-        elif self.current_axes_type == "reciprocal":
-            self.arrow_actors[0].SetXAxisLabelText("a*")
-            self.arrow_actors[1].SetYAxisLabelText("b*")
-            self.arrow_actors[2].SetZAxisLabelText("c*")
-        elif self.current_axes_type == "cartesian":
-            for widget in self.arrow_widgets:
+        if self.current_axes_type == "cartesian":
+            parts = self.axes_assembly.GetParts()
+            parts.InitTraversal()
+            for i in range(parts.GetNumberOfItems()):
+                arrow = parts.GetNextProp()
+                arrow.SetUserTransform(None)
+            self.label_actor.SetUserTransform(None)
+            for widget in self.axes_widgets:
                 widget.SetEnabled(True)
-            self.arrow_actors[0].SetXAxisLabelText("X")
-            self.arrow_actors[1].SetYAxisLabelText("Y")
-            self.arrow_actors[2].SetZAxisLabelText("Z")
+            self.label_actor.SetXAxisLabelText("X")
+            self.label_actor.SetYAxisLabelText("Y")
+            self.label_actor.SetZAxisLabelText("Z")
             return
 
         if self._reader is None:
@@ -600,16 +613,24 @@ class MolecularViewer(QtWidgets.QWidget):
         if uc is None:
             return
 
-        for widget in self.arrow_widgets:
+        for widget in self.axes_widgets:
             widget.SetEnabled(True)
 
         if self.current_axes_type == "direct":
+            self.label_actor.SetXAxisLabelText("a")
+            self.label_actor.SetYAxisLabelText("b")
+            self.label_actor.SetZAxisLabelText("c")
             matrix = uc.direct.copy()
         elif self.current_axes_type == "reciprocal":
+            self.label_actor.SetXAxisLabelText("a*")
+            self.label_actor.SetYAxisLabelText("b*")
+            self.label_actor.SetZAxisLabelText("c*")
             matrix = uc.inverse.copy().T
         matrix /= np.linalg.norm(matrix, axis=1)[:, np.newaxis]
 
-        for i, arrow_actor in enumerate(self.arrow_actors):
+        parts = self.axes_assembly.GetParts()
+        parts.InitTraversal()
+        for i in range(parts.GetNumberOfItems()):
             new_vec = matrix[i]
             cart_vec = np.eye(3)[i]
             rot = R.align_vectors(new_vec, cart_vec)[0].as_matrix()
@@ -622,7 +643,18 @@ class MolecularViewer(QtWidgets.QWidget):
 
             transform = vtk.vtkTransform()
             transform.SetMatrix(vtk_matrix)
-            arrow_actor.SetUserTransform(transform)
+            arrow = parts.GetNextProp()
+            arrow.SetUserTransform(transform)
+
+        matrix = matrix.T
+        vtk_matrix = vtk.vtkMatrix4x4()
+        for i in range(3):
+            for j in range(3):
+                vtk_matrix.SetElement(i, j, matrix[i, j])
+        vtk_matrix.SetElement(3, 3, 1.0)
+        transform = vtk.vtkTransform()
+        transform.SetMatrix(vtk_matrix)
+        self.label_actor.SetUserTransform(transform)
 
     def create_bond_cell_array(
         self,

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -594,12 +594,14 @@ class MolecularViewer(QtWidgets.QWidget):
             return
 
         if self.current_axes_type == "cartesian":
+            transform = vtk.vtkTransform()
+            transform.Identity()
             parts = self.axes_assembly.GetParts()
             parts.InitTraversal()
             for i in range(parts.GetNumberOfItems()):
                 arrow = parts.GetNextProp()
-                arrow.SetUserTransform(None)
-            self.label_actor.SetUserTransform(None)
+                arrow.SetUserTransform(transform)
+            self.label_actor.SetUserTransform(transform)
             for widget in self.axes_widgets:
                 widget.SetEnabled(True)
             self.label_actor.SetXAxisLabelText("X")

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -524,6 +524,7 @@ class MolecularViewer(QtWidgets.QWidget):
         self._atom_colours = []
         self._current_frame = 0
         self.reset_all_polydata()
+        self.update_axes()
 
         self.update_renderer()
 
@@ -566,13 +567,10 @@ class MolecularViewer(QtWidgets.QWidget):
 
     def update_axes(self):
         """Updates the axes depending on the axes type used."""
+        for widget in self.arrow_widgets:
+            widget.SetEnabled(False)
         if self.current_axes_type == "none":
-            for widget in self.arrow_widgets:
-                widget.SetEnabled(False)
             return
-        else:
-            for widget in self.arrow_widgets:
-                widget.SetEnabled(True)
 
         identity = vtk.vtkTransform()
         identity.Identity()
@@ -588,6 +586,8 @@ class MolecularViewer(QtWidgets.QWidget):
             self.arrow_actors[1].SetYAxisLabelText("b*")
             self.arrow_actors[2].SetZAxisLabelText("c*")
         elif self.current_axes_type == "cartesian":
+            for widget in self.arrow_widgets:
+                widget.SetEnabled(True)
             self.arrow_actors[0].SetXAxisLabelText("X")
             self.arrow_actors[1].SetYAxisLabelText("Y")
             self.arrow_actors[2].SetZAxisLabelText("Z")
@@ -598,6 +598,9 @@ class MolecularViewer(QtWidgets.QWidget):
         uc = self._reader.read_pbc(self._current_frame)
         if uc is None:
             return
+
+        for widget in self.arrow_widgets:
+            widget.SetEnabled(True)
 
         if self.current_axes_type == "direct":
             matrix = uc.direct.copy()

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -250,7 +250,8 @@ class MolecularViewer(QtWidgets.QWidget):
         """
         self.current_axes_type = axes_option
         self.update_axes()
-        self.update_renderer()
+        self._iren.GetRenderWindow().Render()
+        self._iren.Render()
 
     def trace_from_dialog(self, params: dict[str, Any]):
         """Passes the input parameter dictionary to the method
@@ -973,6 +974,7 @@ class MolecularViewer(QtWidgets.QWidget):
             self._renderer.ResetCamera()
             self.reset_camera = False
 
+        self._iren.GetRenderWindow().Render()
         self._iren.Render()
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -22,6 +22,7 @@ from qtpy import QtWidgets
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QSizePolicy
 from scipy.spatial import cKDTree as KDTree
+from scipy.spatial.transform import Rotation as R
 from vtk.util import numpy_support
 from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 from vtkmodules.vtkRenderingAnnotation import vtkAxesActor
@@ -119,15 +120,7 @@ class MolecularViewer(QtWidgets.QWidget):
 
         self._iren.GetRenderWindow()
 
-        self.axes_actor = vtkAxesActor()
-        self.axes_actor.AxisLabelsOn()
-        self.axes_actor.SetShaftTypeToCylinder()
-        self.axes_widget = vtk.vtkOrientationMarkerWidget()
-        self.axes_widget.SetOrientationMarker(self.axes_actor)
-        self.axes_widget.SetInteractor(self._iren.GetRenderWindow().GetInteractor())
-        self.axes_widget.SetViewport(0.0, 0.0, 0.25, 0.25)
-        self.axes_widget.SetEnabled(True)
-        self.axes_widget.InteractiveOff()
+        self.arrow_actors, self.arrow_widgets = self.create_arrow_widgets()
 
         self.atom_actor = None
         self._last_coords = None
@@ -149,8 +142,8 @@ class MolecularViewer(QtWidgets.QWidget):
 
         self._atoms_visible = True
         self._bonds_visible = True
-        self._axes_visible = True
         self._cell_visible = True
+        self.current_axes_type = "cartesian"
 
         self._iren.Initialize()
 
@@ -171,6 +164,36 @@ class MolecularViewer(QtWidgets.QWidget):
         self.dummy_size = 0.0
 
         self.reset_camera = False
+
+    def create_arrow_widgets(self):
+        """Create three axes for each direction. We want to create three
+        separate arrows so that we can apply a rotation to each one to
+        align it along the unit cell axes. We could create one axis and
+        apply a non-orthogonal transform to it but this causes the
+        arrows to become distorted.
+        """
+        axes_arrows = []
+        axes_widgets = []
+        labels = ["X", "Y", "Z"]
+        for axes in labels:
+            axes_actor = vtkAxesActor()
+            axes_actor.AxisLabelsOn()
+            axes_actor.SetShaftTypeToCylinder()
+            others = copy.deepcopy(labels)
+            others.remove(axes)
+            for label in others:
+                getattr(axes_actor, f"Get{label}AxisShaftProperty")().SetOpacity(0.0)
+                getattr(axes_actor, f"Get{label}AxisTipProperty")().SetOpacity(0.0)
+                getattr(axes_actor, f"Set{label}AxisLabelText")("")
+            axes_widget = vtk.vtkOrientationMarkerWidget()
+            axes_widget.SetOrientationMarker(axes_actor)
+            axes_widget.SetInteractor(self._iren.GetRenderWindow().GetInteractor())
+            axes_widget.SetViewport(0.0, 0.0, 0.25, 0.25)
+            axes_widget.SetEnabled(True)
+            axes_widget.InteractiveOff()
+            axes_arrows.append(axes_actor)
+            axes_widgets.append(axes_widget)
+        return axes_arrows, axes_widgets
 
     def _new_trajectory_object(self, fname: str, trajectory: Trajectory):
         """Creates and sets a new trajectory reader for the input trajectory.
@@ -212,12 +235,22 @@ class MolecularViewer(QtWidgets.QWidget):
         """
         self._atoms_visible = flags[0]
         self._bonds_visible = flags[1]
-        self._axes_visible = flags[2]
-        self._cell_visible = flags[3]
-        self.axes_widget.SetEnabled(self._axes_visible)
+        self._cell_visible = flags[2]
         result = self.set_coordinates(self._current_frame)
         if result is False:
             self.update_renderer()
+
+    def _change_axes(self, axes_option: str):
+        """Changes the axes type in the 3D viewer.
+
+        Parameters
+        ----------
+        axes_option : str
+            The axes type that will be used.
+        """
+        self.current_axes_type = axes_option
+        self.update_axes()
+        self.update_renderer()
 
     def trace_from_dialog(self, params: dict[str, Any]):
         """Passes the input parameter dictionary to the method
@@ -501,9 +534,10 @@ class MolecularViewer(QtWidgets.QWidget):
         self._polydata = vtk.vtkPolyData()
         self._uc_polydata = vtk.vtkPolyData()
 
-    def update_all_polydata(self):
+    def update_all_polydata_and_axes(self):
         self.update_polydata()
         self.update_uc_polydata()
+        self.update_axes()
 
     def update_polydata(self):
         """Triggers an update of the VTK actors, making them use the
@@ -529,6 +563,62 @@ class MolecularViewer(QtWidgets.QWidget):
                 return
 
         self._polydata_bonds_exist = False
+
+    def update_axes(self):
+        """Updates the axes depending on the axes type used."""
+        if self.current_axes_type == "none":
+            for widget in self.arrow_widgets:
+                widget.SetEnabled(False)
+            return
+        else:
+            for widget in self.arrow_widgets:
+                widget.SetEnabled(True)
+
+        identity = vtk.vtkTransform()
+        identity.Identity()
+        for arrow in self.arrow_actors:
+            arrow.SetUserTransform(identity)
+
+        if self.current_axes_type == "direct":
+            self.arrow_actors[0].SetXAxisLabelText("a")
+            self.arrow_actors[1].SetYAxisLabelText("b")
+            self.arrow_actors[2].SetZAxisLabelText("c")
+        elif self.current_axes_type == "reciprocal":
+            self.arrow_actors[0].SetXAxisLabelText("a*")
+            self.arrow_actors[1].SetYAxisLabelText("b*")
+            self.arrow_actors[2].SetZAxisLabelText("c*")
+        elif self.current_axes_type == "cartesian":
+            self.arrow_actors[0].SetXAxisLabelText("X")
+            self.arrow_actors[1].SetYAxisLabelText("Y")
+            self.arrow_actors[2].SetZAxisLabelText("Z")
+            return
+
+        if self._reader is None:
+            return
+        uc = self._reader.read_pbc(self._current_frame)
+        if uc is None:
+            return
+
+        if self.current_axes_type == "direct":
+            matrix = uc.direct.copy()
+        elif self.current_axes_type == "reciprocal":
+            matrix = uc.inverse.copy().T
+        matrix /= np.linalg.norm(matrix, axis=1)[:, np.newaxis]
+
+        for i, arrow_actor in enumerate(self.arrow_actors):
+            new_vec = matrix[i]
+            cart_vec = np.eye(3)[i]
+            rot = R.align_vectors(new_vec, cart_vec)[0].as_matrix()
+
+            vtk_matrix = vtk.vtkMatrix4x4()
+            for j in range(3):
+                for k in range(3):
+                    vtk_matrix.SetElement(j, k, rot[j, k])
+            vtk_matrix.SetElement(3, 3, 1.0)
+
+            transform = vtk.vtkTransform()
+            transform.SetMatrix(vtk_matrix)
+            arrow_actor.SetUserTransform(transform)
 
     def create_bond_cell_array(
         self,
@@ -774,7 +864,7 @@ class MolecularViewer(QtWidgets.QWidget):
         self._current_frame = frame % self._reader.n_frames
 
         # update the atoms
-        self.update_all_polydata()
+        self.update_all_polydata_and_axes()
 
         # Update the view.
         self.update_renderer()
@@ -857,7 +947,7 @@ class MolecularViewer(QtWidgets.QWidget):
         scalars = ndarray_to_vtkarray(colours, radii, numbers)
         self._polydata = vtk.vtkPolyData()
         self._polydata.GetPointData().SetScalars(scalars)
-        self.update_all_polydata()
+        self.update_all_polydata_and_axes()
         self.update_renderer()
 
     def update_renderer(self):
@@ -1034,8 +1124,8 @@ class MolecularViewerWithPicking(MolecularViewer):
         super().reset_all_polydata()
         self._picked_polydata = vtk.vtkPolyData()
 
-    def update_all_polydata(self):
-        super().update_all_polydata()
+    def update_all_polydata_and_axes(self):
+        super().update_all_polydata_and_axes()
         self.update_picked_polydata()
 
     def create_all_actors(self):


### PR DESCRIPTION
**Description of work**
Updated the 3D viewer and control so that there are now four different axes that can be used.

- none
- cartesian
- direct
- reciprocal

When a trajectory with a unit cell is loaded the user can now select direct to point the axes arrows along the unit cell vector directions or reciprocal to point them along the reciprocal cell vector directions.

<img width="1710" height="1015" alt="image" src="https://github.com/user-attachments/assets/8fd93170-6291-4f75-99f7-2720793c58a1" />


**Fixes**
Closes #373

**To test**
Load a trajectory with a unit cell and check that the axes with the different options point in the correct direction.
