### PR TITLE
Stop column width in RunTable from resetting

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
@@ -15,8 +15,8 @@
 #
 from typing import Union
 
-from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt, Signal, Slot
-from qtpy.QtGui import QContextMenuEvent, QStandardItem
+from qtpy.QtCore import QModelIndex, Qt, Signal, Slot
+from qtpy.QtGui import QContextMenuEvent, QStandardItem, QStandardItemModel
 from qtpy.QtWidgets import QAbstractItemView, QMenu, QMessageBox, QTableView
 
 from MDANSE.Framework.Jobs.JobStatus import ALLOWED_ACTIONS
@@ -42,18 +42,16 @@ class RunTable(QTableView):
         vh = self.verticalHeader()
         vh.setVisible(False)
 
-    def setModel(self, model: QAbstractItemModel) -> None:
+    def setModel(self, model: QStandardItemModel) -> None:
         result = super().setModel(model)
-        self.model().dataChanged.connect(self.selective_resize)
+        model.itemChanged.connect(self.selective_resize)
         return result
 
-    @Slot()
-    def selective_resize(self):
-        columns = (
-            ind for ind in range(self.model().columnCount()) if ind != PROGBAR_COLUMN
-        )
-        for colnum in columns:
-            self.resizeColumnToContents(colnum)
+    @Slot("QStandardItem*")
+    def selective_resize(self, item: QStandardItem):
+        if colind := item.column() == PROGBAR_COLUMN:
+            return
+        self.resizeColumnToContents(colind)
 
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
         index = self.indexAt(event.pos())

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
@@ -45,11 +45,16 @@ class RunTable(QTableView):
     def setModel(self, model: QStandardItemModel) -> None:
         result = super().setModel(model)
         model.itemChanged.connect(self.selective_resize)
+        model.new_job_started.connect(self.name_column_resize)
         return result
+
+    @Slot()
+    def name_column_resize(self):
+        self.resizeColumnToContents(0)
 
     @Slot("QStandardItem*")
     def selective_resize(self, item: QStandardItem):
-        if colind := item.column() == PROGBAR_COLUMN:
+        if (colind := item.column()) == PROGBAR_COLUMN:
             return
         self.resizeColumnToContents(colind)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/RunTable.py
@@ -25,6 +25,8 @@ from MDANSE_GUI.Tabs.Views.Delegates import ProgressDelegate
 from MDANSE_GUI.Tabs.Visualisers.JobLogInfo import JobLogInfo
 from MDANSE_GUI.Tabs.Visualisers.TextInfo import TextInfo
 
+PROGBAR_COLUMN = 1
+
 
 class RunTable(QTableView):
     item_details = Signal(object)
@@ -36,14 +38,22 @@ class RunTable(QTableView):
         self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.clicked.connect(self.item_picked)
         self._progbar = ProgressDelegate()
-        self.setItemDelegateForColumn(1, self._progbar)
+        self.setItemDelegateForColumn(PROGBAR_COLUMN, self._progbar)
         vh = self.verticalHeader()
         vh.setVisible(False)
 
     def setModel(self, model: QAbstractItemModel) -> None:
         result = super().setModel(model)
-        self.model().dataChanged.connect(self.resizeColumnsToContents)
+        self.model().dataChanged.connect(self.selective_resize)
         return result
+
+    @Slot()
+    def selective_resize(self):
+        columns = (
+            ind for ind in range(self.model().columnCount()) if ind != PROGBAR_COLUMN
+        )
+        for colnum in columns:
+            self.resizeColumnToContents(colnum)
 
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
         index = self.indexAt(event.pos())


### PR DESCRIPTION
**Description of work**
The column width in the table of running jobs is still adjusted automatically when the contents change, but the progress bar column is excluded from the changes.

closes #891

**Fixes**
1. Added a custom method `selective_resize` to `RunTable`.

**To test**
Run a job in the GUI. It should be possible to change the width of the progress bar column, and it will not reset.
