### PR TITLE
Disable save button on invalid Action script

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -438,6 +438,7 @@ class Action(QWidget):
             has_warning = has_warning or widget.has_warning
         if self.execute_button is not None:
             self.execute_button.setEnabled(allow)
+            self.save_button.setEnabled(allow)
             if has_warning:
                 self.execute_button.setStyleSheet(
                     "QWidget { background-color:rgb(220,210,30); font-weight: bold }"


### PR DESCRIPTION
**Description of work**
When a script is invalid, but Run and "Save as Script" are disabled.

**Fixes**
Closes #976 

**To test**
Run GUI, create invalid script via Action input field.
