### PR TITLE
Update docs so that complex scattering lengths are used

### DIFF
--- a/Doc/pages/atom_selection.rst
+++ b/Doc/pages/atom_selection.rst
@@ -182,12 +182,18 @@ with selection is
 .. math::
    :label: selection1
 
-   F_{\text{coh},\alpha\beta}{(\mathbf{q},t) =  \frac{1}{N \sqrt{c_{\alpha\, \cap\, s}c_{\beta\, \cap\, s}}}}{\sum\limits_{j \in (\alpha\, \cap\, s)}{\sum\limits_{k \in (\beta\, \cap\, s)} \left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle}},
+   F_{\text{coh},\alpha\beta}(\mathbf{q},t) =  \frac{1}{N \sqrt{c_{\alpha\, \cap\, s}c_{\beta\, \cap\, s}}} \sum\limits_{j \in (\alpha\, \cap\, s)} \sum\limits_{k \in (\beta\, \cap\, s)} \mathrm{Re}\left[ F_{jk}{(\mathbf{q},t)} \right]
 
 .. math::
    :label: selection2
 
-   F_{\text{inc},\alpha}{(\mathbf{q},t ) = \frac{1}{N c_{\alpha\, \cap\, s}}}{\sum\limits_{j \in (\alpha\, \cap\, s)} \left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{j}\left( t \right)} \right\rbrack} \right\rangle}
+   F_{\text{inc},\alpha}(\mathbf{q},t ) = \frac{1}{N c_{\alpha\, \cap\, s}} \sum\limits_{j \in (\alpha\, \cap\, s)} \mathrm{Re}\left[ F_{jj}{(\mathbf{q},t)} \right]
+
+.. math::
+   :label: atompartial2_1
+
+   F_{jk}{(\mathbf{q},t) = \left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle}
+
 
 where :math:`N` is the total number of all atoms,
 :math:`c_{\alpha\, \cap\, s} = N_{\alpha\, \cap\, s} / N`, and :math:`N_{\alpha\, \cap\, s}`
@@ -197,14 +203,14 @@ the DCSF and DISF weights are
 .. math::
    :label: selection4
 
-   W_{\alpha\beta} = \left[2 - \delta_{\alpha\beta}\right]\frac{\sqrt{c_{\alpha\, \cap\, s}c_{\beta\, \cap\, s}} b_{\mathrm{coh},\alpha}b_{\mathrm{coh},\beta}}{\sum_{\gamma\delta} c_{\gamma}c_{\delta}  b_{\mathrm{coh},\gamma}b_{\mathrm{coh},\delta}}
+   W_{\alpha\beta} = \left[2 - \delta_{\alpha\beta}\right]\frac{\sqrt{c_{\alpha\, \cap\, s}c_{\beta\, \cap\, s}}\ \mathrm{Re} \left[ b_{\mathrm{coh},\alpha}^{\dagger}b_{\mathrm{coh},\beta}\right]}{\sum_{\gamma\delta} c_{\gamma}c_{\delta}  b_{\mathrm{coh},\gamma}^{\dagger}b_{\mathrm{coh},\delta}}
 
 and
 
 .. math::
    :label: selection5
 
-   W_{\alpha} = \frac{c_{\alpha\, \cap\, s} b_{\mathrm{inc},\alpha}^2}{\sum_{\gamma} c_{\gamma} b_{\mathrm{inc},\gamma}^2}
+   W_{\alpha} = \frac{c_{\alpha\, \cap\, s} \vert b_{\mathrm{inc},\alpha} \vert^2}{\sum_{\gamma} c_{\gamma} \vert b_{\mathrm{inc},\gamma} \vert^2}
 
 so that the normalisation factors on the weights do not depend on the selection.
 The total DCSF and DISF results are a weighted sum of the partial terms

--- a/Doc/pages/grouping.rst
+++ b/Doc/pages/grouping.rst
@@ -21,7 +21,12 @@ intermediate scattering functions is
 .. math::
    :label: atompartial1
 
-   F_{\text{coh},\text{CH}}{(\mathbf{q},t) =  \frac{1}{N \sqrt{c_{\text{C}}c_{\text{H}}}}}{\sum\limits_{j \in \text{C}}{\sum\limits_{k \in \text{H}}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle}},
+   F_{\text{coh},\text{CH}}(\mathbf{q},t) =  \frac{1}{N \sqrt{c_{\text{C}}c_{\text{H}}}} \sum\limits_{j \in \text{C}} \sum\limits_{k \in \text{H}} \mathrm{Re}\left[F_{jk}(\mathbf{q},t)\right],
+
+.. math::
+   :label: atompartial1_1
+
+   F_{jk}{(\mathbf{q},t) = \left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle}
 
 so the summations run over all carbon and hydrogen atoms in the system.
 The total is a weighted sum of all partial components
@@ -39,7 +44,7 @@ intermediate scattering functions is
 .. math::
    :label: atompartial3
 
-   F_{\text{inc},\text{C}}{(\mathbf{q},t ) = \frac{1}{Nc_{\text{C}}}}{\sum\limits_{j \in \text{C}}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{j}\left( t \right)} \right\rbrack} \right\rangle}
+   F_{\text{inc},\text{C}}(\mathbf{q},t ) = \frac{1}{Nc_{\text{C}}} \sum\limits_{j \in \text{C}} \mathrm{Re}\left[F_{jj}(\mathbf{q},t)\right]
 
 so the summation run over all carbon atoms and the total is a weight sum
 of all partial components
@@ -67,7 +72,7 @@ partial coherent intermediate scattering function is
 .. math::
    :label: moleculepartial1
 
-   F_{\text{coh},\text{HO}}^{[\text{EtOH}][\text{H2O}]}{(\mathbf{q},t) =  \frac{1}{N \sqrt{c_{\text{H}}^{\text{EtOH}}c_{\text{O}}^{\text{H2O}}}}}{\sum\limits_{j \in (\text{EtOH}\, \cap\, \text{H})}{\sum\limits_{k \in (\text{H2O}\, \cap\, \text{O})}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle}},
+   F_{\text{coh},\text{HO}}^{[\text{EtOH}][\text{H2O}]}{(\mathbf{q},t) =  \frac{1}{N \sqrt{c_{\text{H}}^{\text{EtOH}}c_{\text{O}}^{\text{H2O}}}}} \sum\limits_{j \in (\text{EtOH}\, \cap\, \text{H})} \sum\limits_{k \in (\text{H2O}\, \cap\, \text{O})} \mathrm{Re}\left[F_{jk}(\mathbf{q},t)\right]
 
 where :math:`c_{\text{H}}^{\text{EtOH}} = N_{\text{H}}^{\text{EtOH}} / N` and
 :math:`c_{\text{O}}^{\text{H2O}} = N_{\text{O}}^{\text{H2O}} / N`. Here,
@@ -91,7 +96,7 @@ water respectively. For coherent scattering lengths
 .. math::
    :label: moleculepartial3
 
-   W_{\text{HO}}^{[\text{EtOH}][\text{H2O}]} = 2\frac{\sqrt{c_{\text{H}}^{\text{EtOH}}c_{\text{O}}^{\text{H2O}}} b_{\mathrm{coh},\text{H}}b_{\mathrm{coh},\text{O}}}{c_{\text{C}}^{\text{EtOH}}c_{\text{C}}^{\text{EtOH}}  b_{\mathrm{coh},\text{C}}b_{\mathrm{coh},\text{C}} + \cdots}.
+   W_{\text{HO}}^{[\text{EtOH}][\text{H2O}]} = 2\frac{\sqrt{c_{\text{H}}^{\text{EtOH}}c_{\text{O}}^{\text{H2O}}} \ \mathrm{Re} \left[ b_{\mathrm{coh},\text{H}}^{\dagger} b_{\mathrm{coh},\text{O}}\right] }{c_{\text{C}}^{\text{EtOH}}c_{\text{C}}^{\text{EtOH}}  b_{\mathrm{coh},\text{C}}^{\dagger} b_{\mathrm{coh},\text{C}} + \cdots}.
 
 The total coherent intermediate scattering functions
 is a weighted sum of all molecular terms
@@ -113,7 +118,7 @@ carbon atoms is
 .. math::
    :label: moleculepartial5
 
-   F_{\text{inc},\text{C}}^{\text{EtOH}}{(\mathbf{q},t ) = \frac{1}{Nc_{\text{C}}^{\text{EtOH}}}}{\sum\limits_{j \in (\text{EtOH}\, \cap \, \text{C})}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{j}\left( t \right)} \right\rbrack} \right\rangle},
+   F_{\text{inc},\text{C}}^{\text{EtOH}}(\mathbf{q},t ) = \frac{1}{Nc_{\text{C}}^{\text{EtOH}}} \sum\limits_{j \in (\text{EtOH}\, \cap \, \text{C})} \mathrm{Re}\left[F_{jj}(\mathbf{q},t)\right]
 
 and the molecular incoherent intermediate scattering functions for ethanol
 is
@@ -128,7 +133,7 @@ with incoherent scattering length weights of
 .. math::
    :label: moleculepartial7
 
-   W_{\text{C}}^{\text{EtOH}} = \frac{c_{\text{C}}^{\text{EtOH}}b_{\text{inc},\text{C}}^{2}}{c_{\text{C}}^{\text{EtOH}}b_{\text{inc},\text{C}}^{2} + \cdots}.
+   W_{\text{C}}^{\text{EtOH}} = \frac{c_{\text{C}}^{\text{EtOH}}\vert b_{\text{inc},\text{C}} \vert^{2}}{c_{\text{C}}^{\text{EtOH}}\vert b_{\text{inc},\text{C}} \vert^{2} + \cdots}.
 
 The total incoherent intermediate scattering functions
 is a weighted sum of all molecular terms

--- a/Doc/pages/notation.rst
+++ b/Doc/pages/notation.rst
@@ -9,6 +9,7 @@ Symbols and Notation
 :math:`\alpha, \beta, \gamma, \ldots`                   atom types
 :math:`j, k, l, \ldots`                                 atom indices
 :math:`b_{\mathrm{coh},\alpha}`                         the coherent scattering length of atom-types :math:`\alpha`
+:math:`b_{\mathrm{coh},\alpha}^{\dagger}`               the complex conjugate of the coherent scattering length of atom-types :math:`\alpha`
 :math:`b_{\mathrm{inc},\alpha}^{2}`                     the squared incoherent scattering length of atom-types :math:`\alpha`
 :math:`c_{\alpha}`                                      concentration of atom-type :math:`\alpha` where :math:`c_{\alpha} = N_{\alpha} / N`
 :math:`C_{\mathbf{vv}jj}(t)`                            the velocity autocorrelation function of particle :math:`j`

--- a/Doc/pages/scattering.rst
+++ b/Doc/pages/scattering.rst
@@ -508,7 +508,7 @@ In this analysis the total incoherent, total coherent and total
 .. math::
    :label: ndtsf2
    
-   F_{\mathrm{coh}}(\mathbf{q},t) = \sum_{\alpha\beta} \sqrt{c_{\alpha}c_{\beta}}\ \mathrm{Re} \left[ b_{\text{coh},\alpha}b_{\text{coh},\beta} \right] F_{\mathrm{coh},\alpha\beta}(\mathbf{q},t),
+   F_{\mathrm{coh}}(\mathbf{q},t) = \sum_{\alpha\beta} \sqrt{c_{\alpha}c_{\beta}}\ \mathrm{Re} \left[ b_{\text{coh},\alpha}^{\dagger}b_{\text{coh},\beta} \right] F_{\mathrm{coh},\alpha\beta}(\mathbf{q},t),
 
 .. math::
    :label: ndtsf3

--- a/Doc/pages/scattering.rst
+++ b/Doc/pages/scattering.rst
@@ -139,12 +139,12 @@ treatments for coherent and incoherent scattering lengths
 .. math::
    :label: scattering9
 
-   {\text{F}_{\text{coh}}{\left( {q,t} \right) = \frac{1}{N}}{\sum\limits_{jk}b_{\mathrm{coh},j}}b_{\mathrm{coh},k}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\hat{\mathbf{r}}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\hat{\mathbf{r}}_{k}\left( t \right)} \right\rbrack} \right\rangle,}
+   {\text{F}_{\text{coh}}{\left( {q,t} \right) = \frac{1}{N}}{\sum\limits_{jk}b_{\mathrm{coh},j}^{\dagger}}b_{\mathrm{coh},k}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\hat{\mathbf{r}}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\hat{\mathbf{r}}_{k}\left( t \right)} \right\rbrack} \right\rangle,}
 
 .. math::
    :label: scattering10
 
-   {\text{F}_{\text{inc}}{\left( {q,t} \right) = \frac{1}{N}}{\sum\limits_{j}{b_{\mathrm{inc},j}^{2}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\hat{\mathbf{r}}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\hat{\mathbf{r}}_{j}\left( t \right)} \right\rbrack} \right\rangle}}.}
+   {\text{F}_{\text{inc}}{\left( {q,t} \right) = \frac{1}{N}}{\sum\limits_{j}{\vert b_{\mathrm{inc},j} \vert^{2}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\hat{\mathbf{r}}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\hat{\mathbf{r}}_{j}\left( t \right)} \right\rbrack} \right\rangle}}.}
 
 
 **Classical Framework and Corrections**:
@@ -216,7 +216,7 @@ is the correlation function of the Fourier components of the particle current
 .. math::
    :label: ccf1
 
-    J_{\mu\nu}(\mathbf{q}, t) = \sum_{\alpha}\sum_{\beta \geq \alpha} W_{\alpha\beta} J_{\alpha\beta\mu\nu}(\mathbf{q}, t),
+    J_{\mu\nu}(\mathbf{q}, t) = \sum_{\alpha}\sum_{\beta \geq \alpha} W_{\alpha\beta} \mathrm{Re} \left[ J_{\alpha\beta\mu\nu}(\mathbf{q}, t) \right],
 
 .. math::
    :label: ccf2
@@ -251,12 +251,12 @@ partial longitudinal and transverse current correlation functions are
 .. math::
    :label: ccf6
 
-    J^{\mathrm{L}}_{\alpha\beta}(\mathbf{q}, t) = \frac{1}{N \sqrt{c_{\alpha} c_{\beta}}} \langle \mathbf{j}^{\mathrm{L}}_{\alpha}(-\mathbf{q}, 0) \cdot \mathbf{j}^{\mathrm{L}}_{\beta}(\mathbf{q}, t) \rangle,
+    J^{\mathrm{L}}_{\alpha\beta}(\mathbf{q}, t) = \frac{1}{N \sqrt{c_{\alpha} c_{\beta}}}  \mathrm{Re} \left[ \langle \mathbf{j}^{\mathrm{L}}_{\alpha}(-\mathbf{q}, 0) \cdot \mathbf{j}^{\mathrm{L}}_{\beta}(\mathbf{q}, t) \rangle \right],
 
 .. math::
    :label: ccf7
 
-    J^{\mathrm{T}}_{\alpha\beta}(\mathbf{q}, t) = \frac{1}{N \sqrt{c_{\alpha} c_{\beta}}} \langle \mathbf{j}^{\mathrm{T}}_{\alpha}(-\mathbf{q}, 0) \cdot \mathbf{j}^{\mathrm{T}}_{\beta}(\mathbf{q}, t) \rangle.
+    J^{\mathrm{T}}_{\alpha\beta}(\mathbf{q}, t) = \frac{1}{N \sqrt{c_{\alpha} c_{\beta}}}  \mathrm{Re} \left[ \langle \mathbf{j}^{\mathrm{T}}_{\alpha}(-\mathbf{q}, 0) \cdot \mathbf{j}^{\mathrm{T}}_{\beta}(\mathbf{q}, t) \rangle \right].
 
 
 From the continuity equation we can obtain a relation between the
@@ -289,7 +289,7 @@ where
 .. math::
    :label: dcsf3
 
-   F_{\text{coh},\alpha\beta}{(\mathbf{q},t) = \frac{1}{N \sqrt{c_{\alpha} c_{\beta}}}}{\sum\limits_{j \in \alpha}{\sum\limits_{k \in \beta}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle}}
+   F_{\text{coh},\alpha\beta}{(\mathbf{q},t) = \frac{1}{N \sqrt{c_{\alpha} c_{\beta}}}}{\sum\limits_{j \in \alpha}{\sum\limits_{k \in \beta}  \mathrm{Re} \left[ \left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle \right]}}
 
 and
 
@@ -325,7 +325,7 @@ where
 .. math::
    :label: disf3
 
-   F_{\text{inc},\alpha}{(\mathbf{q},t) = \frac{1}{N c_{\alpha} }}{\sum\limits_{j \in \alpha}{\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{j}\left( t \right)} \right\rbrack} \right\rangle}}
+   F_{\text{inc},\alpha}{(\mathbf{q},t) = \frac{1}{N c_{\alpha} }}{\sum\limits_{j \in \alpha}{ \mathrm{Re} \left[\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{j}\left( t \right)} \right\rbrack} \right\rangle \right]}}
 
 and
 
@@ -503,12 +503,12 @@ In this analysis the total incoherent, total coherent and total
 .. math::
    :label: ndtsf1
    
-   F_{\mathrm{inc}}(\mathbf{q},t) = \sum_{\alpha} c_{\alpha}b_{\text{inc},\alpha}^{2} F_{\mathrm{inc},\alpha}(\mathbf{q},t),
+   F_{\mathrm{inc}}(\mathbf{q},t) = \sum_{\alpha} c_{\alpha}\vert b_{\text{inc},\alpha} \vert^{2} F_{\mathrm{inc},\alpha}(\mathbf{q},t),
 
 .. math::
    :label: ndtsf2
    
-   F_{\mathrm{coh}}(\mathbf{q},t) = \sum_{\alpha\beta} \sqrt{c_{\alpha}c_{\beta}} b_{\text{coh},\alpha}b_{\text{coh},\beta} F_{\mathrm{coh},\alpha\beta}(\mathbf{q},t),
+   F_{\mathrm{coh}}(\mathbf{q},t) = \sum_{\alpha\beta} \sqrt{c_{\alpha}c_{\beta}}\ \mathrm{Re} \left[ b_{\text{coh},\alpha}b_{\text{coh},\beta} \right] F_{\mathrm{coh},\alpha\beta}(\mathbf{q},t),
 
 .. math::
    :label: ndtsf3

--- a/Doc/pages/weights.rst
+++ b/Doc/pages/weights.rst
@@ -8,7 +8,7 @@ Partial properties
 ^^^^^^^^^^^^^^^^^^
 
 In MDANSE, most properties are split by atom-type
-and the total results is a sum of these partial
+and the total result is a sum of these partial
 properties. For example, the partial coherent and incoherent intermediate
 scattering functions scaled with weight factors are
 
@@ -36,7 +36,7 @@ the concentrations of atoms of atom-types :math:`\alpha` and :math:`\beta`.
 :math:`N_{\alpha}` and :math:`N_{\beta}` are the the number of atoms-type
 :math:`\alpha` and :math:`\beta`, and :math:`N` is the total number of atoms.
 In MDANSE, the real part of :math:`F_{jk}(\mathbf{q},t)` is taken in Eqs.
-:math:numref:`partial1` so that it will the average over :math:`+\mathbf{q}`
+:math:numref:`partial1` so that it is the average over :math:`+\mathbf{q}`
 and :math:`-\mathbf{q}`. The total is now a sum of the partial terms
 
 .. math::
@@ -47,7 +47,7 @@ and :math:`-\mathbf{q}`. The total is now a sum of the partial terms
 For summation involving two atom-types only the unique pairs are included up,
 since the averaging over :math:`+\mathbf{q}` and :math:`-\mathbf{q}` will mean that
 :math:`\mathcal{F}_{\text{coh},\alpha\beta}(\mathbf{q},t) \approx \mathcal{F}_{\text{coh},\beta\alpha}(\mathbf{q},t)`.
-The factor of two for the off-diagonal terms are included in the weight factor.
+The factor of two for the off-diagonal terms is included in the weight factor.
 
 .. _water-dos-weighted:
 
@@ -56,7 +56,7 @@ The factor of two for the off-diagonal terms are included in the weight factor.
    :width: 11.748cm
    :height: 9.393cm
 
-   The total and partial DOS of water, partial DOS are **weighted** so that the
+   The total and partial DOS of water. Partial DOS are **weighted** so that the
    sum of partial DOS equals to the total.
 
 The partial properties can also be scaled without the weights
@@ -89,8 +89,9 @@ and :math:`F_{\text{inc},\alpha}(\mathbf{q},t)`) partial properties.
    :width: 11.748cm
    :height: 9.393cm
 
-   The total and partial intermolecular PDF of water, partial PDF are
-   **unweighted** so that the weighted sum of partial PDF equals to the total.
+   The total and partial intermolecular PDF of water. Partial PDF are
+   **unweighted** and only
+   their weighted sum equals to the total PDF.
 
 The weighted and unweighted options are more useful for different cases, for example,
 it might be more useful to use the weighted terms for the density of states (DOS) calculations (:numref:`water-dos-weighted`)
@@ -140,7 +141,9 @@ For the DCSF calculation using ``b_coherent``, the weights are
 
 where :math:`b_{\mathrm{coh},\alpha}^{\dagger}` and :math:`b_{\mathrm{coh},\beta}` are
 the coherent scattering lengths of the atoms of types :math:`\alpha` and
-:math:`\beta`. The total coherent intermediate scattering functions becomes
+:math:`\beta`. (:math:`b_{\mathrm{coh},\alpha}^{\dagger}` is the complex conjugate of
+:math:`b_{\mathrm{coh},\alpha}`, as neutron scattering lengths are complex numbers.)
+The total coherent intermediate scattering functions becomes
 
 .. math::
    :label: doubledcsf2

--- a/Doc/pages/weights.rst
+++ b/Doc/pages/weights.rst
@@ -15,30 +15,39 @@ scattering functions scaled with weight factors are
 .. math::
    :label: partial1
 
-   \mathcal{F}_{\text{coh},\alpha\beta}{(\mathbf{q},t) =  \frac{W_{\alpha\beta}}{N \sqrt{c_{\alpha}c_{\beta}}}}{\sum\limits_{j \in \alpha}{\sum\limits_{k \in \beta}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle}},
+   \mathcal{F}_{\text{coh},\alpha\beta}(\mathbf{q},t) =  \frac{W_{\alpha\beta}}{N \sqrt{c_{\alpha}c_{\beta}}} \sum\limits_{j \in \alpha} \sum\limits_{k \in \beta} \mathrm{Re} \left[ F_{jk}(\mathbf{q},t) \right],
 
 .. math::
    :label: partial2
 
-   \mathcal{F}_{\text{inc},\alpha}{(\mathbf{q},t ) = \frac{W_{\alpha}}{Nc_{\alpha}}}{\sum\limits_{j \in \alpha}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{j}\left( t \right)} \right\rbrack} \right\rangle}
+   \mathcal{F}_{\text{inc},\alpha}(\mathbf{q},t ) = \frac{W_{\alpha}}{Nc_{\alpha}} \sum\limits_{j \in \alpha} \mathrm{Re} \left[ F_{jj}(\mathbf{q},t) \right],
+
+.. math::
+   :label: partial2_1
+
+   F_{jk}{(\mathbf{q},t) = \left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle}
+
 
 where :math:`\alpha` and :math:`\beta` are the atom-types.
 :math:`W_{\alpha\beta}` and :math:`W_{\alpha}` are the weights of the
 atom-type pairs :math:`\alpha\beta` and the atom type :math:`\alpha`.
-:math:`c_{\alpha} = N_{\alpha} / N` and :math:`c_{\beta} = N_{\beta} / N` are the concentrations of atoms of
-atom-types :math:`\alpha` and :math:`\beta` and :math:`N_{\alpha}`,
-:math:`N_{\beta}`, and :math:`N` are the :math:`\alpha`, :math:`\beta`,
-and the total number of atoms. The total is now a sum of the partial terms
+:math:`c_{\alpha} = N_{\alpha} / N` and :math:`c_{\beta} = N_{\beta} / N` are
+the concentrations of atoms of atom-types :math:`\alpha` and :math:`\beta`.
+:math:`N_{\alpha}` and :math:`N_{\beta}` are the the number of atoms-type
+:math:`\alpha` and :math:`\beta`, and :math:`N` is the total number of atoms.
+In MDANSE, the real part of :math:`F_{jk}(\mathbf{q},t)` is taken in Eqs.
+:math:numref:`partial1` so that it will the average over :math:`+\mathbf{q}`
+and :math:`-\mathbf{q}`. The total is now a sum of the partial terms
 
 .. math::
    :label: partial3
 
     F_{\text{coh}}(\mathbf{q},t) = \sum_{\alpha}\sum_{\beta \geq \alpha} \mathcal{F}_{\text{coh},\alpha\beta}(\mathbf{q},t), \qquad F_{\text{inc}}(\mathbf{q},t) = \sum_{\alpha} \mathcal{F}_{\text{inc},\alpha}(\mathbf{q},t).
 
-Note that for summation involving two atom-types only the unique pairs
-are summed up. This is because in MDANSE the off-diagonal weight
-terms are doubled and and we assumed that
-:math:`\mathcal{F}_{\text{coh},\alpha\beta} = \mathcal{F}_{\text{coh},\beta\alpha}`.
+For summation involving two atom-types only the unique pairs are included up,
+since the averaging over :math:`+\mathbf{q}` and :math:`-\mathbf{q}` will mean that
+:math:`\mathcal{F}_{\text{coh},\alpha\beta}(\mathbf{q},t) \approx \mathcal{F}_{\text{coh},\beta\alpha}(\mathbf{q},t)`.
+The factor of two for the off-diagonal terms are included in the weight factor.
 
 .. _water-dos-weighted:
 
@@ -55,12 +64,12 @@ The partial properties can also be scaled without the weights
 .. math::
    :label: partial4
 
-   F_{\text{coh},\alpha\beta}{(\mathbf{q},t) = \frac{1}{N \sqrt{c_{\alpha} c_{\beta}}}}{\sum\limits_{j \in \alpha}{\sum\limits_{k \in \beta}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle}},
+   F_{\text{coh},\alpha\beta}(\mathbf{q},t) =  \frac{1}{N \sqrt{c_{\alpha}c_{\beta}}} \sum\limits_{j \in \alpha} \sum\limits_{k \in \beta} \mathrm{Re} \left[ F_{jk}(\mathbf{q},t) \right],
 
 .. math::
    :label: partial5
 
-   F_{\text{inc},\alpha}{(\mathbf{q},t ) = \frac{1}{N c_{\alpha}}}{\sum\limits_{j \in \alpha}\left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{j}\left( t \right)} \right\rbrack} \right\rangle}
+   F_{\text{inc},\alpha}(\mathbf{q},t ) = \frac{1}{Nc_{\alpha}} \sum\limits_{j \in \alpha} \mathrm{Re} \left[ F_{jj}(\mathbf{q},t) \right],
 
 so the total will now be a weighted sum of these partial terms
 
@@ -69,9 +78,9 @@ so the total will now be a weighted sum of these partial terms
 
     F_{\text{coh}}(\mathbf{q},t) = \sum_{\alpha}\sum_{\beta \geq \alpha} W_{\alpha\beta} F_{\text{coh},\alpha\beta}(\mathbf{q},t), \qquad F_{\text{inc}}(\mathbf{q},t) = \sum_{\alpha} W_{\alpha} F_{\text{inc},\alpha}(\mathbf{q},t).
 
-In the MDANSE_GUI you have the option to plot either weighted (e.g. :math:`\mathcal{F}_{\text{coh},\alpha\beta}`
-and :math:`\mathcal{F}_{\text{inc},\alpha}`) or unweighted (e.g. :math:`F_{\text{coh},\alpha\beta}`
-and :math:`F_{\text{inc},\alpha}`) partial properties.
+In the MDANSE_GUI you have the option to plot either weighted (e.g. :math:`\mathcal{F}_{\text{coh},\alpha\beta}(\mathbf{q},t)`
+and :math:`\mathcal{F}_{\text{inc},\alpha}(\mathbf{q},t)`) or unweighted (e.g. :math:`F_{\text{coh},\alpha\beta}(\mathbf{q},t)`
+and :math:`F_{\text{inc},\alpha}(\mathbf{q},t)`) partial properties.
 
 .. _water-pdf-unweighted:
 
@@ -98,9 +107,9 @@ MDANSE weights are rescaled so that weights for DISF calculation using the ``b_i
 .. math::
    :label: single1
 
-   W_{\alpha} = \frac{c_{\alpha} b_{\mathrm{inc},\alpha}^2}{\sum_{\gamma} c_{\gamma} b_{\mathrm{inc},\gamma}^2}
+   W_{\alpha} = \frac{c_{\alpha} \vert b_{\mathrm{inc},\alpha} \vert^2}{\sum_{\gamma} c_{\gamma} \vert b_{\mathrm{inc},\gamma} \vert^2}
 
-where :math:`b_{\mathrm{inc},\alpha}^2` is the squared incoherent
+where :math:`\vert b_{\mathrm{inc},\alpha} \vert^2` is the squared incoherent
 scattering length of the atom type :math:`\alpha`. Note that the
 weights were squared prior to the rescaling, see :ref:`weighting-scheme-squared`
 for details. By using the rescaled weights the total incoherent intermediate
@@ -109,7 +118,7 @@ scattering functions becomes
 .. math::
    :label: single2
 
-   F_{\text{inc}}{(\mathbf{q},t ) = \frac{1}{\sum_{\gamma} c_{\gamma}   b_{\mathrm{inc},\gamma}^2 } \frac{1}{N}}{\sum\limits_{j} b_{\mathrm{inc},\alpha}^2 \left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{j}\left( t \right)} \right\rbrack} \right\rangle}.
+   F_{\text{inc}}(\mathbf{q},t ) = \frac{1}{\sum_{\gamma} c_{\gamma} \vert b_{\mathrm{inc},\gamma} \vert^2 } \frac{1}{N} \sum\limits_{j} \vert b_{\mathrm{inc},\alpha} \vert^2 \ \mathrm{Re} \left[ F_{jj}(\mathbf{q},t) \right]
 
 Notice that by using this weight scheme the total DISF has the property that
 
@@ -126,20 +135,19 @@ For the DCSF calculation using ``b_coherent``, the weights are
 .. math::
    :label: doubledcsf1
 
-   W_{\alpha\beta} = \left[2 - \delta_{\alpha\beta}\right]\frac{\sqrt{c_{\alpha}c_{\beta}} b_{\mathrm{coh},\alpha}b_{\mathrm{coh},\beta}}{\sum_{\gamma\delta} c_{\gamma}c_{\delta}  b_{\mathrm{coh},\gamma}b_{\mathrm{coh},\delta}}
+   W_{\alpha\beta} = \left[2 - \delta_{\alpha\beta}\right] \frac{\sqrt{c_{\alpha}c_{\beta}}\ \mathrm{Re} \left[b_{\mathrm{coh},\alpha}^{\dagger}b_{\mathrm{coh},\beta} \right]}{\sum_{\gamma\delta} c_{\gamma}c_{\delta}  b_{\mathrm{coh},\gamma}^{\dagger}b_{\mathrm{coh},\delta}}
 
 
-where :math:`b_{\mathrm{coh},\alpha}` and :math:`b_{\mathrm{coh},\beta}` are
-the coherent scattering lengths of the atoms of types :math:`\alpha` and :math:`\beta`.
-The total coherent intermediate scattering functions becomes
+where :math:`b_{\mathrm{coh},\alpha}^{\dagger}` and :math:`b_{\mathrm{coh},\beta}` are
+the coherent scattering lengths of the atoms of types :math:`\alpha` and
+:math:`\beta`. The total coherent intermediate scattering functions becomes
 
 .. math::
    :label: doubledcsf2
 
-   F_{\text{coh}}{(\mathbf{q},t) = \frac{1}{\sum_{\gamma\delta} c_{\gamma} c_{\delta}  b_{\mathrm{coh},\gamma}b_{\mathrm{coh},\delta}} \frac{1}{N}}{{\sum\limits_{jk} b_{\mathrm{coh},j}b_{\mathrm{coh},k} \left\langle {\exp\left\lbrack {{- i}\mathbf{q}\cdot\mathbf{r}_{j}\left( 0 \right)} \right\rbrack\exp\left\lbrack {i\mathbf{q}\cdot\mathbf{r}_{k}\left( t \right)} \right\rbrack} \right\rangle}}
+   F_{\text{coh}}(\mathbf{q},t) = \frac{\sqrt{c_{\alpha}c_{\beta}}}{\sum_{\gamma\delta} c_{\gamma}c_{\delta}  b_{\mathrm{coh},\gamma}^{\dagger}b_{\mathrm{coh},\delta}} \frac{1}{N} \sum\limits_{jk} \mathrm{Re} \left[  b_{\mathrm{coh},\alpha}^{\dagger}b_{\mathrm{coh},\beta} \right]  \mathrm{Re} \left[ F_{jk}(\mathbf{q},t) \right]
 
-
-where :math:`b_{\mathrm{coh},j}` and
+where :math:`b_{\mathrm{coh},j}^{\dagger}` and
 :math:`b_{\mathrm{coh},k}` are the coherent scattering lengths of
 atoms :math:`j` and :math:`k`. Notice that the total intermediate scattering function
 (sum of the incoherent and coherent parts) will not be equal (or equal to the
@@ -172,7 +180,7 @@ are the partial PDFs. Using ``b_coherent`` the weights are
 .. math::
    :label: doubleother3
 
-   W_{\alpha\beta} = \left[2 - \delta_{\alpha\beta}\right]\frac{c_{\alpha}c_{\beta} b_{\mathrm{coh},\alpha}b_{\mathrm{coh},\beta}}{\sum_{\gamma\delta} c_{\gamma}c_{\delta}  b_{\mathrm{coh},\gamma}b_{\mathrm{coh},\delta}},
+   W_{\alpha\beta} = \left[2 - \delta_{\alpha\beta}\right] \frac{c_{\alpha}c_{\beta} \ \mathrm{Re} \left[b_{\mathrm{coh},\alpha}^{\dagger}b_{\mathrm{coh},\beta} \right]}{\sum_{\gamma\delta} c_{\gamma}c_{\delta}  b_{\mathrm{coh},\gamma}^{\dagger}b_{\mathrm{coh},\delta}}
 
 notice that the concentrations :math:`c_{\alpha}c_{\beta}` are not
 square-rooted, this is because the the partial SSF has a prefactor of
@@ -193,13 +201,13 @@ with single atom-type weights will be
 .. math::
    :label: squared1
 
-   W_{\alpha} = \frac{c_{\alpha} w_{\alpha}}{\sum_{\gamma} c_{\gamma} w_{\gamma}}
+   W_{\alpha} = \mathrm{Re} \left[ \frac{c_{\alpha} w_{\alpha}}{\sum_{\gamma} c_{\gamma} w_{\gamma}} \right]
 
 while in some cases when the weight are squared
 
 .. math::
    :label: squared2
 
-   W_{\alpha} = \frac{c_{\alpha} w_{\alpha}^2}{\sum_{\gamma} c_{\gamma} w_{\gamma}^2}
+   W_{\alpha} = \frac{c_{\alpha} \vert w_{\alpha} \vert^2}{\sum_{\gamma} c_{\gamma} \vert w_{\gamma} \vert^2}
 
 where :math:`w_{\alpha}` is some weight parameter for the atom-type :math:`\alpha`.


### PR DESCRIPTION
**Description of work**
Updated documentation so that it is consistent with the recent update made in #963. Daggers are added to complex scattering lengths in some equations. An explaination about the averaging over $q$ and $-q$ is added to the weights section. Explicitly written where the real part of some function are taken in some equations. Feel free to edit and commit over this PR.
