### PR TITLE
Adjust job categories

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
@@ -54,6 +54,7 @@ class ASE(Converter):
     standard input file names.
     """
 
+    category = ("Converters", "General")
     label = "ASE"
 
     settings = collections.OrderedDict()

--- a/MDANSE/Src/MDANSE/Framework/Converters/Converter.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Converter.py
@@ -28,7 +28,7 @@ from MDANSE.MLogging import LOG
 class Converter(IJob, metaclass=SubclassFactory):
     """Outputs a trajectory in the MDT format."""
 
-    category = ("Converters",)
+    category = ("Converters", "Specific")
     ancestor = ["empty_data"]
     runscript_import_line = (
         "from MDANSE.Framework.Converters.Converter import Converter"

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
@@ -44,6 +44,7 @@ class MDAnalysis(Converter):
     <a href="https://userguide.mdanalysis.org/stable/formats/index.html#formats">formats</a>.
     """
 
+    category = ("Converters", "General")
     label = "MDAnalysis"
     settings = collections.OrderedDict()
     settings["topology_file"] = (

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -39,6 +39,7 @@ class MDTraj(Converter):
     trajectories will be stitched together.
     """
 
+    category = ("Converters", "General")
     label = "MDTraj"
     settings = collections.OrderedDict()
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
@@ -43,10 +43,7 @@ class AverageStructure(IJob):
 
     label = "Average Structure"
 
-    category = (
-        "Analysis",
-        "Structure",
-    )
+    category = ("Trajectory",)
 
     ancestor = ["hdf_trajectory", "molecular_viewer"]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -40,10 +40,7 @@ class CenterOfMassesTrajectory(IJob):
 
     label = "Center Of Masses Trajectory"
 
-    category = (
-        "Analysis",
-        "Trajectory",
-    )
+    category = ("Trajectory",)
 
     ancestor = ["hdf_trajectory", "molecular_viewer"]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CroppedTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CroppedTrajectory.py
@@ -32,10 +32,7 @@ class CroppedTrajectory(IJob):
 
     label = "Cropped Trajectory"
 
-    category = (
-        "Analysis",
-        "Trajectory",
-    )
+    category = ("Trajectory",)
 
     ancestor = ["hdf_trajectory", "molecular_viewer"]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GlobalMotionFilteredTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GlobalMotionFilteredTrajectory.py
@@ -51,10 +51,7 @@ class GlobalMotionFilteredTrajectory(IJob):
 
     label = "Global Motion Filtered Trajectory"
 
-    category = (
-        "Analysis",
-        "Trajectory",
-    )
+    category = ("Trajectory",)
 
     ancestor = ["hdf_trajectory", "molecular_viewer"]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RigidBodyTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RigidBodyTrajectory.py
@@ -50,7 +50,6 @@ class RigidBodyTrajectory(IJob):
     label = "Rigid Body Trajectory"
 
     category = (
-        "Analysis",
         "Trajectory",
     )
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -46,10 +46,7 @@ class TrajectoryEditor(IJob):
 
     label = "Trajectory Editor"
 
-    category = (
-        "Analysis",
-        "Trajectory",
-    )
+    category = ("Trajectory",)
 
     ancestor = ["hdf_trajectory", "molecular_viewer"]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -51,10 +51,7 @@ class TrajectoryFilter(IJob):
 
     label = "Trajectory Filter"
 
-    category = (
-        "Analysis",
-        "Trajectory",
-    )
+    category = ("Trajectory",)
 
     ancestor = ["hdf_trajectory", "molecular_viewer"]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/UnfoldedTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/UnfoldedTrajectory.py
@@ -32,10 +32,7 @@ class UnfoldedTrajectory(IJob):
 
     enabled = False
 
-    category = (
-        "Analysis",
-        "Trajectory",
-    )
+    category = ("Trajectory",)
 
     ancestor = ["hdf_trajectory", "molecular_viewer"]
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/ConverterTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/ConverterTab.py
@@ -112,7 +112,7 @@ class ConverterTab(GeneralTab):
             session=session,
             settings=settings,
             logger=logger,
-            model=kwargs.get("model", JobTree(parent_class=Converter)),
+            model=kwargs.get("model", JobTree(parent_class=Converter, hidden_levels=1)),
             view=ActionsTree(),
             visualiser=action,
             layout=partial(
@@ -130,6 +130,7 @@ class ConverterTab(GeneralTab):
             action=action,
         )
         action.set_settings(the_tab._settings)
+        the_tab._view.expandAll()
         return the_tab
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
@@ -232,7 +232,7 @@ class JobTab(GeneralTab):
             action=action,
         )
         action.set_settings(the_tab._settings)
-        the_tab._view.expandToDepth(0)
+        the_tab._view.expand(the_tab._model.index(0, 0))
         return the_tab
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
@@ -212,7 +212,7 @@ class JobTab(GeneralTab):
             session=session,
             settings=settings,
             logger=logger,
-            model=kwargs.get("model", JobTree(filter="Analysis")),
+            model=kwargs.get("model", JobTree(filter="Converters")),
             combo_model=kwargs.get("combo_model", None),
             instrument_model=kwargs.get("instrument_model", None),
             view=ActionsTree(),
@@ -232,6 +232,7 @@ class JobTab(GeneralTab):
             action=action,
         )
         action.set_settings(the_tab._settings)
+        the_tab._view.expandToDepth(0)
         return the_tab
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobTree.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobTree.py
@@ -20,6 +20,7 @@ from collections import defaultdict
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtGui import QStandardItem, QStandardItemModel
 
+from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Jobs.IJob import IJob
 
 
@@ -36,11 +37,17 @@ class JobTree(QStandardItemModel):
     doc_string = Signal(str)
     error = Signal(str)
 
-    def __init__(self, *args, **kwargs):
-        parent_class = kwargs.pop("parent_class", IJob)
+    def __init__(
+        self,
+        *args,
+        parent_class: IJob | Converter = IJob,
+        hidden_levels: int = 0,
+        **kwargs,
+    ):
         filter = kwargs.pop("filter", None)
         super().__init__(*args, **kwargs)
 
+        self._hidden_levels = hidden_levels
         self._nodes = {}  # dict of {number: QStandardItem}
         self._docstrings = {}  # dict of {number: str}
         self._values = {}  # dict of {number: str}
@@ -72,8 +79,9 @@ class JobTree(QStandardItemModel):
 
         cat_dicts = {cat: sorted(cat_dicts[cat]) for cat in sorted(cat_dicts)}
         for cat, vals in cat_dicts.items():
-            for subcat in vals:
-                self.parentsFromCategories((cat, subcat))
+            if filter and cat not in filter:
+                for subcat in vals:
+                    self.parentsFromCategories((cat, subcat))
         for class_name in sorted_keys:
             class_object = full_dict[class_name]
             if class_object.enabled:
@@ -104,13 +112,14 @@ class JobTree(QStandardItemModel):
         except TypeError:
             pass
         if hasattr(thing, "category"):
+            trimmed_category = thing.category[self._hidden_levels :]
             if filter:
-                if filter in thing.category:
-                    parent = self.parentsFromCategories(thing.category)
+                if filter not in thing.category:
+                    parent = self.parentsFromCategories(trimmed_category)
                 else:
                     return
             else:
-                parent = self.parentsFromCategories(thing.category)
+                parent = self.parentsFromCategories(trimmed_category)
         else:
             parent = self.invisibleRootItem()
         parent.appendRow(new_node)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/ActionsTree.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/ActionsTree.py
@@ -54,12 +54,6 @@ class ActionsTree(QTreeView):
         LOG.info(f"tree: clicked on {text}")
         self.jobname_selected.emit(text)
 
-    @Slot(DataTreeItem)
-    def showValidActions(self, item: DataTreeItem):
-        LOG.info(f"Creating model from {item}")
-        new_model = ActionsHolder(item)
-        self.setModel(new_model)
-
     @Slot(QModelIndex)
     def item_picked(self, index: QModelIndex):
         model = self.model()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/ActionsTree.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/ActionsTree.py
@@ -39,7 +39,6 @@ class ActionsTree(QTreeView):
         self.click_position = None
 
         self.clicked.connect(self.on_select_action)
-        self.doubleClicked.connect(self.pop_action_dialog)
         self.clicked.connect(self.item_picked)
 
     def mousePressEvent(self, e: QMouseEvent) -> None:
@@ -54,20 +53,6 @@ class ActionsTree(QTreeView):
         text = item.text()
         LOG.info(f"tree: clicked on {text}")
         self.jobname_selected.emit(text)
-
-    def pop_action_dialog(self, index):
-        model = self.model()
-        item = model.itemFromIndex(index)
-        # debug
-        text = item.text()
-        LOG.info(f"About to execute action {text}")
-
-        number = item.data(Qt.ItemDataRole.UserRole)
-        LOG.info(f"Node number is {number}")
-        if number is None:
-            return
-        action = model._values[number]
-        self.execute_action.emit(action)
 
     @Slot(DataTreeItem)
     def showValidActions(self, item: DataTreeItem):


### PR DESCRIPTION
**Description of work**
Change the category tuples of analysis and converter jobs. This is meant to make the GUI trees easier to navigate.

closes #918 

**Fixes**
1. The "Converters" node in the converter tab is now hidden.
2. Converters are separated into "General" and "Specific".
3. The converter tree is fully expanded.
4. Analysis jobs which do not produce an .mda file are now in a "Trajectory" section, outside of "Analysis".

**To test**
Manual test of the GUI: Converter tab and analysis tab should be showing the new layout of available jobs.
