### PR TITLE
Stop counting elapsed time after job has finished

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/JobStatus.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/JobStatus.py
@@ -53,6 +53,7 @@ class JobInfo:
     pid: int = PLATFORM.pid()
     type: str | None = None
     start: float | None = None
+    end: float | None = None
     elapsed: float | Literal["N/A"] = "N/A"
     rate: float | Literal["N/A"] = "N/A"
     pct_rate: float | Literal["N/A"] = "N/A"
@@ -79,7 +80,7 @@ class JobStatus(Status):
         self.save_status()
 
     def finish_status(self):
-        pass
+        self.state.end = time.time()
 
     @property
     def state(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/JobStatusProcess.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/JobStatusProcess.py
@@ -128,6 +128,7 @@ class JobStatusProcess(Status):
     def finish_status(self):
         """Assert finished state."""
         self.job_state = JobStates.FINISHED
+        self.state.end = time.time()
         self._pipe.send(self.state)
 
     def start_status(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -164,8 +164,13 @@ class JobEntry(QObject):
 
         try:
             comp_time = (self.job.n_steps - self.job.current_step) / self.job.rate
-        except TypeError:
+        except (TypeError, ZeroDivisionError):
             comp_time = "N/A"
+
+        if self.job.end:
+            elapsed_time = self.job.end - self.job.start
+        else:
+            elapsed_time = time.time() - self.job.start
 
         return f"""\
 Job type: {self._command}
@@ -177,7 +182,7 @@ Status:
   Percent rate: {self.job.pct_rate} %/s
   Steps: {self.job.current_step}/{self.job.n_steps}
   Step rate: {self.job.rate} steps/s
-  Elapsed time: {self._sec_fmt(time.time() - self.job.start)}
+  Elapsed time: {self._sec_fmt(elapsed_time)}
   Estimated remaining time: {self._sec_fmt(comp_time)}
 """
 
@@ -202,6 +207,7 @@ Status:
             return
         self._finished = True
         file_name = self.expected_output()
+        self.job.end = time.time()
 
         if success:
             if self._load_afterwards:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/NotificationTabWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/NotificationTabWidget.py
@@ -34,7 +34,7 @@ class NotificationTabWidget(QTabWidget):
 
     @Slot(int)
     def set_special_color(self, tab_index: int):
-        if tab_index != self.currentIndex:
+        if tab_index != self.currentIndex():
             self.tabBar().setTabTextColor(tab_index, self._special_color)
             self.tabBar().setTabIcon(
                 tab_index, QIcon.fromTheme(QIcon.ThemeIcon.DialogInformation)


### PR DESCRIPTION
**Description of work**
A clear and concise description of the change.  Please include motivation and context.

**Fixes**
1. Save the time the job finished in `JobInfo`.
2. If `end` time is not None, compare `start` to `end` when calculating elapsed time.
3. `comp_time` is N/A if the first step has not completed and `rate` is 0.
4. Correct the missing function call when comparing tab ID to determine if red highlight is needed.

**To test**
Run a GUI job. Check that the elapsed time stops changing once the job has stopped running.
