### PR TITLE
render math in job tab info

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
@@ -30,7 +30,7 @@ from MDANSE_GUI.Tabs.Layouts.MultiPanel import MultiPanel
 from MDANSE_GUI.Tabs.Models.JobTree import JobTree
 from MDANSE_GUI.Tabs.Views.ActionsTree import ActionsTree
 from MDANSE_GUI.Tabs.Visualisers.Action import Action
-from MDANSE_GUI.Tabs.Visualisers.TextInfo import TextInfo
+from MDANSE_GUI.Tabs.Visualisers.TextInfo import MathInfo
 
 job_tab_label = """This is the list of <b>analysis tasks</b>
 you can run using MDANSE.
@@ -182,7 +182,7 @@ class JobTab(GeneralTab):
             layout=partial(
                 MultiPanel,
                 left_panels=[
-                    TextInfo(
+                    MathInfo(
                         header="MDANSE Analysis",
                         footer="Look up our Read The Docs page:"
                         + "https://mdanse.readthedocs.io/en/protos/",
@@ -220,7 +220,7 @@ class JobTab(GeneralTab):
             layout=partial(
                 MultiPanel,
                 left_panels=[
-                    TextInfo(
+                    MathInfo(
                         header="MDANSE Analysis",
                         footer="Look up our "
                         + '<a href="https://mdanse.readthedocs.io/en/protos/">Read The Docs</a>'
@@ -253,7 +253,7 @@ if __name__ == "__main__":
         layout=partial(
             MultiPanel,
             left_panels=[
-                TextInfo(
+                MathInfo(
                     header="MDANSE Analysis",
                     footer="Look up our "
                     + '<a href="https://mdanse.readthedocs.io/en/protos/">Read The Docs</a>'

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import io
 import re

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -113,15 +113,28 @@ class MathRenderer:
         return f"${text}$"
 
     @staticmethod
-    def render(expression: str) -> None:
+    def render(expression: str, dark: bool = False) -> None:
         # Create a figure containing the rendered LaTex expression
         fig, ax = plt.subplots(figsize=(0.01, 0.01))
         ax.axis("off")
-        fig.text(0, 0, MathRenderer.mask(expression), fontsize=7)
+        fig.text(
+            0,
+            0,
+            MathRenderer.mask(expression),
+            fontsize=7,
+            color="white" if dark else "black",
+        )
 
         # Save the image as bytes
         buffer = io.BytesIO()
-        plt.savefig(buffer, format="png", bbox_inches="tight", pad_inches=0.1, dpi=150)
+        plt.savefig(
+            buffer,
+            format="png",
+            bbox_inches="tight",
+            pad_inches=0.1,
+            dpi=150,
+            transparent=dark,
+        )
         plt.close(fig)
         buffer.seek(0)
         image = base64.b64encode(buffer.read()).decode("utf-8")

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -2,7 +2,6 @@ import re
 import io
 import base64
 from matplotlib import pyplot as plt
-from typing import List, Any
 
 
 class MathRenderer:
@@ -23,12 +22,12 @@ class MathRenderer:
     def ignore(text: str) -> bool:
         return text in MathRenderer.ignores
 
-    def scan(self) -> List[Any]:
+    def scan(self) -> dict[str, bool]:
         # Use regex matching to find expressions
         pattern = r"(:math:`.*?`)"
         substrings = re.split(pattern, self.raw_text)
 
-        scanned = []
+        scanned = dict()
         for s in substrings:
             if not s:
                 # This is not a string - skip
@@ -45,10 +44,10 @@ class MathRenderer:
             if s.startswith(":math:`") and s.endswith("`"):
                 # This is a raw LaTex expression string - instantiate object to identify it as such
                 expr = s[len(":math:`") : -1]
-                scanned.append(MathExpression(expr))
+                scanned.update({expr: True})
             else:
                 # Normal text string
-                scanned.append(s)
+                scanned.update({s: False})
 
         return scanned
 
@@ -85,11 +84,3 @@ class MathRenderer:
     @classmethod
     def from_cache(cls, key):
         return cls.cache[key]
-
-
-class MathExpression:
-    def __init__(self, expr: str):
-        self.expr = expr
-
-    def get(self) -> str:
-        return self.expr

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -22,7 +22,7 @@ class MathRenderer:
 
     # Line breaks used
     BREAK = r"<br\s*/?>"
-    DOUBLE_BREAK = f"{BREAK}\s*{BREAK}"
+    DOUBLE_BREAK = rf"{BREAK}\s*{BREAK}"
 
     def __init__(self, text: str, dark: bool = False) -> None:
         self.raw_text = text
@@ -86,13 +86,10 @@ class MathRenderer:
         matches = tuple(re.finditer(pattern, text))
         for i, match in enumerate(matches):
             last_span = matches[i - 1].span()
-            expr_start, expr_end = match.span()
+            expr_start = match.span()[0]
             plain_text = text[(0 if i < 1 else last_span[1]) : expr_start]
             scanned.append(self.process_plain_text(plain_text))
-            span, expression = (
-                match[0],
-                match[1].strip(f"{MathRenderer.INLINE}").strip("`"),
-            )
+            expression = match[1].strip(f"{MathRenderer.INLINE}").strip("`")
             rendered = self.render(expression, self.dark)
             scanned.append(rendered)
         substrings[index] = "".join(scanned)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -12,7 +12,7 @@ class MathRenderer:
     cache = {}
 
     # Ignore the following expression
-    ignores = {r"`\mathbf{q}`": "q"}
+    ignores = {r"\mathbf{q}": "q"}
 
     def __init__(self, text: str) -> None:
         self.raw_text = text
@@ -66,7 +66,7 @@ class MathRenderer:
         pattern = r"(:math:`.*?`)"
         substrings = re.split(pattern, text)
         scanned = []
-        for s in substrings:
+        for index, s in enumerate(substrings):
             if s.startswith(":math:"):
                 expr = s[len(":math:`"):-1]
                 scanned.append((expr, True))
@@ -115,7 +115,7 @@ class MathRenderer:
         # Create a figure containing the rendered LaTex expression
         fig, ax = plt.subplots(figsize=(0.01, 0.01))
         ax.axis("off")
-        fig.text(0, 0, MathRenderer.mask(expression), fontsize=6)
+        fig.text(0, 0, MathRenderer.mask(expression), fontsize=7)
 
         # Save the image as bytes
         buffer = io.BytesIO()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -65,8 +65,8 @@ class MathRenderer:
 
     @staticmethod
     def ignore(text: str) -> bool:
-        """Returns a boolean determining whether to replace the instance of a mathematical expression that we do not want to render
-        as an image, but keep as plain text (i.e. a single variable that is referred to often).
+        """Returns a boolean determining whether to replace the instance of a mathematical expression that we do not
+        want to render as an image, but keep as plain text (i.e. a single variable that is referred to often).
 
         Parameters
         ----------
@@ -86,7 +86,7 @@ class MathRenderer:
         """Returns a boolean determining whether the current substring from the parent html description string contains
         a multiline block expression.
 
-        This is assessed based on a regex search for the presence of the pattern ".. math::" enclosed within line breaks.
+        This is assessed based on a regex search for the presence of the pattern ".. math::" enclosed within line breaks
 
         For example:
 
@@ -237,14 +237,12 @@ class MathRenderer:
         text = substrings[index]
         scanned = []
         matches = tuple(re.finditer(pattern, text))
+        # To account for potentially several inline expressions on the same line, iterate over all matches
         for i, match in enumerate(matches):
-            last_span = matches[i - 1].span()
-            expr_start = match.span()[0]
-            plain_text = text[(0 if i < 1 else last_span[1]) : expr_start]
+            plain_text = text[(0 if i < 1 else matches[i - 1].end()) : match.start()]
             scanned.append(self.process_plain_text(plain_text))
             expression = match[1].strip(f"{MathRenderer.INLINE}").strip("`")
-            rendered = self.render(expression, self.dark)
-            scanned.append(rendered)
+            scanned.append(self.render(expression, self.dark))
         substrings[index] = "".join(scanned)
 
     def process_plain_text(self, text: str) -> str:
@@ -260,9 +258,9 @@ class MathRenderer:
         return f'<span style="margin:0; padding:0;">{text}</span>'
 
     def scan(self) -> str:
-        """Traverses the parent html string as a list of substrings separated by line breaks, applying the above conditions
-        to each substring to determine whether they are an inline, block, or multiline block LaTex expression, or simple
-        plain text, and processes the substrings accordingly.
+        """Traverses the parent html string as a list of substrings separated by line breaks, applying the above
+        conditions to each substring to determine whether they are an inline, block, or multiline block LaTex expression
+        , or simple plain text, and processes the substrings accordingly.
 
         After processing these component substrings are joined back together into a html object for display.
 
@@ -272,7 +270,6 @@ class MathRenderer:
             Processed html with embedded LaTex expression images.
 
         """
-
         # Use regex matching to find expressions
         pattern = r"(<br />.*?<br />)"
         substrings = re.split(pattern, self.raw_text)
@@ -299,7 +296,8 @@ class MathRenderer:
 
     @staticmethod
     def mask(text: str) -> str:
-        """Format the input text string into the form "$<EXPRESSION>$", for compatibilty with matplotlib LaTex rendering.
+        """Format the input text string into the form "$<EXPRESSION>$", for compatibility with matplotlib
+        LaTex rendering.
 
         Parameters
         ----------
@@ -332,7 +330,6 @@ class MathRenderer:
             Html string containing embedded image.
 
         """
-
         # Create a figure containing the rendered LaTex expression
         fig, ax = plt.subplots(figsize=(0.01, 0.01))
         ax.axis("off")

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -25,33 +25,84 @@ class MathRenderer:
     def ignore(text: str) -> bool:
         return text in MathRenderer.ignores
 
+    @staticmethod
+    def containsMultiLineBlockExpression(text: str) -> bool:
+        return text == ".. math::" or text == r"<br />.. math::<br />"
+
+    @staticmethod
+    def containsBlockExpression(text: str) -> bool:
+        return text.startswith(".. math:")
+
+    @staticmethod
+    def containsInlineExpressions(text: str) -> bool:
+        pattern = r"(:math:`.*?`)"
+        substrings = re.split(pattern, text)
+        return len(substrings) > 1
+
+    @staticmethod
+    def processBlockExpression(text: str) -> list[tuple[str, bool]]:
+        return [(text[len(".. math:: "):], True)]
+
+    @staticmethod
+    def processMultiLineBlockExpression(strings: list[str], n: int) -> tuple[list[tuple[str, bool]], int]:
+        substrings = strings[n+1:]
+        group = []
+        for s in substrings:
+            if (not s) or (s == r"<br /><br />"):
+                break
+            group.append(s)
+
+        group = [s.replace(r"<br />", "") for s in group]
+        total = "".join(group)
+        if total.startswith(r"<br />") and total.endswith(r"<br />"):
+            result = total.split(r"<br />")[1]
+        else:
+            result = total.split(r"<br /><br />")[0]
+
+        return [(result, True)], n + len(group) + 1
+
+    @staticmethod
+    def processInlineExpressions(text: str) -> list[tuple[str, bool]]:
+        pattern = r"(:math:`.*?`)"
+        substrings = re.split(pattern, text)
+        scanned = []
+        for s in substrings:
+            if s.startswith(":math:"):
+                expr = s[len(":math:`"):-1]
+                scanned.append((expr, True))
+            else:
+                scanned.append((s, False))
+
+        return scanned
+
     def scan(self) -> list[tuple[str, bool]]:
         # Use regex matching to find expressions
-        pattern = r"(:math:`.*?`)"
+        pattern = r"(<br />.*?<br />)"
         substrings = re.split(pattern, self.raw_text)
 
         scanned = []
-        for s in substrings:
-            if not s:
-                # This is not a string - skip
-                continue
-
-            # Get the raw expression content to check if it is ignored
-            raw_expr = s[len(":math:") :]
-            if self.ignore(raw_expr):
-                # We ignore rendering this
-                prefix = MathRenderer.replace_ignored(raw_expr)
-                substrings[-1] = prefix + substrings[-1]
-                continue
-
-            if s.startswith(":math:`") and s.endswith("`"):
-                # This is a raw LaTex expression string - instantiate object to identify it as such
-                expr = s[len(":math:`") : -1]
-                scanned.append((expr, True))
-            else:
-                # Normal text string
-                scanned.append((s, False))
-
+        for index, s in enumerate(substrings):
+            if s:
+                if self.containsMultiLineBlockExpression(s):
+                    # Html is a multiline block expression
+                    group, end = self.processMultiLineBlockExpression(substrings, index)
+                    scanned.extend(group)
+                    substrings[index:end] = [""] * (end - index)
+                elif self.containsBlockExpression(s):
+                    # Html substring contains a block expression
+                    group = self.processBlockExpression(s)
+                    scanned.extend(group)
+                elif self.containsInlineExpressions(s):
+                    # Html substring contains inline math expressions
+                    group = self.processInlineExpressions(s)
+                    scanned.extend(group)
+                elif ":Example:" in s:
+                    # We have reached the end of the section containing math expressions
+                    rest = "".join(substrings[index:])
+                    scanned.append((rest, False))
+                else:
+                    # Html substring contains plain text only
+                    scanned.append((s, False))
         return scanned
 
     @staticmethod

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -1,6 +1,7 @@
-import re
-import io
 import base64
+import io
+import re
+
 from matplotlib import pyplot as plt
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -100,6 +100,7 @@ class MathRenderer:
                     # We have reached the end of the section containing math expressions
                     rest = "".join(substrings[index:])
                     scanned.append((rest, False))
+                    break
                 else:
                     # Html substring contains plain text only
                     scanned.append((s, False))

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -25,12 +25,12 @@ class MathRenderer:
     def ignore(text: str) -> bool:
         return text in MathRenderer.ignores
 
-    def scan(self) -> dict[str, bool]:
+    def scan(self) -> list[tuple[str, bool]]:
         # Use regex matching to find expressions
         pattern = r"(:math:`.*?`)"
         substrings = re.split(pattern, self.raw_text)
 
-        scanned = {}
+        scanned = []
         for s in substrings:
             if not s:
                 # This is not a string - skip
@@ -47,10 +47,10 @@ class MathRenderer:
             if s.startswith(":math:`") and s.endswith("`"):
                 # This is a raw LaTex expression string - instantiate object to identify it as such
                 expr = s[len(":math:`") : -1]
-                scanned.update({expr: True})
+                scanned.append((expr, True))
             else:
                 # Normal text string
-                scanned.update({s: False})
+                scanned.append((s, False))
 
         return scanned
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -8,6 +8,14 @@ from matplotlib import pyplot as plt
 
 
 class MathRenderer:
+    """Operates on a html string by scanning through the string to locate renderable mathematical expressions using
+    LaTex typesetting. This works for inline, block, and multiline block expressions.
+
+    These html embedded expressions are mutated in-place to display an image, rendered in Matplotlib, of the expression
+    within the parent description text.
+
+    """
+
     # Cache mapping the raw LaTex expression to its rendered image form
     cache = {}
 
@@ -25,32 +33,155 @@ class MathRenderer:
     DOUBLE_BREAK = rf"{BREAK}\s*{BREAK}"
 
     def __init__(self, text: str, dark: bool = False) -> None:
+        """
+        Parameters
+        ----------
+        text : str
+            Html description string to be processed.
+        dark : bool
+            Boolean value determining the current configuration of dark/light mode at application startup time.
+
+        """
         self.raw_text = text
         self.dark = dark
 
     @staticmethod
     def replace_ignored(text: str) -> str:
+        """Returns a standard string to replace the instance of a mathematical expression that we do not want to render
+        as an image, but keep as plain text (i.e. a single variable that is referred to often).
+
+        Parameters
+        ----------
+        text : str
+            LaTex symbol for expression to be ignored.
+
+        Returns
+        -------
+        str
+            Plain text symbol to display instead of ignored expression.
+
+        """
         return MathRenderer.ignores[text]
 
     @staticmethod
     def ignore(text: str) -> bool:
+        """Returns a boolean determining whether to replace the instance of a mathematical expression that we do not want to render
+        as an image, but keep as plain text (i.e. a single variable that is referred to often).
+
+        Parameters
+        ----------
+        text : str
+            LaTex symbol for expression to be ignored.
+
+        Returns
+        -------
+        bool
+            Boolean value - if true, we ignore the expression.
+
+        """
         return text in MathRenderer.ignores
 
     @staticmethod
     def contains_multiline_block_expression(text: str) -> bool:
+        """Returns a boolean determining whether the current substring from the parent html description string contains
+        a multiline block expression.
+
+        This is assessed based on a regex search for the presence of the pattern ".. math::" enclosed within line breaks.
+
+        For example:
+
+            '<br />.. math::<br />',
+            '\\hat{\\mathbf{n}}(t) =  \\frac{\\mathbf{r}_{i}(t)
+                                        - \\mathbf{r}_{j}(t)}{\\vert \\mathbf{r}_{i}(t) - \\mathbf{r}_{j}(t) \\vert}'
+            |                                                                                                          |
+            ____________________________________________________________________________________________________________
+                                                            ^
+                                                This is the block expression to be rendered
+
+        Parameters
+        ----------
+        text : str
+            Html string to be searched.
+
+        Returns
+        -------
+        bool
+            Boolean value - if true, this string contains a multiline block LaTex expression.
+
+        """
         return (
             re.search(f"<br />{MathRenderer.MULTILINE_BLOCK}<br />", text) is not None
         )
 
     @staticmethod
     def contains_block_expression(text: str) -> bool:
+        """Returns a boolean determining whether the current substring from the parent html description string contains
+        a multiline block expression.
+
+        This is assessed based on the string commencing with the identifier ".. math::".
+
+        For example:
+
+            '.. math::',
+            '<br />\\phi(t = t_{1}-t_{0}) = \\arccos( \\hat{\\mathbf{n}}(t_{1}) \\cdot \\hat{\\mathbf{n}}(t_{0}))<br />'
+                   |                                                                                            |
+                   ______________________________________________________________________________________________
+                                                            ^
+                                                This is the block expression to be rendered
+        Parameters
+        ----------
+        text : str
+            Html string to be searched.
+
+        Returns
+        -------
+        bool
+            Boolean value - if true, this string contains a block LaTex expression.
+
+        """
         return text.startswith(".. math:")
 
     @staticmethod
     def contains_inline_expressions(text: str) -> bool:
+        """Returns a boolean determining whether the current substring from the parent html description string contains
+        a multiline block expression.
+
+        This is assessed based on a regex search for the presence of the pattern ".. math::" followed immediately by a
+        mathematical expression on the same line.
+
+        For example:
+
+                '<br />The general result is :math:`C_{l}(t) = \\langle P_{l}[\\cos(\\phi(t))] \\rangle`,<br />'
+                                                    |                                                 |
+                                                    ___________________________________________________
+                                                            ^
+                                                This is the inline expression to be rendered
+
+        Parameters
+        ----------
+        text : str
+            Html string to be searched.
+
+        Returns
+        -------
+        bool
+            Boolean value - if true, this string contains an inline LaTex expression.
+
+        """
         return re.search(f"({MathRenderer.INLINE}`.*?`)", text) is not None
 
     def process_block_expression(self, substrings: list[str], index: int) -> None:
+        """Renders a block expression as an image and modifies the parent html to embed the image.
+
+        Parameters
+        ----------
+        substrings : str
+            Parent html string list.
+
+        index : str
+            Index of parent strings to be modified.
+
+        """
         expr = substrings[index].strip(f"{MathRenderer.MULTILINE_BLOCK}").strip("`")
         if not expr:
             match = re.search(r"<br\s*/?>(.*?)<br\s*/?>", substrings[index + 1])
@@ -61,10 +192,21 @@ class MathRenderer:
     def process_multiline_block_expression(
         self, strings: list[str], index: int
     ) -> None:
+        """Renders a multiline block expression as an image and modifies the parent html to embed the image.
+
+        Parameters
+        ----------
+        substrings : str
+            Parent html string list.
+
+        index : str
+            Index of parent strings to be modified.
+
+        """
         substrings = strings[index + 1 :]
         group = []
         for s in substrings:
-            if (not s) or re.fullmatch(self.DOUBLE_BREAK, s):
+            if (not s) or re.fullmatch(self.DOUBLE_BREAK, s) or (":Example:" in s):
                 break
             group.append(s)
 
@@ -80,6 +222,17 @@ class MathRenderer:
         strings[index + 1 : expr_end] = [""] * len(discard)
 
     def process_inline_expressions(self, substrings: list[str], index: int) -> None:
+        """Renders an inline expression as an image and modifies the parent html to embed the image.
+
+        Parameters
+        ----------
+        substrings : str
+            Parent html string list.
+
+        index : str
+            Index of parent strings to be modified.
+
+        """
         pattern = f"({MathRenderer.INLINE}`.*?`)"
         text = substrings[index]
         scanned = []
@@ -95,10 +248,31 @@ class MathRenderer:
         substrings[index] = "".join(scanned)
 
     def process_plain_text(self, text: str) -> str:
+        """Embeds the plain text in a html span.
+
+        Parameters
+        ----------
+        text : str
+            Parent html string list.
+
+        """
         text = text.replace("\n", "<br>")
         return f'<span style="margin:0; padding:0;">{text}</span>'
 
-    def scan(self) -> list[tuple[str, bool]]:
+    def scan(self) -> str:
+        """Traverses the parent html string as a list of substrings separated by line breaks, applying the above conditions
+        to each substring to determine whether they are an inline, block, or multiline block LaTex expression, or simple
+        plain text, and processes the substrings accordingly.
+
+        After processing these component substrings are joined back together into a html object for display.
+
+        Returns
+        -------
+        str
+            Processed html with embedded LaTex expression images.
+
+        """
+
         # Use regex matching to find expressions
         pattern = r"(<br />.*?<br />)"
         substrings = re.split(pattern, self.raw_text)
@@ -115,7 +289,7 @@ class MathRenderer:
                     # Html substring contains inline math expressions
                     self.process_inline_expressions(substrings, index)
                 elif ":Example:" in s:
-                    # Break - we don't process any info below this line
+                    # Break - we don't process any info below this line containing the header "Example"
                     break
                 else:
                     # This is plain text
@@ -125,10 +299,40 @@ class MathRenderer:
 
     @staticmethod
     def mask(text: str) -> str:
+        """Format the input text string into the form "$<EXPRESSION>$", for compatibilty with matplotlib LaTex rendering.
+
+        Parameters
+        ----------
+        text : str
+            Input string.
+
+        Returns
+        -------
+        str
+            Formatted text with mask applied.
+
+        """
         return f"${text}$"
 
     @staticmethod
     def render(expression: str, dark: bool = False) -> str:
+        """Renders the LaTex expression string in matplotlib.
+
+        Parameters
+        ----------
+        expression : str
+            Expression string.
+
+        dark : bool
+            Boolean value - if true, dark mode is set.
+
+        Returns
+        -------
+        str
+            Html string containing embedded image.
+
+        """
+
         # Create a figure containing the rendered LaTex expression
         fig, ax = plt.subplots(figsize=(0.01, 0.01))
         ax.axis("off")
@@ -165,21 +369,84 @@ class MathRenderer:
 
     @staticmethod
     def embed_html(image: str) -> str:
+        """Embed a rendered image string in html.
+
+        Parameters
+        ----------
+        image : str
+            Rendered image as a string.
+
+        Returns
+        -------
+        str
+            Formatted html string containing embedded image.
+
+        """
         return f'<span style="vertical-align:middle;"><img src="data:image/png;base64,{image}" style="height:1em; display:inline;"></span>'
 
     @staticmethod
     def embed_html_large(image: str) -> str:
+        """Embed a large rendered image string in html.
+
+        Parameters
+        ----------
+        image : str
+            Rendered image as a string.
+
+        Returns
+        -------
+        str
+            Formatted html string containing embedded image.
+
+        """
         return f'<div style="text-align:left; margin:2px 0; padding:0;"><img src="data:image/png;base64,{image}" style="vertical-align:middle;"></div>'
 
     @classmethod
     def set_cache(cls, key, value) -> None:
+        """Insert a key value pair, representing an expression and a rendered image respectively.
+
+        Parameters
+        ----------
+        key : str
+            LaTex expression.
+
+        value : str
+            Rendered image as a string.
+
+        """
         cls.cache.update({key: value})
 
     @classmethod
     def cached(cls, key) -> bool:
+        """Determine whether a key value pair, representing an expression and a rendered image, exists in the cache.
+
+        Parameters
+        ----------
+        key : str
+            LaTex expression.
+
+        Returns
+        -------
+        bool
+            Boolean value - true if the cache contains the image for the given expression.
+
+        """
         result = key in cls.cache
         return result
 
     @classmethod
     def from_cache(cls, key) -> str:
+        """Retrieve a key value pair, representing an expression and a rendered image respectively.
+
+        Parameters
+        ----------
+        key : str
+            LaTex expression.
+
+        Returns
+        -------
+        str
+            Rendered image as string.
+
+        """
         return cls.cache[key]

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -81,7 +81,7 @@ class MathRenderer:
 
     @classmethod
     def cached(cls, key) -> bool:
-        result = key in cls.cache.keys()
+        result = key in cls.cache
         return result
 
     @classmethod

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -35,9 +35,7 @@ class MathRenderer:
 
     @staticmethod
     def containsInlineExpressions(text: str) -> bool:
-        pattern = r"(:math:`.*?`)"
-        substrings = re.split(pattern, text)
-        return len(substrings) > 1
+        return re.search(r"(:math:`.*?`)", text) is not None
 
     @staticmethod
     def processBlockExpression(text: str) -> list[tuple[str, bool]]:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -14,8 +14,19 @@ class MathRenderer:
     # Ignore the following expression
     ignores = {r"\mathbf{q}": "q"}
 
-    def __init__(self, text: str) -> None:
+    # Inline expression marker
+    INLINE = r":math:"
+
+    # Multiline block expression marker
+    MULTILINE_BLOCK = r".. math::"
+
+    # Line breaks used
+    BREAK = r"<br\s*/?>"
+    DOUBLE_BREAK = f"{BREAK}\s*{BREAK}"
+
+    def __init__(self, text: str, dark: bool = False) -> None:
         self.raw_text = text
+        self.dark = dark
 
     @staticmethod
     def replace_ignored(text: str) -> str:
@@ -26,92 +37,101 @@ class MathRenderer:
         return text in MathRenderer.ignores
 
     @staticmethod
-    def containsMultiLineBlockExpression(text: str) -> bool:
-        return text in {".. math::", r"<br />.. math::<br />"}
+    def contains_multiline_block_expression(text: str) -> bool:
+        return (
+            re.search(f"<br />{MathRenderer.MULTILINE_BLOCK}<br />", text) is not None
+        )
 
     @staticmethod
-    def containsBlockExpression(text: str) -> bool:
+    def contains_block_expression(text: str) -> bool:
         return text.startswith(".. math:")
 
     @staticmethod
-    def containsInlineExpressions(text: str) -> bool:
-        return re.search(r"(:math:`.*?`)", text) is not None
+    def contains_inline_expressions(text: str) -> bool:
+        return re.search(f"({MathRenderer.INLINE}`.*?`)", text) is not None
 
-    @staticmethod
-    def processBlockExpression(text: str) -> list[tuple[str, bool]]:
-        return [(text[len(".. math:: ") :], True)]
+    def process_block_expression(self, substrings: list[str], index: int) -> None:
+        expr = substrings[index].strip(f"{MathRenderer.MULTILINE_BLOCK}").strip("`")
+        if not expr:
+            match = re.search(r"<br\s*/?>(.*?)<br\s*/?>", substrings[index + 1])
+            expr = match.group(1).strip()
+        substrings[index] = self.render(expr, self.dark)
+        substrings[index + 1] = ""
 
-    @staticmethod
-    def processMultiLineBlockExpression(
-        strings: list[str], n: int
-    ) -> tuple[list[tuple[str, bool]], int]:
-        substrings = strings[n + 1 :]
+    def process_multiline_block_expression(
+        self, strings: list[str], index: int
+    ) -> None:
+        substrings = strings[index + 1 :]
         group = []
         for s in substrings:
-            if (not s) or (s == r"<br /><br />"):
+            if (not s) or re.fullmatch(self.DOUBLE_BREAK, s):
                 break
             group.append(s)
 
-        group = [s.replace(r"<br />", "") for s in group]
-        total = "".join(group)
+        total = re.sub(self.BREAK, "", "".join(group))
         if total.startswith(r"<br />") and total.endswith(r"<br />"):
             result = total.split(r"<br />")[1]
         else:
             result = total.split(r"<br /><br />")[0]
 
-        return [(result, True)], n + len(group) + 1
+        strings[index] = self.render(result, self.dark)
+        expr_end = index + len(group) + 1
+        discard = strings[index + 1 : expr_end]
+        strings[index + 1 : expr_end] = [""] * len(discard)
 
-    @staticmethod
-    def processInlineExpressions(text: str) -> list[tuple[str, bool]]:
-        pattern = r"(:math:`.*?`)"
-        substrings = re.split(pattern, text)
+    def process_inline_expressions(self, substrings: list[str], index: int) -> None:
+        pattern = f"({MathRenderer.INLINE}`.*?`)"
+        text = substrings[index]
         scanned = []
-        for s in substrings:
-            if s.startswith(":math:"):
-                expr = s[len(":math:`") : -1]
-                scanned.append((expr, True))
-            else:
-                scanned.append((s, False))
+        matches = tuple(re.finditer(pattern, text))
+        for i, match in enumerate(matches):
+            last_span = matches[i - 1].span()
+            expr_start, expr_end = match.span()
+            plain_text = text[(0 if i < 1 else last_span[1]) : expr_start]
+            scanned.append(self.process_plain_text(plain_text))
+            span, expression = (
+                match[0],
+                match[1].strip(f"{MathRenderer.INLINE}").strip("`"),
+            )
+            rendered = self.render(expression, self.dark)
+            scanned.append(rendered)
+        substrings[index] = "".join(scanned)
 
-        return scanned
+    def process_plain_text(self, text: str) -> str:
+        text = text.replace("\n", "<br>")
+        return f'<span style="margin:0; padding:0;">{text}</span>'
 
     def scan(self) -> list[tuple[str, bool]]:
         # Use regex matching to find expressions
         pattern = r"(<br />.*?<br />)"
         substrings = re.split(pattern, self.raw_text)
 
-        scanned = []
         for index, s in enumerate(substrings):
             if s:
-                if self.containsMultiLineBlockExpression(s):
+                if self.contains_multiline_block_expression(s):
                     # Html is a multiline block expression
-                    group, end = self.processMultiLineBlockExpression(substrings, index)
-                    scanned.extend(group)
-                    substrings[index:end] = [""] * (end - index)
-                elif self.containsBlockExpression(s):
+                    self.process_multiline_block_expression(substrings, index)
+                elif self.contains_block_expression(s):
                     # Html substring contains a block expression
-                    group = self.processBlockExpression(s)
-                    scanned.extend(group)
-                elif self.containsInlineExpressions(s):
+                    self.process_block_expression(substrings, index)
+                elif self.contains_inline_expressions(s):
                     # Html substring contains inline math expressions
-                    group = self.processInlineExpressions(s)
-                    scanned.extend(group)
+                    self.process_inline_expressions(substrings, index)
                 elif ":Example:" in s:
-                    # We have reached the end of the section containing math expressions
-                    rest = "".join(substrings[index:])
-                    scanned.append((rest, False))
+                    # Break - we don't process any info below this line
                     break
                 else:
-                    # Html substring contains plain text only
-                    scanned.append((s, False))
-        return scanned
+                    # This is plain text
+                    substrings[index] = self.process_plain_text(s)
+
+        return "".join(substrings)
 
     @staticmethod
     def mask(text: str) -> str:
         return f"${text}$"
 
     @staticmethod
-    def render(expression: str, dark: bool = False) -> None:
+    def render(expression: str, dark: bool = False) -> str:
         # Create a figure containing the rendered LaTex expression
         fig, ax = plt.subplots(figsize=(0.01, 0.01))
         ax.axis("off")
@@ -139,6 +159,20 @@ class MathRenderer:
 
         # Cache rendered expression
         MathRenderer.set_cache(expression, image)
+
+        return (
+            MathRenderer.embed_html(image)
+            if len(expression) < 10
+            else MathRenderer.embed_html_large(image)
+        )
+
+    @staticmethod
+    def embed_html(image: str) -> str:
+        return f'<span style="vertical-align:middle;"><img src="data:image/png;base64,{image}" style="height:1em; display:inline;"></span>'
+
+    @staticmethod
+    def embed_html_large(image: str) -> str:
+        return f'<div style="text-align:left; margin:2px 0; padding:0;"><img src="data:image/png;base64,{image}" style="vertical-align:middle;"></div>'
 
     @classmethod
     def set_cache(cls, key, value) -> None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -9,7 +9,7 @@ from matplotlib import pyplot as plt
 
 class MathRenderer:
     # Cache mapping the raw LaTex expression to its rendered image form
-    cache = dict()
+    cache = {}
 
     # Ignore the following expression
     ignores = {"`\mathbf{q}`": "q"}
@@ -30,7 +30,7 @@ class MathRenderer:
         pattern = r"(:math:`.*?`)"
         substrings = re.split(pattern, self.raw_text)
 
-        scanned = dict()
+        scanned = {}
         for s in substrings:
             if not s:
                 # This is not a string - skip

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -1,0 +1,95 @@
+import re
+import io
+import base64
+from matplotlib import pyplot as plt
+from typing import List, Any
+
+
+class MathRenderer:
+    # Cache mapping the raw LaTex expression to its rendered image form
+    cache = dict()
+
+    # Ignore the following expression
+    ignores = {"`\mathbf{q}`": "q"}
+
+    def __init__(self, text: str) -> None:
+        self.raw_text = text
+
+    @staticmethod
+    def replace_ignored(text: str) -> str:
+        return MathRenderer.ignores[text]
+
+    @staticmethod
+    def ignore(text: str) -> bool:
+        return text in MathRenderer.ignores
+
+    def scan(self) -> List[Any]:
+        # Use regex matching to find expressions
+        pattern = r"(:math:`.*?`)"
+        substrings = re.split(pattern, self.raw_text)
+
+        scanned = []
+        for s in substrings:
+            if not s:
+                # This is not a string - skip
+                continue
+
+            # Get the raw expression content to check if it is ignored
+            raw_expr = s[len(":math:") :]
+            if self.ignore(raw_expr):
+                # We ignore rendering this
+                s = MathRenderer.replace_ignored(raw_expr)
+                substrings[-1] = s + substrings[-1]
+                continue
+
+            if s.startswith(":math:`") and s.endswith("`"):
+                # This is a raw LaTex expression string - instantiate object to identify it as such
+                expr = s[len(":math:`") : -1]
+                scanned.append(MathExpression(expr))
+            else:
+                # Normal text string
+                scanned.append(s)
+
+        return scanned
+
+    @staticmethod
+    def mask(text: str) -> str:
+        return f"${text}$"
+
+    @staticmethod
+    def render(expression: str) -> None:
+        # Create a figure containing the rendered LaTex expression
+        fig, ax = plt.subplots(figsize=(0.01, 0.01))
+        ax.axis("off")
+        fig.text(0, 0, MathRenderer.mask(expression), fontsize=10)
+
+        # Save the image as bytes
+        buffer = io.BytesIO()
+        plt.savefig(buffer, format="png", bbox_inches="tight", pad_inches=0.1, dpi=150)
+        plt.close(fig)
+        buffer.seek(0)
+        image = base64.b64encode(buffer.read()).decode("utf-8")
+
+        # Cache rendered expression
+        MathRenderer.set_cache(expression, image)
+
+    @classmethod
+    def set_cache(cls, key, value) -> None:
+        cls.cache.update({key: value})
+
+    @classmethod
+    def cached(cls, key) -> bool:
+        result = key in cls.cache.keys()
+        return result
+
+    @classmethod
+    def from_cache(cls, key):
+        return cls.cache[key]
+
+
+class MathExpression:
+    def __init__(self, expr: str):
+        self.expr = expr
+
+    def get(self) -> str:
+        return self.expr

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -12,7 +12,7 @@ class MathRenderer:
     cache = {}
 
     # Ignore the following expression
-    ignores = {"`\mathbf{q}`": "q"}
+    ignores = {r"`\mathbf{q}`": "q"}
 
     def __init__(self, text: str) -> None:
         self.raw_text = text

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -19,14 +19,11 @@ class MathRenderer:
     # Cache mapping the raw LaTex expression to its rendered image form
     cache = {}
 
-    # Ignore the following expression
-    ignores = {r"\mathbf{q}": "q"}
-
     # Inline expression marker
     INLINE = r":math:"
 
     # Multiline block expression marker
-    MULTILINE_BLOCK = r".. math::"
+    BLOCK = r".. math::"
 
     # Line breaks used
     BREAK = r"<br\s*/?>"
@@ -44,74 +41,6 @@ class MathRenderer:
         """
         self.raw_text = text
         self.dark = dark
-
-    @staticmethod
-    def replace_ignored(text: str) -> str:
-        """Returns a standard string to replace the instance of a mathematical expression that we do not want to render
-        as an image, but keep as plain text (i.e. a single variable that is referred to often).
-
-        Parameters
-        ----------
-        text : str
-            LaTex symbol for expression to be ignored.
-
-        Returns
-        -------
-        str
-            Plain text symbol to display instead of ignored expression.
-
-        """
-        return MathRenderer.ignores[text]
-
-    @staticmethod
-    def ignore(text: str) -> bool:
-        """Returns a boolean determining whether to replace the instance of a mathematical expression that we do not
-        want to render as an image, but keep as plain text (i.e. a single variable that is referred to often).
-
-        Parameters
-        ----------
-        text : str
-            LaTex symbol for expression to be ignored.
-
-        Returns
-        -------
-        bool
-            Boolean value - if true, we ignore the expression.
-
-        """
-        return text in MathRenderer.ignores
-
-    @staticmethod
-    def contains_multiline_block_expression(text: str) -> bool:
-        """Returns a boolean determining whether the current substring from the parent html description string contains
-        a multiline block expression.
-
-        This is assessed based on a regex search for the presence of the pattern ".. math::" enclosed within line breaks
-
-        For example:
-
-            '<br />.. math::<br />',
-            '\\hat{\\mathbf{n}}(t) =  \\frac{\\mathbf{r}_{i}(t)
-                                        - \\mathbf{r}_{j}(t)}{\\vert \\mathbf{r}_{i}(t) - \\mathbf{r}_{j}(t) \\vert}'
-            |                                                                                                          |
-            ____________________________________________________________________________________________________________
-                                                            ^
-                                                This is the block expression to be rendered
-
-        Parameters
-        ----------
-        text : str
-            Html string to be searched.
-
-        Returns
-        -------
-        bool
-            Boolean value - if true, this string contains a multiline block LaTex expression.
-
-        """
-        return (
-            re.search(f"<br />{MathRenderer.MULTILINE_BLOCK}<br />", text) is not None
-        )
 
     @staticmethod
     def contains_block_expression(text: str) -> bool:
@@ -139,7 +68,7 @@ class MathRenderer:
             Boolean value - if true, this string contains a block LaTex expression.
 
         """
-        return text.startswith(".. math:")
+        return re.search(MathRenderer.BLOCK, text)
 
     @staticmethod
     def contains_inline_expressions(text: str) -> bool:
@@ -182,8 +111,15 @@ class MathRenderer:
             Index of parent strings to be modified.
 
         """
-        expr = substrings[index].strip(f"{MathRenderer.MULTILINE_BLOCK}").strip("`")
+        expr = substrings[index].strip(f"{MathRenderer.BLOCK}").strip("`")
+        if MathRenderer.BLOCK in expr:
+            # Attempted to isolate expression but could not strip identifier, since it is enclosed in line breaks -
+            # this is a multiline block expression
+            self.process_multiline_block_expression(substrings, index)
+            return
+
         if not expr:
+            # Expression not located in same substring as identifier, try to locate it in the adjacent substring
             match = re.search(r"<br\s*/?>(.*?)<br\s*/?>", substrings[index + 1])
             expr = match.group(1).strip()
         substrings[index] = self.render(expr, self.dark)
@@ -196,7 +132,7 @@ class MathRenderer:
 
         Parameters
         ----------
-        substrings : str
+        strings : str
             Parent html string list.
 
         index : str
@@ -276,10 +212,7 @@ class MathRenderer:
 
         for index, s in enumerate(substrings):
             if s:
-                if self.contains_multiline_block_expression(s):
-                    # Html is a multiline block expression
-                    self.process_multiline_block_expression(substrings, index)
-                elif self.contains_block_expression(s):
+                if self.contains_block_expression(s):
                     # Html substring contains a block expression
                     self.process_block_expression(substrings, index)
                 elif self.contains_inline_expressions(s):
@@ -337,7 +270,7 @@ class MathRenderer:
             0,
             0,
             MathRenderer.mask(expression),
-            fontsize=7,
+            fontsize=5,
             color="white" if dark else "black",
         )
 
@@ -347,8 +280,8 @@ class MathRenderer:
             buffer,
             format="png",
             bbox_inches="tight",
-            pad_inches=0.1,
-            dpi=150,
+            pad_inches=0,
+            dpi=200,
             transparent=dark,
         )
         plt.close(fig)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -27,7 +27,7 @@ class MathRenderer:
 
     @staticmethod
     def containsMultiLineBlockExpression(text: str) -> bool:
-        return text == ".. math::" or text == r"<br />.. math::<br />"
+        return text in {".. math::", r"<br />.. math::<br />"}
 
     @staticmethod
     def containsBlockExpression(text: str) -> bool:
@@ -41,11 +41,13 @@ class MathRenderer:
 
     @staticmethod
     def processBlockExpression(text: str) -> list[tuple[str, bool]]:
-        return [(text[len(".. math:: "):], True)]
+        return [(text[len(".. math:: ") :], True)]
 
     @staticmethod
-    def processMultiLineBlockExpression(strings: list[str], n: int) -> tuple[list[tuple[str, bool]], int]:
-        substrings = strings[n+1:]
+    def processMultiLineBlockExpression(
+        strings: list[str], n: int
+    ) -> tuple[list[tuple[str, bool]], int]:
+        substrings = strings[n + 1 :]
         group = []
         for s in substrings:
             if (not s) or (s == r"<br /><br />"):
@@ -66,9 +68,9 @@ class MathRenderer:
         pattern = r"(:math:`.*?`)"
         substrings = re.split(pattern, text)
         scanned = []
-        for index, s in enumerate(substrings):
+        for s in substrings:
             if s.startswith(":math:"):
-                expr = s[len(":math:`"):-1]
+                expr = s[len(":math:`") : -1]
                 scanned.append((expr, True))
             else:
                 scanned.append((s, False))

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -40,8 +40,8 @@ class MathRenderer:
             raw_expr = s[len(":math:") :]
             if self.ignore(raw_expr):
                 # We ignore rendering this
-                s = MathRenderer.replace_ignored(raw_expr)
-                substrings[-1] = s + substrings[-1]
+                prefix = MathRenderer.replace_ignored(raw_expr)
+                substrings[-1] = prefix + substrings[-1]
                 continue
 
             if s.startswith(":math:`") and s.endswith("`"):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -85,5 +85,5 @@ class MathRenderer:
         return result
 
     @classmethod
-    def from_cache(cls, key):
+    def from_cache(cls, key) -> str:
         return cls.cache[key]

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/MathRenderer.py
@@ -61,7 +61,7 @@ class MathRenderer:
         # Create a figure containing the rendered LaTex expression
         fig, ax = plt.subplots(figsize=(0.01, 0.01))
         ax.axis("off")
-        fig.text(0, 0, MathRenderer.mask(expression), fontsize=10)
+        fig.text(0, 0, MathRenderer.mask(expression), fontsize=6)
 
         # Save the image as bytes
         buffer = io.BytesIO()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -56,7 +56,7 @@ class MathInfo(TextInfo):
         super().__init__(*args, **kwargs)
 
     @staticmethod
-    def scan(text: str) -> dict[str, bool]:
+    def scan(text: str) -> list[tuple[str, bool]]:
         # Instantiate renderer object
         renderer = MathRenderer(text)
 
@@ -64,7 +64,7 @@ class MathInfo(TextInfo):
         scanned = renderer.scan()
 
         # Iterate over scanned text, rendering LaTex substrings if image not already cached
-        for token, is_expression in scanned.items():
+        for token, is_expression in scanned:
             if is_expression and not MathRenderer.cached(token):
                 renderer.render(token)
 
@@ -75,7 +75,7 @@ class MathInfo(TextInfo):
         scanned = self.scan(filtered)
 
         html_substrings = []
-        for token, is_expression in scanned.items():
+        for token, is_expression in scanned:
             if is_expression:
                 image = MathRenderer.from_cache(token)
                 html_substrings.append(

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -58,44 +58,14 @@ class MathInfo(TextInfo):
     @staticmethod
     def scan(text: str) -> list[tuple[str, bool]]:
         # Instantiate renderer object
-        renderer = MathRenderer(text)
+        renderer = MathRenderer(
+            text, QApplication.styleHints().colorScheme() == Qt.ColorScheme.Dark
+        )
 
         # Scan text for existence of raw LaTex expressions
-        scanned = renderer.scan()
-
-        # Iterate over scanned text, rendering LaTex substrings if image not already cached
-        for token, is_expression in scanned:
-            if is_expression and not MathRenderer.cached(token):
-                renderer.render(
-                    token,
-                    QApplication.styleHints().colorScheme() == Qt.ColorScheme.Dark,
-                )
-
-        return scanned
+        return renderer.scan()
 
     def filter_text(self, some_text: str, line_break="<br />"):
         filtered = super().filter_text(some_text, line_break)
-        scanned = self.scan(filtered)
-
-        html_substrings = []
-        for token, is_expression in scanned:
-            if is_expression:
-                image = MathRenderer.from_cache(token)
-                if len(token) < 10:
-                    # This is a small expression, inline rendered expression
-                    html_substrings.append(
-                        f'<span style="vertical-align:middle;"><img src="data:image/png;base64,{image}" style="height:1em; display:inline;"></span>'
-                    )
-                else:
-                    # This is a large expression, it gets its own line
-                    html_substrings.append(
-                        f'<div style="text-align:left; margin:2px 0; padding:0;"><img src="data:image/png;base64,{image}" style="vertical-align:middle;"></div>'
-                    )
-            else:
-                # Format plain text
-                text = token.replace("\n", "<br>")
-                html_substrings.append(
-                    f'<span style="margin:0; padding:0;">{text}</span>'
-                )
-
-        return "".join(html_substrings)
+        result = self.scan(filtered)
+        return result

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -29,18 +29,18 @@ class TextInfo(QTextBrowser):
         self._footer = kwargs.pop("footer", "")
         super().__init__(*args, **kwargs)
         self.setOpenExternalLinks(True)
-        self.setHtml(self.filter(""))
+        self.setHtml(self.filter_text(""))
 
     @Slot(object)
     def update_panel(self, incoming: object):
-        filtered = self.filter(incoming)
+        filtered = self.filter_text(incoming)
         self.setHtml(filtered)
 
     @Slot(str)
     def append_text(self, new_text: str):
         self.append(new_text)
 
-    def filter(self, some_text: str, line_break="<br />"):
+    def filter_text(self, some_text: str, line_break="<br />"):
         new_text = ""
         if self._header:
             new_text += self._header + line_break
@@ -73,8 +73,8 @@ class MathInfo(TextInfo):
 
         return scanned
 
-    def filter(self, some_text: str, line_break="<br />"):
-        filtered = super().filter(some_text, line_break)
+    def filter_text(self, some_text: str, line_break="<br />"):
+        filtered = super().filter_text(some_text, line_break)
         scanned = self.scan(filtered)
 
         html_substrings = []

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QTextBrowser
+from .MathRenderer import MathRenderer, MathExpression
+from typing import List, Any
 
 
 class TextInfo(QTextBrowser):
@@ -47,3 +49,45 @@ class TextInfo(QTextBrowser):
         if self._footer:
             new_text += line_break + self._footer
         return new_text
+
+
+class MathInfo(TextInfo):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def is_expression(arg: Any) -> bool:
+        return isinstance(arg, MathExpression)
+
+    @staticmethod
+    def scan(text: str) -> List[Any]:
+        # Instantiate renderer object
+        renderer = MathRenderer(text)
+
+        # Scan text for existence of raw LaTex expressions
+        scanned = renderer.scan()
+
+        # Iterate over scanned text, rendering LaTex substrings if image not already cached
+        for token in scanned:
+            if MathInfo.is_expression(token):
+                if not MathRenderer.cached(token.get()):
+                    renderer.render(token.get())
+
+        return scanned
+
+    def filter(self, some_text: str, line_break="<br />"):
+        filtered = super().filter(some_text, line_break)
+        scanned = self.scan(filtered)
+
+        html_substrings = []
+        for token in scanned:
+            if self.is_expression(token):
+                image = MathRenderer.from_cache(token.get())
+                html_substrings.append(
+                    f'<div style="text-align:center; margin:4px 0;">'
+                    f'<img src="data:image/png;base64, {image}"></div>'
+                )
+            else:
+                html_substrings.append(f"<p>{token}</p>")
+
+        return "".join(html_substrings)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -80,13 +80,19 @@ class MathInfo(TextInfo):
                 image = MathRenderer.from_cache(token)
                 if len(token) < 10:
                     # This is a small expression, inline rendered expression
-                    html_substrings.append(f'<span style="vertical-align:middle;"><img src="data:image/png;base64,{image}" style="height:1em; display:inline;"></span>')
+                    html_substrings.append(
+                        f'<span style="vertical-align:middle;"><img src="data:image/png;base64,{image}" style="height:1em; display:inline;"></span>'
+                    )
                 else:
                     # This is a large expression, it gets its own line
-                    html_substrings.append(f'<div style="text-align:left; margin:2px 0; padding:0;"><img src="data:image/png;base64,{image}" style="vertical-align:middle;"></div>')
+                    html_substrings.append(
+                        f'<div style="text-align:left; margin:2px 0; padding:0;"><img src="data:image/png;base64,{image}" style="vertical-align:middle;"></div>'
+                    )
             else:
                 # Format plain text
                 text = token.replace("\n", "<br>")
-                html_substrings.append(f'<span style="margin:0; padding:0;">{text}</span>')
+                html_substrings.append(
+                    f'<span style="margin:0; padding:0;">{text}</span>'
+                )
 
         return "".join(html_substrings)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -15,8 +15,8 @@
 #
 from __future__ import annotations
 
-from qtpy.QtCore import Signal, Slot
-from qtpy.QtWidgets import QTextBrowser
+from qtpy.QtCore import Signal, Slot, Qt
+from qtpy.QtWidgets import QTextBrowser, QApplication
 
 from .MathRenderer import MathRenderer
 
@@ -66,7 +66,10 @@ class MathInfo(TextInfo):
         # Iterate over scanned text, rendering LaTex substrings if image not already cached
         for token, is_expression in scanned:
             if is_expression and not MathRenderer.cached(token):
-                renderer.render(token)
+                renderer.render(
+                    token,
+                    QApplication.styleHints().colorScheme() == Qt.ColorScheme.Dark,
+                )
 
         return scanned
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QTextBrowser
+
 from .MathRenderer import MathRenderer
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -78,11 +78,15 @@ class MathInfo(TextInfo):
         for token, is_expression in scanned:
             if is_expression:
                 image = MathRenderer.from_cache(token)
-                html_substrings.append(
-                    f'<div style="text-align:center; margin:4px 0;">'
-                    f'<img src="data:image/png;base64, {image}"></div>'
-                )
+                if len(token) < 10:
+                    # This is a small expression, inline rendered expression
+                    html_substrings.append(f'<span style="vertical-align:middle;"><img src="data:image/png;base64,{image}" style="height:1em; display:inline;"></span>')
+                else:
+                    # This is a large expression, it gets its own line
+                    html_substrings.append(f'<div style="text-align:left; margin:2px 0; padding:0;"><img src="data:image/png;base64,{image}" style="vertical-align:middle;"></div>')
             else:
-                html_substrings.append(f"<p>{token}</p>")
+                # Format plain text
+                text = token.replace("\n", "<br>")
+                html_substrings.append(f'<span style="margin:0; padding:0;">{text}</span>')
 
         return "".join(html_substrings)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -15,8 +15,8 @@
 #
 from __future__ import annotations
 
-from qtpy.QtCore import Signal, Slot, Qt
-from qtpy.QtWidgets import QTextBrowser, QApplication
+from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtWidgets import QApplication, QTextBrowser
 
 from .MathRenderer import MathRenderer
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -64,9 +64,8 @@ class MathInfo(TextInfo):
 
         # Iterate over scanned text, rendering LaTex substrings if image not already cached
         for token, is_expression in scanned.items():
-            if is_expression:
-                if not MathRenderer.cached(token):
-                    renderer.render(token)
+            if is_expression and not MathRenderer.cached(token):
+                renderer.render(token)
 
         return scanned
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TextInfo.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QTextBrowser
-from .MathRenderer import MathRenderer, MathExpression
-from typing import List, Any
+from .MathRenderer import MathRenderer
 
 
 class TextInfo(QTextBrowser):
@@ -56,11 +55,7 @@ class MathInfo(TextInfo):
         super().__init__(*args, **kwargs)
 
     @staticmethod
-    def is_expression(arg: Any) -> bool:
-        return isinstance(arg, MathExpression)
-
-    @staticmethod
-    def scan(text: str) -> List[Any]:
+    def scan(text: str) -> dict[str, bool]:
         # Instantiate renderer object
         renderer = MathRenderer(text)
 
@@ -68,10 +63,10 @@ class MathInfo(TextInfo):
         scanned = renderer.scan()
 
         # Iterate over scanned text, rendering LaTex substrings if image not already cached
-        for token in scanned:
-            if MathInfo.is_expression(token):
-                if not MathRenderer.cached(token.get()):
-                    renderer.render(token.get())
+        for token, is_expression in scanned.items():
+            if is_expression:
+                if not MathRenderer.cached(token):
+                    renderer.render(token)
 
         return scanned
 
@@ -80,9 +75,9 @@ class MathInfo(TextInfo):
         scanned = self.scan(filtered)
 
         html_substrings = []
-        for token in scanned:
-            if self.is_expression(token):
-                image = MathRenderer.from_cache(token.get())
+        for token, is_expression in scanned.items():
+            if is_expression:
+                image = MathRenderer.from_cache(token)
                 html_substrings.append(
                     f'<div style="text-align:center; margin:4px 0;">'
                     f'<img src="data:image/png;base64, {image}"></div>'


### PR DESCRIPTION
**Description of work**
Currently, the Job tab info does not render the embedded LaTex expression strings, which can look less informative and cluttered. This PR proposes an enhancement in which images (rendered in a simple `matplotlib` figure) of the expression are inserted into the html of the Job tab, allowing mathematical expressions to be displayed in the text.

**Fixes**
Before:
<img width="1855" height="624" alt="Screenshot 2025-09-26 094524" src="https://github.com/user-attachments/assets/bc006b9e-e721-4741-9f12-6f9074f09171" />

After:
<img width="1752" height="621" alt="Screenshot 2025-09-26 094921" src="https://github.com/user-attachments/assets/269e605d-e33e-4a56-b85c-0a78f11c4868" />



**To test**
Please describe the tests that were run to verify the changes.
