### PR TITLE
Added option to display atom labels in the 3D viewer

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -249,20 +249,23 @@ class ViewerControls(QWidget):
         layout4.addWidget(size_factor)
         wrapper4.setLayout(layout4)
         layout.addWidget(wrapper4)
+
         wrapper5 = QGroupBox("Visible Objects", base)
         layout5 = QGridLayout(wrapper5)
+
         atoms_visible = QCheckBox("atoms:")
         atoms_visible.setLayoutDirection(Qt.RightToLeft)
         bonds_visible = QCheckBox("bonds:")
         bonds_visible.setLayoutDirection(Qt.RightToLeft)
         cell_visible = QCheckBox("cell:")
         cell_visible.setLayoutDirection(Qt.RightToLeft)
-        self.axes_combo = QComboBox()
-        self.axes_combo.addItems(["none", "cartesian", "direct", "reciprocal"])
-        self.axes_combo.setCurrentIndex(1)
         layout5.addWidget(atoms_visible, 0, 0, 1, 1)
         layout5.addWidget(bonds_visible, 0, 1, 1, 1)
         layout5.addWidget(cell_visible, 0, 2, 1, 1)
+
+        self.axes_combo = QComboBox()
+        self.axes_combo.addItems(["none", "cartesian", "direct", "reciprocal"])
+        self.axes_combo.setCurrentIndex(1)
         label = QLabel("axes:")
         label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         layout5.addWidget(label, 1, 0, 1, 1)
@@ -272,11 +275,21 @@ class ViewerControls(QWidget):
             bonds_visible,
             cell_visible,
         ]
+
+        self.labels_combo = QComboBox()
+        self.labels_combo.addItems(["none", "index", "label", "atom", "molecule"])
+        label = QLabel("labels:")
+        label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        layout5.addWidget(label, 2, 0, 1, 1)
+        layout5.addWidget(self.labels_combo, 2, 1, 1, 2)
+
         for nw, box in enumerate(self._visibility_checkboxes):
             box.setTristate(False)
             box.setChecked(self._visibility[nw])
             box.stateChanged.connect(self.setVisibility)
         self.axes_combo.currentIndexChanged.connect(self.changeAxes)
+        self.labels_combo.currentIndexChanged.connect(self.changeLabels)
+
         layout.addWidget(wrapper5)
         # the database of atom types
         self._atom_details.setModel(self._viewer._colour_manager)
@@ -332,6 +345,10 @@ class ViewerControls(QWidget):
     @Slot()
     def changeAxes(self):
         self._viewer._change_axes(self.axes_combo.currentText())
+
+    @Slot()
+    def changeLabels(self):
+        self._viewer._change_atom_labels(self.labels_combo.currentText())
 
     @Slot(int)
     def setTimeStep(self, new_value: int):

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -116,6 +116,7 @@ class MolecularViewer(QtWidgets.QWidget):
         self._label_renderer = vtk.vtkRenderer()
         self._label_renderer.SetLayer(1)
         self._label_renderer.SetBackgroundAlpha(0)
+        self._label_renderer.SetInteractive(False)
 
         self._iren.GetRenderWindow().SetNumberOfLayers(2)
         self._iren.GetRenderWindow().AddRenderer(self._renderer)
@@ -1147,7 +1148,7 @@ class MolecularViewerExtended(MolecularViewer):
         if self._last_coords is None:
             return
 
-        picker = vtk.vtkPropPicker()
+        picker = vtk.vtkCellPicker()
 
         picker.AddPickList(self.atom_actor)
         picker.PickFromListOn()
@@ -1200,7 +1201,7 @@ class MolecularViewerWithPicking(MolecularViewer):
         if self._picking_domain is None:
             return
 
-        picker = vtk.vtkPropPicker()
+        picker = vtk.vtkCellPicker()
 
         picker.AddPickList(self._picking_domain)
         picker.PickFromListOn()

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -623,7 +623,9 @@ class MolecularViewer(QtWidgets.QWidget):
         if not self.atom_label_actors or self.atom_label_type == "none":
             return
 
-        for follower, coord in zip(self.atom_label_actors, self._reader.read_frame(self._current_frame)):
+        for follower, coord in zip(
+            self.atom_label_actors, self._reader.read_frame(self._current_frame)
+        ):
             follower.SetPosition(*coord)
 
     def clear_atom_labels(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -16,6 +16,7 @@
 import copy
 from typing import Any, Optional
 
+import more_itertools
 import numpy as np
 import vtk
 from qtpy import QtWidgets
@@ -572,7 +573,9 @@ class MolecularViewer(QtWidgets.QWidget):
             label_dict = self._reader._trajectory.chemical_system._labels
             if not label_dict:
                 return
-            keys = more_itertools.run_length.decode(((k, len(v)) for k, v in label_dict.items()))
+            keys = more_itertools.run_length.decode(
+                ((k, len(v)) for k, v in label_dict.items())
+            )
             labels = sorted(keys, key=label_dict.__getitem__)
         elif self.atom_label_type == "atom":
             labels = self._atoms
@@ -580,8 +583,12 @@ class MolecularViewer(QtWidgets.QWidget):
             label_dict = self._reader._trajectory.chemical_system._clusters
             if not label_dict:
                 return
-            label_dict = {k: list(more_itertools.collapse(v)) for k, v in label_dict.items()}
-            keys = more_itertools.run_length.decode(((k, len(v)) for k, v in label_dict.items()))
+            label_dict = {
+                k: list(more_itertools.collapse(v)) for k, v in label_dict.items()
+            }
+            keys = more_itertools.run_length.decode(
+                ((k, len(v)) for k, v in label_dict.items())
+            )
             labels = sorted(keys, key=label_dict.__getitem__)
         else:
             return

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -286,7 +286,7 @@ class MolecularViewer(QtWidgets.QWidget):
         self._iren.GetRenderWindow().Render()
         self._iren.Render()
 
-    def _change_atom_labels(self, label_option: str):
+    def _change_atom_labels(self, label_option: str) -> None:
         """Changes the atoms label text.
 
         Parameters
@@ -572,25 +572,17 @@ class MolecularViewer(QtWidgets.QWidget):
             label_dict = self._reader._trajectory.chemical_system._labels
             if not label_dict:
                 return
-            keys = []
-            vals = []
-            for k, v in label_dict.items():
-                keys += [k] * len(v)
-                vals += v
-            labels, _ = zip(*sorted(zip(keys, vals), key=lambda x: x[1]))
+            keys = more_itertools.run_length.decode(((k, len(v)) for k, v in label_dict.items()))
+            labels = sorted(keys, key=label_dict.__getitem__)
         elif self.atom_label_type == "atom":
             labels = self._atoms
         elif self.atom_label_type == "molecule":
             label_dict = self._reader._trajectory.chemical_system._clusters
             if not label_dict:
                 return
-            keys = []
-            vals = []
-            for k, v in label_dict.items():
-                indices = [i for j in v for i in j]
-                keys += [k] * len(indices)
-                vals += indices
-            labels, _ = zip(*sorted(zip(keys, vals), key=lambda x: x[1]))
+            label_dict = {k: list(more_itertools.collapse(v)) for k, v in label_dict.items()}
+            keys = more_itertools.run_length.decode(((k, len(v)) for k, v in label_dict.items()))
+            labels = sorted(keys, key=label_dict.__getitem__)
         else:
             return
 
@@ -618,10 +610,11 @@ class MolecularViewer(QtWidgets.QWidget):
 
     def update_atom_label_actors(self):
         """Updates the atom label follwer positions."""
-        if self._reader is None:
-            return
-
-        if not self.atom_label_actors or self.atom_label_type == "none":
+        if (
+            self._reader is None
+            or not self.atom_label_actors
+            or self.atom_label_type == "none"
+        ):
             return
 
         for follower, coord in zip(

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -109,8 +109,17 @@ class MolecularViewer(QtWidgets.QWidget):
         setattr(self._iren, "keyPressEvent", dummy_method)
 
         self._renderer = vtk.vtkRenderer()
+        self._renderer.SetLayer(0)
+        # create another renderer for the atoms labels, we want the
+        # labels to be ontop of the atoms so they can be read more
+        # easily
+        self._label_renderer = vtk.vtkRenderer()
+        self._label_renderer.SetLayer(1)
+        self._label_renderer.SetBackgroundAlpha(0)
 
+        self._iren.GetRenderWindow().SetNumberOfLayers(2)
         self._iren.GetRenderWindow().AddRenderer(self._renderer)
+        self._iren.GetRenderWindow().AddRenderer(self._label_renderer)
 
         self._iren.GetRenderWindow().SetPosition((0, 0))
 
@@ -126,6 +135,7 @@ class MolecularViewer(QtWidgets.QWidget):
 
         self.atom_actor = None
         self._last_coords = None
+        self.atom_label_actors = []
 
         layout = QtWidgets.QStackedLayout(self)
         layout.addWidget(self._iren)
@@ -135,6 +145,7 @@ class MolecularViewer(QtWidgets.QWidget):
         self._camera = vtk.vtkCamera()
         # associate camera to renderer
         self._renderer.SetActiveCamera(self._camera)
+        self._label_renderer.SetActiveCamera(self._camera)
         self._camera.SetFocalPoint(0, 0, 0)
         self._camera.SetPosition(0, 0, 20)
 
@@ -531,9 +542,33 @@ class MolecularViewer(QtWidgets.QWidget):
 
         del self._actors
 
+    def create_atom_label_actors(self):
+        if self._reader is None:
+            return []
+
+        atom_label_actors = []
+        for i, coord in enumerate(self._reader.read_frame(self._current_frame)):
+            actor = vtk.vtkBillboardTextActor3D()
+            actor.SetPosition(*coord)
+            actor.SetInput(f"{i}")
+            atom_label_actors.append(actor)
+        self.atom_label_actors = atom_label_actors
+
+        return atom_label_actors
+
+    def clear_atom_labels(self):
+        if not self.atom_label_actors:
+            return
+
+        for actor in self.atom_label_actors:
+            self._label_renderer.RemoveActor(actor)
+
+        self.atom_label_actors = []
+
     def clear_panel(self) -> None:
         """Clears the Molecular Viewer panel"""
         self.clear_trajectory()
+        self.clear_atom_labels()
 
         self._reader = None
 
@@ -922,6 +957,7 @@ class MolecularViewer(QtWidgets.QWidget):
 
         self.reset_camera = True
         self.clear_trajectory()
+        self.clear_atom_labels()
 
         self._reader = reader
 
@@ -994,6 +1030,7 @@ class MolecularViewer(QtWidgets.QWidget):
         """
         # deleting old frame
         self.clear_trajectory(clear_isosurfaces=False)
+        self.clear_atom_labels()
 
         # creating new polydata
         self._actors = vtk.vtkAssembly()
@@ -1002,6 +1039,10 @@ class MolecularViewer(QtWidgets.QWidget):
 
         # adding polydata to renderer
         self._renderer.AddActor(self._actors)
+
+        # overlay trajectory with atom labels
+        for actor in self.create_atom_label_actors():
+            self._label_renderer.AddActor(actor)
 
         # rendering
         if self.reset_camera:

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -157,6 +157,7 @@ class MolecularViewer(QtWidgets.QWidget):
         self._bonds_visible = True
         self._cell_visible = True
         self.current_axes_type = "cartesian"
+        self.atom_label_type = "none"
 
         self._iren.Initialize()
 
@@ -281,6 +282,20 @@ class MolecularViewer(QtWidgets.QWidget):
         """
         self.current_axes_type = axes_option
         self.update_axes()
+        self._iren.GetRenderWindow().Render()
+        self._iren.Render()
+
+    def _change_atom_labels(self, label_option: str):
+        """Changes the atoms label text.
+
+        Parameters
+        ----------
+        label_option : str
+            The atom label option.
+        """
+        self.atom_label_type = label_option
+        self.clear_atom_labels()
+        self.create_atom_label_actors()
         self._iren.GetRenderWindow().Render()
         self._iren.Render()
 
@@ -543,20 +558,76 @@ class MolecularViewer(QtWidgets.QWidget):
         del self._actors
 
     def create_atom_label_actors(self):
+        """Creates atom label actors, setting the text to the chosen
+        atom_label_type.
+        """
+        self.atom_label_actors = []
         if self._reader is None:
-            return []
+            return
+
+        if self.atom_label_type == "index":
+            labels = list(range(self._reader._n_atoms))
+        elif self.atom_label_type == "label":
+            label_dict = self._reader._trajectory.chemical_system._labels
+            if not label_dict:
+                return
+            keys = []
+            vals = []
+            for k, v in label_dict.items():
+                keys += [k] * len(v)
+                vals += v
+            labels, _ = zip(*sorted(zip(keys, vals), key=lambda x: x[1]))
+        elif self.atom_label_type == "atom":
+            labels = self._atoms
+        elif self.atom_label_type == "molecule":
+            label_dict = self._reader._trajectory.chemical_system._clusters
+            if not label_dict:
+                return
+            keys = []
+            vals = []
+            for k, v in label_dict.items():
+                indices = [i for j in v for i in j]
+                keys += [k] * len(indices)
+                vals += indices
+            labels, _ = zip(*sorted(zip(keys, vals), key=lambda x: x[1]))
+        else:
+            return
+
+        if len(labels) != self._reader._n_atoms:
+            return
 
         atom_label_actors = []
-        for i, coord in enumerate(self._reader.read_frame(self._current_frame)):
-            actor = vtk.vtkBillboardTextActor3D()
-            actor.SetPosition(*coord)
-            actor.SetInput(f"{i}")
-            atom_label_actors.append(actor)
+        for label, coord in zip(labels, self._reader.read_frame(self._current_frame)):
+            text = vtk.vtkVectorText()
+            text.SetText(f"{label}")
+
+            mapper = vtk.vtkPolyDataMapper()
+            mapper.SetInputConnection(text.GetOutputPort())
+
+            follower = vtk.vtkFollower()
+            follower.SetMapper(mapper)
+            follower.SetScale(0.025)
+            follower.SetPosition(*coord)
+            follower.SetCamera(self._label_renderer.GetActiveCamera())
+
+            atom_label_actors.append(follower)
+            self._label_renderer.AddActor(follower)
+
         self.atom_label_actors = atom_label_actors
 
-        return atom_label_actors
+    def update_atom_label_actors(self):
+        """Updates the atom label follwer positions."""
+        if self._reader is None:
+            return
+
+        if not self.atom_label_actors or self.atom_label_type == "none":
+            return
+
+        for follower, coord in zip(self.atom_label_actors, self._reader.read_frame(self._current_frame)):
+            follower.SetPosition(*coord)
 
     def clear_atom_labels(self):
+        """Clears the atoms labels."""
         if not self.atom_label_actors:
             return
 
@@ -1011,6 +1082,8 @@ class MolecularViewer(QtWidgets.QWidget):
         self.reset_all_polydata()
         self._polydata.GetPointData().SetScalars(scalars)
 
+        self.create_atom_label_actors()
+
         self._colour_manager.onNewValues()
         self.new_max_frames.emit(self._n_frames - 1)
         self._trace_dialog.update_limits()
@@ -1030,7 +1103,6 @@ class MolecularViewer(QtWidgets.QWidget):
         """
         # deleting old frame
         self.clear_trajectory(clear_isosurfaces=False)
-        self.clear_atom_labels()
 
         # creating new polydata
         self._actors = vtk.vtkAssembly()
@@ -1040,9 +1112,8 @@ class MolecularViewer(QtWidgets.QWidget):
         # adding polydata to renderer
         self._renderer.AddActor(self._actors)
 
-        # overlay trajectory with atom labels
-        for actor in self.create_atom_label_actors():
-            self._label_renderer.AddActor(actor)
+        # update atom label positions
+        self.update_atom_label_actors()
 
         # rendering
         if self.reset_camera:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/View3D.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/View3D.py
@@ -52,3 +52,4 @@ class View3D(QWidget):
         except AttributeError:
             self.error.emit(f"3D View could not visualise {fullpath}")
             self._viewer.clear_trajectory()
+            self._viewer.clear_atom_labels()


### PR DESCRIPTION
**Description of work**
Adds atom labels to the 3D viewer. Currently supports the following options.

- none
- index
- label
- atom
- molecule

For the cases where there are no labels/molecules no labels are shown in the 3D view. I find that there is a slight slow down to the 3D viewer when playing but I think this should be acceptable since in most cases you want be playing the 3D view while looking at the labels.

Let me know if you have any suggestion for more labels or have any options on font size etc.

<img width="1058" height="738" alt="image" src="https://github.com/user-attachments/assets/e3478efa-28ae-4ccc-873e-70a12adfd69e" />

<img width="1058" height="738" alt="image" src="https://github.com/user-attachments/assets/5882f6ed-880f-41bd-b09b-22734a139170" />


**Fixes**
Closes #499

**To test**
Check labels in the 3D view including atom selection and transmutation. Check that labels update correctly when switching or deleting the trajectory.
