### PR TITLE
Force NDTSF scaling factor to be real

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
@@ -410,10 +410,10 @@ class NeutronDynamicTotalStructureFactor(IJob):
             bi = self.trajectory.get_atom_property(ele_i, "b_incoherent")
             self._outputData[f"ndsf/f(q,t)_inc/{label}"].scaling_factor *= (
                 bi**2 * number * norm_natoms
-            )
+            ).real
             self._outputData[f"ndsf/s(q,f)_inc/{label}"].scaling_factor *= (
                 bi**2 * number * norm_natoms
-            )
+            ).real
             self._outputData["ndsf/f(q,t)_inc/total"][:] += (
                 self._outputData[f"ndsf/f(q,t)_inc/{label}"][:]
                 * self._outputData[f"ndsf/f(q,t)_inc/{label}"].scaling_factor

--- a/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
@@ -385,10 +385,10 @@ class NeutronDynamicTotalStructureFactor(IJob):
             pre_fac = 1 if label_i == label_j else 2
             self._outputData[f"ndsf/f(q,t)_coh/{pair_str}"].scaling_factor *= (
                 pre_fac * bi * bj * sqrt_cij
-            )
+            ).real
             self._outputData[f"ndsf/s(q,f)_coh/{pair_str}"].scaling_factor *= (
                 pre_fac * bi * bj * sqrt_cij
-            )
+            ).real
 
             self._outputData["ndsf/f(q,t)_coh/total"][:] += (
                 self._outputData[f"ndsf/f(q,t)_coh/{pair_str}"][:]


### PR DESCRIPTION
**Description of work**
Explicitly use only the `real` part of the scaling factors in NeutronDynamicTotalStructureFactor analysis.

closes #956 

**Fixes**
1. Added `.real` to all the neutron-related scaling factors in the NDTSF `finalize()` method.

**To test**
Unit tests should pass.
Try any trajectory with C, H, N, O, P, S, Na, Cl elements. The NDTSF calculation should fail on the main branch and finish without error on this branch.
This https://www.ccpbiosim.ac.uk/slim-md/slimmd-database/protein-membrane/beta2-receptor-in-the-empty-form-40-ns or similar trajectories should be useful for triggering the error. (For the record, I removed water from the trajectory first using TrajectoryEditor, and only then ran the DCSF+DISF calculations.)
