### PR TITLE
Fixed 3d view controls while animation is playing

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -106,6 +106,7 @@ class ViewerControls(QWidget):
         self._animation_timer.timeout.connect(self.advance_frame)
         self._mutex = QMutex()
         self._frame_step = 1
+        self._current_step_size = 1
         self._time_per_frame = 80  # in ms
         self._frame_factor = 1  # just a scalar multiplication factor
         self._visibility = [True, True, True, True]
@@ -318,12 +319,14 @@ class ViewerControls(QWidget):
     @Slot(int)
     def setTimeStep(self, new_value: int):
         self._time_per_frame = new_value
-        self.animate()
+        if self._animation_timer.isActive():
+            self.animate(self._current_step_size)
 
     @Slot(int)
     def setFrameSkip(self, new_value: int):
         self._frame_factor = new_value
-        self.animate()
+        if self._animation_timer.isActive():
+            self.animate(self._current_step_size)
 
     @Slot(float)
     def setAtomSize(self, new_value: float):
@@ -357,7 +360,8 @@ class ViewerControls(QWidget):
         """
         if self._animation_timer.isActive():
             self._animation_timer.stop()
-        self._frame_step = step_size * self._frame_factor
+        self._current_step_size = step_size
+        self._frame_step = self._current_step_size * self._frame_factor
         self._animation_timer.setInterval(self._time_per_frame)
         self._animation_timer.start()
 


### PR DESCRIPTION
**Description of work**
Fixed the 3D view so that when the "time per frame" or "show every N frames" are changed the 3D view does not start playing if it was not already playing.

Also fixed the 3D view so that when it is fast forwarding or backwarding then changes the "time per frame" or "show every N frames" setting leaves it fast forwarding or backwarding but with the new "time per frame" or "show every N frames" options.

**Fixes**
Fixes #882

**To test**
- 3D view should not play when "time per frame" or "show every N frames" are changed.
- 3D view should continue to play when "time per frame" or "show every N frames" are changed if it was playing.
- 3D view should continue fast forwarding or backwarding when "time per frame" or "show every N frames" are changed.
