### PR TITLE
Run IJob.check_status before IJob.initialize

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -492,10 +492,9 @@ class IJob(Configurable, metaclass=SubclassFactory):
                 self._status = self._status_constructor(self)
 
             self.setup(parameters)
+            self.check_status()
 
             self.initialize()
-
-            self.check_status()
 
             if self._status is not None:
                 self._status.start(self.numberOfSteps)


### PR DESCRIPTION
**Description of work**
It seems that a lot of jobs with bad inputs fail during `IJob.initialize` and do not generate a meaningful error, because the bad error parameters are only reported in `IJob.check_status`. This PR makes sure that `check_status` is run before `initialize`.

**Fixes**
1. Swapped 'IJob.initialize()` with `IJob.check_status()` in `IJob.run`.

**To test**
Save any analysis script and change the parameters in the script to some wrong values. Run the script and check if the error output matches the wrong input variable.

