### PR TITLE
Migrate to Python 3.10 officially

### DIFF
--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     if: |
       !contains( github.ref, 'legacy' )
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         # os: [ubuntu-20.04, windows-2019, macOS-11, ubuntu-latest, windows-latest, macOS-latest]
 
     if: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         # os: [ubuntu-20.04, windows-2019, macOS-11, ubuntu-latest, windows-latest, macOS-latest]
     if: |
       !contains( github.ref, 'legacy' )
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         # os: [ubuntu-20.04, windows-2019, macOS-11, ubuntu-latest, windows-latest, macOS-latest]
     if: |
       !contains( github.ref, 'legacy' )
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.os }}_python${{ matrix.python-version }}_wheel
@@ -84,4 +84,3 @@ jobs:
           name: ${{ matrix.os }}_python${{ matrix.python-version }}_GUI_wheel
           path: ./MDANSE_GUI/dist/*.whl
           retention-days: 30
-

--- a/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
+++ b/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
@@ -330,13 +330,13 @@ class ChemicalSystem:
             Filename or a file object of the trajectory.
         """
         close_on_end = False
-        if isinstance(trajectory, (Path, str)):
+        if isinstance(trajectory, Path | str):
             close_on_end = True
             source = h5py.File(trajectory)
         else:
             source = trajectory
 
-        assert isinstance(source, (h5py.File, dict))
+        assert isinstance(source, h5py.File | dict)
 
         if "composition" not in source:
             if close_on_end:

--- a/MDANSE/Src/MDANSE/Framework/AtomGrouping/grouping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomGrouping/grouping.py
@@ -16,8 +16,7 @@
 from __future__ import annotations
 
 import itertools as it
-from collections.abc import Iterable
-from typing import Callable
+from collections.abc import Callable, Iterable
 
 import numpy.typing as npt
 
@@ -280,7 +279,7 @@ def add_grouped_totals_2D(
             output_data[group_id].scaling_factor = conc
 
 
-def label_pairs(labels: Iterable[str], *, all_pairs: bool) -> list[tuple[str, str]]:
+def label_pairs(labels: Iterable[str], *, all_pairs: bool) -> Iterable[tuple[str, str]]:
     """
     Parameters
     ----------

--- a/MDANSE/Src/MDANSE/Framework/Configurators/VectorConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/VectorConfigurator.py
@@ -67,7 +67,7 @@ class VectorConfigurator(IConfigurator):
 
         self._original_input = value
 
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, list | tuple):
             self.error_status = "Invalid input type"
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Units.py
+++ b/MDANSE/Src/MDANSE/Framework/Units.py
@@ -252,7 +252,7 @@ class _Unit:
         10 V
         """
         u = copy.deepcopy(self)
-        if isinstance(other, (numbers.Number, numbers.Complex)):
+        if isinstance(other, numbers.Number | numbers.Complex):
             u._factor /= other
         elif isinstance(other, _Unit):
             u._div_by(other)
@@ -308,7 +308,7 @@ class _Unit:
         """
 
         u = copy.deepcopy(self)
-        if isinstance(other, (numbers.Number, numbers.Complex)):
+        if isinstance(other, numbers.Number | numbers.Complex):
             u._factor *= other
             return u
         elif isinstance(other, _Unit):
@@ -467,7 +467,7 @@ class _Unit:
         __div__
         """
 
-        if isinstance(other, (numbers.Number, numbers.Complex)):
+        if isinstance(other, numbers.Number | numbers.Complex):
             self._factor /= other
             return self
         elif isinstance(other, _Unit):
@@ -496,7 +496,7 @@ class _Unit:
         __mul__
         """
 
-        if isinstance(other, (numbers.Number, numbers.Complex)):
+        if isinstance(other, numbers.Number | numbers.Complex):
             self._factor *= other
             return self
         elif isinstance(other, _Unit):
@@ -542,7 +542,7 @@ class _Unit:
 
     def __rdiv__(self, other):
         u = copy.deepcopy(self)
-        if isinstance(other, (numbers.Number, numbers.Complex)):
+        if isinstance(other, numbers.Number | numbers.Complex):
             u._factor /= other
             return u
         elif isinstance(other, _Unit):
@@ -555,7 +555,7 @@ class _Unit:
         """Multiply _Unit instances.  See __mul__."""
 
         u = copy.deepcopy(self)
-        if isinstance(other, (numbers.Number, numbers.Complex)):
+        if isinstance(other, numbers.Number | numbers.Complex):
             u._factor *= other
             return u
         elif isinstance(other, _Unit):

--- a/MDANSE/Src/MDANSE/IO/IOUtils.py
+++ b/MDANSE/Src/MDANSE/IO/IOUtils.py
@@ -32,7 +32,7 @@ class MDANSEEncoder(json.JSONEncoder):
     """Custom JSON encoder to encode paths as strings."""
 
     def default(self, obj):
-        if isinstance(obj, (Path, complex)):
+        if isinstance(obj, Path | complex):
             return str(obj)
         elif isinstance(obj, np.ndarray):
             return "\n".join(map(str, obj))

--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -7,7 +7,7 @@ name = "MDANSE"
 version = "2.0.0rc2"
 description = 'MDANSE Core package - Molecular Dynamics trajectory handling and analysis code'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = ["molecular dynamics", "science", "simulation", "analysis"]
 maintainers = [

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -16,8 +16,8 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Sequence
-from typing import Any, Callable
+from collections.abc import Callable, Sequence
+from typing import Any
 
 import matplotlib.pyplot as mpl
 import numpy as np

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/TrajectoryView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/TrajectoryView.py
@@ -78,7 +78,7 @@ class TrajectoryView(QListView):
         visualiser : View3D or TrajectoryInfo
             A visualiser to connect to this view.
         """
-        if isinstance(visualiser, (View3D, TrajectoryInfo)):
+        if isinstance(visualiser, View3D | TrajectoryInfo):
             self.item_details.connect(visualiser.update_panel)
         else:
             raise NotImplementedError(

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -367,7 +367,7 @@ class Action(QWidget):
             return
         self.check_inputs()
         for widget in self._widgets:
-            if isinstance(widget, (OutputFilesWidget, OutputTrajectoryWidget)):
+            if isinstance(widget, OutputFilesWidget | OutputTrajectoryWidget):
                 widget.updateValue()
         self.allow_execution()
 

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -7,7 +7,7 @@ name = "MDANSE_GUI"
 version = "1.0.0rc2"
 description = 'MDANSE GUI package - the graphical interface for MDANSE'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = ["molecular dynamics", "science", "simulation", "analysis"]
 maintainers = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 line-length = 88
 indent-width = 4
-target-version = "py39"
+target-version = "py310"
 
 extend-exclude = [
     "MDANSE/Src/MDANSE/Framework/Jobs/RigidBodyTrajectory.py",


### PR DESCRIPTION
**Description of work**
Python 3.9 will be deprecated come October. This is the minimal set of changes to appease `ruff` and deprecate 3.9.

**Fixes**
Replace `isinstance` tuples with `|`
Move `Callable` to `collections.abc`

**To test**
Standard tests