### PR TITLE
Fix IIR filter trajectory power spectrum graph

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -1192,7 +1192,7 @@ class FilterDesigner(QDialog):
         )
 
         if self.current_filter_units() == Filter.FrequencyUnits.CYCLIC:
-            freqs /= (2*np.pi)
+            freqs /= 2 * np.pi
 
         return (freqs, normalised, normalised * attenuation(freqs))
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -1170,22 +1170,19 @@ class FilterDesigner(QDialog):
         response = tr_filter.freq_response
 
         # Trajectory power spectrum data
-        raw_power_spectrum = copy.deepcopy(self._trajectory_power_spectrum)
-        raw_power_spectrum_freqs, raw_power_spectrum_values = raw_power_spectrum
+        freqs, values = copy.deepcopy(self._trajectory_power_spectrum)
 
-        # Resample trajectory power spectrum energies (x-axis) and convert to frequency domain
-        power_spectrum_freqs = np.linspace(
-            raw_power_spectrum_freqs.min(),
-            raw_power_spectrum_freqs.max(),
+        # Resample trajectory power spectrum energies (x-axis) and convert to frequency domain, setting
+        # custom frequency range on filter object
+        tr_filter.custom_freq_range = np.linspace(
+            freqs.min(),
+            freqs.max(),
             len(response.frequencies),
         )
-
-        # Set custom frequency range on filter object
-        tr_filter.custom_freq_range = power_spectrum_freqs
         tr_filter.freq_response = (tr_filter.coeffs, Filter.FrequencyRangeMethod.CUSTOM)
 
-        # Resample and normalise trajectory power spectrum (y-axis)
-        ps = raw_power_spectrum_values / np.max(raw_power_spectrum_values)
+        # Normalise trajectory power spectrum (y-axis)
+        normalised = values / np.max(values)
 
         attenuation = interp1d(
             tr_filter.freq_response.frequencies,
@@ -1193,10 +1190,11 @@ class FilterDesigner(QDialog):
             fill_value=0.0,
             bounds_error=False,
         )
-        # Compute power spectral attenuation due to filter (multiplicative)
-        attenuated_ps = ps * attenuation(raw_power_spectrum_freqs)
 
-        return (raw_power_spectrum_freqs, ps, attenuated_ps)
+        if self.current_filter_units() == Filter.FrequencyUnits.CYCLIC:
+            freqs /= (2*np.pi)
+
+        return (freqs, normalised, normalised * attenuation(freqs))
 
     def create_settings_layout(self, widget_area: QVBoxLayout) -> None:
         """Create the filter settings vertical layout.


### PR DESCRIPTION
**Description of work**
This is a fix for the filter designer issue described in #955, where the graphs for IIR filter (Notch, Peak, Comb) appear distorted and do not line up with the frequency axis.

Additionally, the code inside `set_trajectory_power_spectrum` method has been tidied up a little - some function calls have been inlined, and variable names simplified for clarity.

**Fixes**
Closes #955

Fixed by applying a conversion factor of 1/2pi to the trajectory power spectrum frequency axis if the filter is IIR (and therefore uses THz instead of rad/ps for display).

**To test**
Run standard unit tests