### PR TITLE
Add warning to interpolation order input

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
@@ -55,6 +55,7 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
         """
         if not self.update_needed(value):
             return
+        self.warning_status = ""
 
         frames_configurator = self.configurable[self.dependencies["frames"]]
         if not frames_configurator.valid:
@@ -67,21 +68,19 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
 
         IntegerConfigurator.configure(self, value)
 
-        if value == 0:
-            trajConfig = self.configurable[self.dependencies["trajectory"]]
+        trajConfig = self.configurable[self.dependencies["trajectory"]]
+        traj_has_velocities = "velocities" in trajConfig["instance"].variables()
 
-            if "velocities" not in trajConfig["instance"].variables():
+        if value == 0:
+            if not traj_has_velocities:
                 self.error_status = "the trajectory does not contain any velocities. Use an interpolation order higher than 0"
                 return
-
             self["variable"] = "velocities"
-
         elif value > 5:
             self.error_status = (
                 "Use an interpolation order greater than 5 is not implemented."
             )
             return
-
         else:
             number = frames_configurator["number"]
             if number < value + 1:
@@ -89,6 +88,12 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
                     f"Not enough MD frames to apply derivatives of order {value}"
                 )
                 return
-
             self["variable"] = "coordinates"
         self.error_status = "OK"
+        if value > 0 and traj_has_velocities:
+            self.warning_status = (
+                "Input trajectory contains velocities."
+                " There should be no need to interpolate atom positions."
+                " Set interpolation order to 0 to use the velocities"
+                " from the trajectory file."
+            )

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
@@ -69,7 +69,7 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
         IntegerConfigurator.configure(self, value)
 
         trajConfig = self.configurable[self.dependencies["trajectory"]]
-        traj_has_velocities = "velocities" in trajConfig["instance"].variables()
+        traj_has_velocities = trajConfig["instance"].has_variable("velocities")
 
         if value == 0:
             if not traj_has_velocities:

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InterpolationOrderWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/InterpolationOrderWidget.py
@@ -41,12 +41,16 @@ class InterpolationOrderWidget(WidgetBase):
         trajectory = configurator.configurable[configurator.dependencies["trajectory"]][
             "instance"
         ]
+        label = QLabel("Interpolation order", self._base)
+        self.numerator = QLabel("st order")
         if not trajectory.has_variable("velocities"):
             self._field.setMinimum(1)
             self._field.setValue(3)
-        label = QLabel("Interpolation order", self._base)
-        self.numerator = QLabel("st order")
-        self.adjust_numerator_and_update(3)
+            self.adjust_numerator_and_update(3)
+        else:
+            self._field.setMinimum(0)
+            self._field.setValue(0)
+            self.adjust_numerator_and_update(0)
 
         self._layout.addWidget(label)
         self._layout.addWidget(self._field)


### PR DESCRIPTION
**Description of work**
A warning is shown if the input trajectory contains velocities, but the interpolation order is set to a non-zero value.

closes #888 

**Fixes**
1. `InterpolationOrderConfigurator.warning_status` is set to a warning message if the input trajectory contains velocities and the interpolation order is not 0.
2. The initial text of the interpolation order input widget has been corrected to show "0th order - no interpolation" if the trajectory contains velocities.

**To test**
Load a trajectory with velocities into the GUI. Select an analysis type with interpolation order (e.g. density of states). Change interpolation order from 0 to other values and back.
The input widget should be highlighted on warning, and the warning text shown as tooltip and in the logger.
