### PR TITLE
Include atom selection in CentreOfMassesTrajectory

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -83,18 +83,24 @@ class CenterOfMassesTrajectory(IJob):
 
         self.cluster_composition = {}
         original_atom_list = chemical_system.atom_list
+        selected_indices = (
+            set(self.trajectory._selection)
+            if self.trajectory._selection
+            else set(chemical_system._atom_indices)
+        )
         new_element_list = []
         used_up_atoms = set()
         new_chemical_system = ChemicalSystem()
         for cluster_name in chemical_system._clusters.keys():
             for cluster in chemical_system._clusters[cluster_name]:
-                if cluster_name not in self.cluster_composition:
-                    self.cluster_composition[cluster_name] = [
-                        original_atom_list[ind] for ind in cluster
-                    ]
-                new_element_list.append(cluster_name)
-                used_up_atoms.update(set(cluster))
-        for index in chemical_system._atom_indices:
+                if selected_indices and set(cluster) <= selected_indices:
+                    if cluster_name not in self.cluster_composition:
+                        self.cluster_composition[cluster_name] = [
+                            original_atom_list[ind] for ind in cluster
+                        ]
+                    new_element_list.append(cluster_name)
+                    used_up_atoms.update(set(cluster))
+        for index in selected_indices:
             if index not in used_up_atoms:
                 new_element_list.append(chemical_system.atom_list[index])
         self._used_up_atoms = used_up_atoms
@@ -113,6 +119,7 @@ class CenterOfMassesTrajectory(IJob):
         self._molecule_radii = {
             cluster_name: [] for cluster_name in chemical_system._clusters.keys()
         }
+        self.selected_indices = selected_indices
 
     def run_step(self, index):
         """
@@ -142,6 +149,8 @@ class CenterOfMassesTrajectory(IJob):
         mol_index = 0
         for cluster_name in chemical_system._clusters.keys():
             for cluster in chemical_system._clusters[cluster_name]:
+                if not set(cluster).issubset(self.selected_indices):
+                    continue
                 masses = [
                     atom_database.get_atom_property(
                         chemical_system.atom_list[cluster_index], "atomic_weight"
@@ -156,7 +165,7 @@ class CenterOfMassesTrajectory(IJob):
                 average_radius = np.average(average_radius, weights=masses)
                 temp_radii[cluster_name].append(average_radius)
                 mol_index += 1
-        for atom_index in chemical_system._atom_indices:
+        for atom_index in self.selected_indices:
             if atom_index not in self._used_up_atoms:
                 com_coords[mol_index] = conf.coordinates[atom_index]
                 mol_index += 1


### PR DESCRIPTION
**Description of work**
Atom selection is one of the inputs of `CentreOfMassesTrajectory` but it is subsequently ignored in the analysis code. This PR is meant to correct this.

closes #942 

**Fixes**
1. Only include the selected atoms in the COMT analysis.
2. Only replace the molecules that have been _completely_ selected. The atoms from incompletely selected molecules are included in the output trajectory, unchanged.

**To test**
Load a trajectory containing molecules. Run COMT with atom selection and verify the results. Check that you can run further analysis on the resulting trajectory.
