### PR TITLE
Fixed GUI periodic table information display on hover

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/PeriodicTableViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/PeriodicTableViewer.py
@@ -340,7 +340,7 @@ class InfoDisplay(QFrame):
             "<sup>" + str(info_object["proton"]) + "</sup>" + str(info_object["symbol"])
         )
         self.fields[2].setText(
-            f"{info_object['group']:2s},{info_object['period']},{info_object['block']}",
+            f"{info_object['group']},{info_object['period']},{info_object['block']}",
         )
         self.fields[3].setText(str(info_object["element"]))
         self.fields[4].setText(str(info_object["family"]))


### PR DESCRIPTION
**Description of work**
Fixed GUI periodic table information display on hover.

<img width="927" height="437" alt="image" src="https://github.com/user-attachments/assets/18372ce2-ef94-40bf-821c-6277135dc783" />

**Fixes**
Periodic table element information not displayed on hover.

**To test**
Start the GUI and open the periodic table. Hover the mouse over some elements and check that the element information is displayed.
