### PR TITLE
Documentation for CLI progress bars

### DIFF
--- a/Doc/pages/H_start.rst
+++ b/Doc/pages/H_start.rst
@@ -59,6 +59,22 @@ Use ``pip`` to install the MDANSE package from the specified GitHub repository:
 The MDANSE package contains all the code needed to perform trajectory conversion
 and analysis using MDANSE, but none of the visualisation tools.
 
+Optional Dependencies
+'''''''''''''''''''''
+
+If you intend to use MDANSE in the command line rather than in the GUI, you can
+include optional dependencies targeted specifically at Command Line Interface (CLI)
+users:
+
+.. code-block:: bash
+
+   pip install "MDANSE[cli]"
+
+At the moment, this is equivalent to running ``pip install MDANSE tqdm``.
+You can run MDANSE scripts in the command line independent of whether ``tqdm``
+is installed or not, but if ``tqdm`` is present, it will be used to provide
+a CLI progress bar for MDANSE jobs.
+
 Install MDANSE_GUI Package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/MDANSE/README.md
+++ b/MDANSE/README.md
@@ -72,6 +72,19 @@ pip install --upgrade pip
 ```
 and try again.
 
+### Optional dependencies
+
+Most users prefer to install [MDANSE_GUI](https://pypi.org/project/MDANSE-GUI/) alongside MDANSE,
+and use the GUI to convert, analyse and view trajectories and to visualise results.
+
+Users who prefer running MDANSE scripts in the command line can include optional dependencies
+by installing MDANSE with
+```
+pip install mdanse[cli]
+```
+This will install [tqdm](https://pypi.org/project/tqdm/), which will then be used to display
+a progress bar when an MDANSE script is running in the shell.
+
 ## Quick start: workflow
 
 The typical workflow of MDANSE:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ it directly from GitHub using pip:
 python3 -m pip install "git+https://github.com/ISISNeutronMuon/MDANSE@protos#egg=MDANSE&subdirectory=MDANSE"
 python3 -m pip install "git+https://github.com/ISISNeutronMuon/MDANSE@protos#egg=MDANSE_GUI&subdirectory=MDANSE_GUI"
 ```
+## Installation: optional dependencies
+
+If you prefer running MDANSE via scripts in the command line instead of using
+the GUI, you can install MDANSE with additional dependencies for CLI runs.
+This can be done using the command
+```
+pip install MDANSE[cli]
+```
+At the moment, the only additional package that will be added is
+``tqdm``, which will then be used to display
+progress bars for MDANSE scripts running in the shell.
 
 ## Quick start: the workflow
 


### PR DESCRIPTION
**Description of work**
MDANSE can be installed with optional dependences since #906 has been merged. This PR adds to the documentation some basic information about using the `pip install mdanse[cli]`.

closes #909 

**Fixes**
1. Text added to README.md and MDANSE_GUI/README.md
2. Text added to Doc/pages/H_start.rst

**To test**
Please check the new text for correctness and clarity.
