### PR TITLE
Complex weight fix: average q and -q

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -300,7 +300,7 @@ class DensityOfStates(IJob):
         if self.configuration["weights"]["property"] in ("b_coherent", "b_incoherent"):
             for weights in selected_weights, all_weights:
                 for key, value in weights.items():
-                    weights[key] = value**2
+                    weights[key] = abs(value)**2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DensityOfStates.py
@@ -300,7 +300,7 @@ class DensityOfStates(IJob):
         if self.configuration["weights"]["property"] in ("b_coherent", "b_incoherent"):
             for weights in selected_weights, all_weights:
                 for key, value in weights.items():
-                    weights[key] = abs(value)**2
+                    weights[key] = abs(value) ** 2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -278,7 +278,7 @@ class DynamicIncoherentStructureFactor(IJob):
         )
         for weights in selected_weights, all_weights:
             for key, value in weights.items():
-                weights[key] = value**2
+                weights[key] = abs(value)**2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -278,7 +278,7 @@ class DynamicIncoherentStructureFactor(IJob):
         )
         for weights in selected_weights, all_weights:
             for key, value in weights.items():
-                weights[key] = abs(value)**2
+                weights[key] = abs(value) ** 2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -211,7 +211,7 @@ class ElasticIncoherentStructureFactor(IJob):
         )
         for weights in selected_weights, all_weights:
             for key, value in weights.items():
-                weights[key] = value**2
+                weights[key] = abs(value)**2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -211,7 +211,7 @@ class ElasticIncoherentStructureFactor(IJob):
         )
         for weights in selected_weights, all_weights:
             for key, value in weights.items():
-                weights[key] = abs(value)**2
+                weights[key] = abs(value) ** 2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -310,7 +310,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         )
         for weights in selected_weights, all_weights:
             for key, value in weights.items():
-                weights[key] = value**2
+                weights[key] = abs(value)**2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -310,7 +310,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         )
         for weights in selected_weights, all_weights:
             for key, value in weights.items():
-                weights[key] = abs(value)**2
+                weights[key] = abs(value) ** 2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
@@ -384,11 +384,11 @@ class NeutronDynamicTotalStructureFactor(IJob):
             )
             pre_fac = 1 if label_i == label_j else 2
             self._outputData[f"ndsf/f(q,t)_coh/{pair_str}"].scaling_factor *= (
-                pre_fac * bi * bj * sqrt_cij
-            )
+                pre_fac * bi.conjugate() * bj * sqrt_cij
+            ).real
             self._outputData[f"ndsf/s(q,f)_coh/{pair_str}"].scaling_factor *= (
-                pre_fac * bi * bj * sqrt_cij
-            )
+                pre_fac * bi.conjugate() * bj * sqrt_cij
+            ).real
 
             self._outputData["ndsf/f(q,t)_coh/total"][:] += (
                 self._outputData[f"ndsf/f(q,t)_coh/{pair_str}"][:]
@@ -409,10 +409,10 @@ class NeutronDynamicTotalStructureFactor(IJob):
             ele_i = self.trajectory.element_from_label[label]
             bi = self.trajectory.get_atom_property(ele_i, "b_incoherent")
             self._outputData[f"ndsf/f(q,t)_inc/{label}"].scaling_factor *= (
-                bi**2 * number * norm_natoms
+                abs(bi)**2 * number * norm_natoms
             )
             self._outputData[f"ndsf/s(q,f)_inc/{label}"].scaling_factor *= (
-                bi**2 * number * norm_natoms
+                abs(bi)**2 * number * norm_natoms
             )
             self._outputData["ndsf/f(q,t)_inc/total"][:] += (
                 self._outputData[f"ndsf/f(q,t)_inc/{label}"][:]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/NeutronDynamicTotalStructureFactor.py
@@ -409,10 +409,10 @@ class NeutronDynamicTotalStructureFactor(IJob):
             ele_i = self.trajectory.element_from_label[label]
             bi = self.trajectory.get_atom_property(ele_i, "b_incoherent")
             self._outputData[f"ndsf/f(q,t)_inc/{label}"].scaling_factor *= (
-                abs(bi)**2 * number * norm_natoms
+                abs(bi) ** 2 * number * norm_natoms
             )
             self._outputData[f"ndsf/s(q,f)_inc/{label}"].scaling_factor *= (
-                abs(bi)**2 * number * norm_natoms
+                abs(bi) ** 2 * number * norm_natoms
             )
             self._outputData["ndsf/f(q,t)_inc/total"][:] += (
                 self._outputData[f"ndsf/f(q,t)_inc/{label}"][:]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -180,7 +180,7 @@ class PositionAutoCorrelationFunction(IJob):
         if self.configuration["weights"]["property"] in ("b_coherent", "b_incoherent"):
             for weights in selected_weights, all_weights:
                 for key, value in weights.items():
-                    weights[key] = abs(value)**2
+                    weights[key] = abs(value) ** 2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionAutoCorrelationFunction.py
@@ -180,7 +180,7 @@ class PositionAutoCorrelationFunction(IJob):
         if self.configuration["weights"]["property"] in ("b_coherent", "b_incoherent"):
             for weights in selected_weights, all_weights:
                 for key, value in weights.items():
-                    weights[key] = value**2
+                    weights[key] = abs(value)**2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
@@ -285,7 +285,7 @@ class PositionPowerSpectrum(IJob):
         if self.configuration["weights"]["property"] in ("b_coherent", "b_incoherent"):
             for weights in selected_weights, all_weights:
                 for key, value in weights.items():
-                    weights[key] = value**2
+                    weights[key] = abs(value)**2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionPowerSpectrum.py
@@ -285,7 +285,7 @@ class PositionPowerSpectrum(IJob):
         if self.configuration["weights"]["property"] in ("b_coherent", "b_incoherent"):
             for weights in selected_weights, all_weights:
                 for key, value in weights.items():
-                    weights[key] = abs(value)**2
+                    weights[key] = abs(value) ** 2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
@@ -323,7 +323,7 @@ class VanHoveFunctionSelf(IJob):
         )
         for weights in selected_weights, all_weights:
             for key, value in weights.items():
-                weights[key] = value**2
+                weights[key] = abs(value)**2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
@@ -323,7 +323,7 @@ class VanHoveFunctionSelf(IJob):
         )
         for weights in selected_weights, all_weights:
             for key, value in weights.items():
-                weights[key] = abs(value)**2
+                weights[key] = abs(value) ** 2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -214,7 +214,7 @@ class VelocityAutoCorrelationFunction(IJob):
         if self.configuration["weights"]["property"] in ("b_coherent", "b_incoherent"):
             for weights in selected_weights, all_weights:
                 for key, value in weights.items():
-                    weights[key] = abs(value)**2
+                    weights[key] = abs(value) ** 2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityAutoCorrelationFunction.py
@@ -214,7 +214,7 @@ class VelocityAutoCorrelationFunction(IJob):
         if self.configuration["weights"]["property"] in ("b_coherent", "b_incoherent"):
             for weights in selected_weights, all_weights:
                 for key, value in weights.items():
-                    weights[key] = value**2
+                    weights[key] = abs(value)**2
         weight_dict = get_weights(
             selected_weights,
             all_weights,

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -62,7 +62,11 @@ def get_weights(
     )
     _, normFactor = adjust_weights(all_props, all_contents, n_atms, dim, conc_exp)
 
-    normalise = abs(normFactor) > 0.0  # if normFactor is 0, all weights are 0 too.
+    try:
+        # skip normalisation if weights are q-dependent e.g. x-ray SSF
+        len(normFactor)
+    except TypeError:
+        normalise = abs(normFactor) > 0.0  # if normFactor is 0, all weights are 0 too.
     if normalise:
         for k in weights:
             weights[k] /= normFactor

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -62,8 +62,8 @@ def get_weights(
     )
     _, normFactor = adjust_weights(all_props, all_contents, n_atms, dim, conc_exp)
 
+    normalise = True
     try:
-        # skip normalisation if weights are q-dependent e.g. x-ray SSF
         len(normFactor)
     except TypeError:
         normalise = abs(normFactor) > 0.0  # if normFactor is 0, all weights are 0 too.

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -105,11 +105,11 @@ def adjust_weights(
     weights = {}
 
     if dim == 1:
-        for el in props.keys():
+        for el in props:
             atom_conc_product = contents[el] / n_atms
             property_product = props[el]
             factor = atom_conc_product**conc_exp * property_product
-            weights[el] = factor
+            weights[(el, )] = factor
             normFactor += atom_conc_product * property_product
     elif dim == 2:
         cartesianProduct = itertools.product(props, repeat=2)

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -109,9 +109,8 @@ def adjust_weights(
     weights = {}
 
     if dim == 1:
-        for el in props:
+        for el, property_product in props.items():
             atom_conc_product = contents[el] / n_atms
-            property_product = props[el]
             factor = atom_conc_product**conc_exp * property_product
             weights[(el,)] = factor
             normFactor += atom_conc_product * property_product

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -109,7 +109,7 @@ def adjust_weights(
             atom_conc_product = contents[el] / n_atms
             property_product = props[el]
             factor = atom_conc_product**conc_exp * property_product
-            weights[(el, )] = factor
+            weights[(el,)] = factor
             normFactor += atom_conc_product * property_product
     elif dim == 2:
         cartesianProduct = itertools.product(props, repeat=2)

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -108,13 +108,13 @@ def adjust_weights(
         for el in props:
             atom_conc_product = contents[el] / n_atms
             property_product = props[el]
-            factor = atom_conc_product ** conc_exp * property_product
+            factor = atom_conc_product**conc_exp * property_product
             weights[el] = factor
             normFactor += atom_conc_product * property_product
     elif dim == 2:
         cartesianProduct = itertools.product(props, repeat=2)
         for el_a, el_b in cartesianProduct:
-            atom_conc_product = contents[el_a] * contents[el_b]  / n_atms**2
+            atom_conc_product = contents[el_a] * contents[el_b] / n_atms**2
             property_product = props[el_a].conjugate() * props[el_b]
 
             factor = atom_conc_product**conc_exp * property_product

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -105,7 +105,7 @@ def adjust_weights(
     weights = {}
 
     if dim == 1:
-        for el in props:
+        for el in props.keys():
             atom_conc_product = contents[el] / n_atms
             property_product = props[el]
             factor = atom_conc_product**conc_exp * property_product

--- a/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Arithmetic.py
@@ -23,13 +23,13 @@ import numpy as np
 
 
 def get_weights(
-    selected_props: dict[str, float],
-    all_props: dict[str, float],
+    selected_props: dict[str, float | complex],
+    all_props: dict[str, float | complex],
     selected_contents: dict[str, int],
     all_contents: dict[str, int],
     dim: int,
     conc_exp: float = 1.0,
-) -> dict[str, float]:
+) -> dict[str, float | complex]:
     """Calculate the scaling factors to be applied to output datasets.
 
     Returns a dictionary of scaling factors, where the
@@ -62,27 +62,22 @@ def get_weights(
     )
     _, normFactor = adjust_weights(all_props, all_contents, n_atms, dim, conc_exp)
 
-    normalise = True
-    try:
-        len(normFactor)
-    except TypeError:
-        normalise = abs(normFactor) > 0.0  # if normFactor is 0, all weights are 0 too.
+    normalise = abs(normFactor) > 0.0  # if normFactor is 0, all weights are 0 too.
     if normalise:
         for k in weights:
-            weights[k] /= np.float64(normFactor)
-
+            weights[k] /= normFactor
     weights["sum"] = normFactor
 
     return weights
 
 
 def adjust_weights(
-    props: dict[str, float],
+    props: dict[str, float | complex],
     contents: dict[str, int],
     n_atms: int,
     dim: int,
     conc_exp: float = 1.0,
-) -> tuple[dict[str | tuple[str], float], float]:
+) -> tuple[dict[str | tuple[str], float | complex], float]:
     """Combine the weights based on whether they will be used for nth-body
     property and adjust them based on their atom concentrations.
 
@@ -109,24 +104,34 @@ def adjust_weights(
 
     weights = {}
 
-    cartesianProduct = itertools.product(props, repeat=dim)
-    for elements in cartesianProduct:
-        atom_conc_product = np.prod([contents[el] / n_atms for el in elements])
-        property_product = np.prod(np.array([props[el] for el in elements]), axis=0)
+    if dim == 1:
+        for el in props:
+            atom_conc_product = contents[el] / n_atms
+            property_product = props[el]
+            factor = atom_conc_product ** conc_exp * property_product
+            weights[el] = factor
+            normFactor += atom_conc_product * property_product
+    elif dim == 2:
+        cartesianProduct = itertools.product(props, repeat=2)
+        for el_a, el_b in cartesianProduct:
+            atom_conc_product = contents[el_a] * contents[el_b]  / n_atms**2
+            property_product = props[el_a].conjugate() * props[el_b]
 
-        factor = atom_conc_product**conc_exp * property_product
-        # E.g. for property b_coh, 5 Cu atoms, 100 total atoms, and dim=2
-        # factor = (5*5/(100*100))**conc_exp * b_coh(Cu)*b_coh(Cu)
+            factor = atom_conc_product**conc_exp * property_product
+            # E.g. for property b_coh, 5 Cu atoms, 100 total atoms, and dim=2
+            # factor = (5*5/(100*100))**conc_exp * b_coh_cu.conjugate() * b_coh_cu
 
-        weights[elements] = np.float64(np.copy(factor))
-        normFactor += atom_conc_product * property_product
+            weights[(el_a, el_b)] = factor
+            normFactor += atom_conc_product * property_product
+    else:
+        raise NotImplementedError(f"Dimension {dim} not implemented.")
 
-    return weights, normFactor
+    return weights, abs(normFactor.real)
 
 
 def assign_weights(
     values: dict[str, np.ndarray],
-    weights: dict[str, float],
+    weights: dict[str, float | complex],
     match_key: str,
     match_labels: Iterable[tuple[str, tuple[str, ...]]],
     symmetric: bool = True,
@@ -157,9 +162,9 @@ def assign_weights(
     for k in values.keys() & matches:
         if symmetric:
             permutations = set(itertools.permutations(matches[k], r=len(matches[k])))
-            w = sum(weights[p] for p in permutations)
+            w = sum(weights[p].real for p in permutations)
         else:
-            w = weights[matches[k]]
+            w = weights[matches[k]].real
 
         values[k].scaling_factor *= w
 

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -268,7 +268,7 @@ class Trajectory:
         self,
         *,
         prop: str | None = None,
-    ) -> tuple[dict[str, float], dict[str, float]]:
+    ) -> tuple[dict[str, float | complex], dict[str, float | complex]]:
         """Generate a dictionary of weights.
 
         Parameters


### PR DESCRIPTION
**Description of work**
Fixes the complex weight by applying,

```math
\tilde{F}_{AB}(q,t) = \frac{1}{2}(F_{AB}(q,t) + F_{AB}(-q,t)) = \frac{2}{N\sqrt{c_{A}c_{B}}} \mathrm{Re} \left\{\beta_{A}^{*}\beta_{B} \right\}  \mathrm{Re} \left\{ C_{AB}(q,t) \right\}
```

note that for single dimension results e.g. DOS the complex components of the weight are dropped unless it is squared which can happen when the b_coh or b_inc is used.

**Derivation of above**
In the theory of simple liquids, equation 7.1.9 for a generation correlation function $C_{AB}(t)$

```math
C_{AB}(t) = \epsilon_{A}\epsilon_{B}C_{AB}(-t) = \epsilon_{A}\epsilon_{B}C_{BA}^{*}(t)
```
where $\epsilon_{A}$ and $\epsilon_{B}$ are the time-reversal signatures of $A$ and can be +1 or -1. So that for DCSF and related

```math
C_{AB}(q,t) = C_{AB}(q,-t) = C_{BA}^{*}(q,t)
```

since $A$ and $B$ will have the same sign for their time-reversal signatures. Also

```math
C_{AB}(-q, t) = C_{AB}^{*}(q, t) = C_{BA}(q, t).
```

We need to calculate

```math
F_{AB}(q,t) =  \frac{1}{N\sqrt{c_{A}c_{B}}} \left[ \beta_{A}^{*}\beta_{B} C_{AB}(q,t)+ \beta_{B}^{*}\beta_{A}C_{BA}(q,t) \right]
```

using the above expressions we should find that

```math
\tilde{F}_{AB}(q,t) = \frac{1}{2}(F_{AB}(q,t) + F_{AB}(-q,t)) = \frac{2}{N\sqrt{c_{A}c_{B}}} \mathrm{Re} \left\{\beta_{A}^{*}\beta_{B} \right\}  \mathrm{Re} \left\{ C_{AB}(q,t) \right\}
```

so that this fix means that whenever a $q$-vector is generated with a value $q$, the results returned by MDANSE will be averaged over $q$ and $-q$.

**Test Calculations**
Here is a comparison between 
```math
F_{AB}(q,t) =  \frac{1}{N\sqrt{c_{A}c_{B}}} \mathrm{Re}\left[ \beta_{A}^{*}\beta_{B} C_{AB}(q,t)\right]
```

and

```math
\tilde{F}_{AB}(q,t) = \frac{1}{2}(F_{AB}(q,t) + F_{AB}(-q,t)) = \frac{2}{N\sqrt{c_{A}c_{B}}} \mathrm{Re} \left\{\beta_{A}^{*}\beta_{B} \right\}  \mathrm{Re} \left\{ C_{AB}(q,t) \right\}
```
using croco MD with the following atom types

<img width="535" height="38" alt="image" src="https://github.com/user-attachments/assets/a9f20100-3182-40c3-80cd-1c13043d8a52" />
<img width="557" height="37" alt="image" src="https://github.com/user-attachments/assets/d9d5cc4f-dba2-441a-acd8-7b2bf57293e3" />
<img width="544" height="39" alt="image" src="https://github.com/user-attachments/assets/783e6e9b-9639-4425-9cd3-e4f1e52a270d" />

For a small q-vectors, results can be a bit different. Here is "/dcsf/f(q,t)/C (copy)O (copy)" with 10 q-vectors and with $|q|=20$ and seed=1 (blue is the first equation)

<img width="580" height="424" alt="image" src="https://github.com/user-attachments/assets/8e898a39-bbd6-45be-87b1-51819ce09019" />

here is 100

<img width="596" height="418" alt="image" src="https://github.com/user-attachments/assets/9acc02a6-7203-4dc8-85eb-e32763776b01" />

they are the same because I'm using lattice q-vectors and have sampled q and -q.

Here I do it again with $|q|=40$ and 10 q-vectors,
<img width="503" height="434" alt="image" src="https://github.com/user-attachments/assets/22d5abdd-d5a2-4fee-b3ec-0b0972b68779" />


and 100 q-vectors

<img width="586" height="429" alt="image" src="https://github.com/user-attachments/assets/513879f7-9892-451b-bcc0-e5bb120b2e22" />


Basically, if we go for this correction, then the user might need to increase the number of q-vectors they use. Also, if we ever decide to allow the user to plot s(q,w) in terms of q_x, q_y, q_z, and w, we might need to take another look at this again since s(q,w) will be averaged over $q$ and $-q$.

**Fixes**
Fixes #956

**To test**
Run DCSF, DISF, and NDTSF and check results are consistent.
