### PR TITLE
Update AtomSelectionWidget on selection change

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -580,6 +580,7 @@ class AtomSelectionWidget(WidgetBase):
         self.update_labels()
         self.updateValue()
         self._field.setToolTip(self._tooltip_text)
+        self.selection_model.selection_changed.connect(self.updateValue)
 
     def create_helper(
         self,


### PR DESCRIPTION
**Description of work**
The minimal change preventing the user from running an analysis on an empty selection.

closes #887

**Fixes**
`SelectionModel.selection_changed` signal has been connected to `AtomSelectionWidget.updateValue`.

**To test**
Load a trajectory, pick an analysis with atom selection, and invert selection. The GUI should prevent you from running the analysis.
