### PR TITLE
Replace kwargs with actual arguments where relevant

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomMapping/atom_mapping.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 import re
-from typing import TypeVar
+from typing import SupportsFloat, TypeVar
 
 import numpy as np
 
@@ -26,7 +26,7 @@ AtLabel = TypeVar("AtLabel", bound="AtomLabel")
 
 
 class AtomLabel:
-    def __init__(self, atm_label: str, **kwargs):
+    def __init__(self, atm_label: str, mass: SupportsFloat | None = None, **kwargs):
         """Creates an atom label object which is used for atom mapping
         and atom type guessing.
 
@@ -41,14 +41,11 @@ class AtomLabel:
         # methods as of writing e.g. re.sub
         translation = str.maketrans("", "", ";=")
         self.atm_label = atm_label.translate(translation)
-        self.grp_label = ""
-        if kwargs:
-            for k, v in kwargs.items():
-                self.grp_label += f"{k}={str(v).translate(translation)};"
-            self.grp_label = self.grp_label[:-1]
-        self.mass = kwargs.get("mass")
-        if self.mass is not None:
-            self.mass = float(self.mass)
+        self.grp_label = ";".join(
+            f"{k}={str(v).translate(translation)}"
+            for k, v in (kwargs | {"mass": mass}).items()
+        )
+        self.mass = None if mass in {None, "None"} else float(mass)
 
     def __eq__(self, other: AtLabel) -> bool:
         """Used to check if atom labels are equal.
@@ -249,12 +246,8 @@ def mapping_to_labels(mapping: dict[str, dict[str, str]]) -> list[AtomLabel]:
     """
     labels = []
     for grp_label, atm_map in mapping.items():
-        kwargs = {}
-        if grp_label:
-            for k, v in [i.split("=") for i in grp_label.split(";")]:
-                kwargs[k] = v
-        for atm_label in atm_map:
-            labels.append(AtomLabel(atm_label, **kwargs))
+        kwargs = dict(i.split("=") for i in grp_label.split(";") if i)
+        labels.extend(AtomLabel(atm_label, **kwargs) for atm_label in atm_map)
     return labels
 
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AseInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AseInputFileConfigurator.py
@@ -28,7 +28,13 @@ class AseInputFileConfigurator(InputFileConfigurator):
     _default = ""
     _allowed_formats = ["guess"] + [str(x) for x in all_formats]
 
-    def __init__(self, name, wildcard="All files (*)", **kwargs):
+    def __init__(
+        self,
+        name: str,
+        wildcard: str = "All files (*)",
+        format: str | None = None,
+        **kwargs,
+    ):
         """
         Initializes the configurator object.
 
@@ -43,7 +49,7 @@ class AseInputFileConfigurator(InputFileConfigurator):
         InputFileConfigurator.__init__(self, name, **kwargs)
 
         self.wildcard = wildcard
-        self["format"] = kwargs.get("format")
+        self["format"] = format
         self["value"] = ""
 
     def configure(self, values):

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
@@ -14,9 +14,9 @@ class DistHistCutoffConfigurator(RangeConfigurator):
     the periodic image of any atom in the system.
     """
 
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, max_value: bool = True, **kwargs):
         super().__init__(name, **kwargs)
-        self._max_value = kwargs.get("max_value", True)
+        self._max_value = max_value
 
     def configure(self, value):
         """Configure the distance histogram cutoff configurator.

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
@@ -109,7 +109,7 @@ class IConfigurator(dict, metaclass=SubclassFactory):
         name: str,
         *,
         configurable: Configurable | None = None,
-        root: None = None,
+        root: type | None = None,
         dependencies: dict[str, str] | None = None,
         default: Any | None = None,
         label: str | None = None,
@@ -137,21 +137,16 @@ class IConfigurator(dict, metaclass=SubclassFactory):
         ]
 
         self.configurable = configurable
-
         self.root = root
-
         self.dependencies = dependencies or {}
-
         self.default = default or type(self)._default
-
-        self.label = label or getattr(
-            type(self), "label", name.replace("_", " ").strip()
+        self.label = (
+            label
+            or getattr(type(self), "label", None)
+            or name.replace("_", " ").strip()
         )
-
         self.optional = optional
-
         self.configured = False
-
         self.valid = True
 
         self._error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTopologyFileConfigurator.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 import MDAnalysis as mda
+from more_itertools import first
 
 from MDANSE.Framework.AtomMapping import AtomLabel
 
@@ -76,19 +77,19 @@ class MDAnalysisTopologyFileConfigurator(FileWithAtomDataConfigurator):
         AtomLabel
             An atom label.
         """
-        args = []
-        for arg in ["element", "name", "type", "resname", "mass"]:
-            if hasattr(self.atoms[0], arg):
-                args.append(arg)
-        if len(args) == 0:
+        args = [
+            arg
+            for arg in ("element", "name", "type", "resname", "mass")
+            if hasattr(self.atoms[0], arg)
+        ]
+
+        if not args:
             yield from []
             return
 
         for at in self.atoms:
-            kwargs = {}
-            for arg in args:
-                kwargs[arg] = getattr(at, arg)
+            kwargs = {arg: getattr(at, arg) for arg in args}
             # the first out of the list above will be the main label
-            (k, main_label) = next(iter(kwargs.items()))
+            k, main_label = first(kwargs.items())
             kwargs.pop(k)
             yield AtomLabel(main_label, **kwargs)

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -384,13 +384,13 @@ class Filter(ABC):
         FUNDAMENTAL_EVENLY_DIVIDES_FS: int = 2
 
     @abstractmethod
-    def __init__(self, **kwargs):
+    def __init__(self, n_steps: int, time_step_ps: float, **kwargs):
         # Custom frequency range (assumes frequencies are angular) around which to compute the filter frequency response
         self.custom_freq_range = []
         # Number of simulation steps
-        self.n_steps = kwargs.pop("n_steps")
+        self.n_steps = n_steps
         # Simulation sample frequency in THz
-        self.sample_freq = 1 / kwargs.pop("time_step_ps")
+        self.sample_freq = 1 / time_step_ps
         self.set_filter_attributes(kwargs)
 
     def compute_frequencies(


### PR DESCRIPTION
**Description of work**
Excessive or unnecessary use of kwargs can obscure parameters, argument hinting in IDEs, not support type-hints and hide invalid arguments being passed by ignoring them.

**Fixes**
Replace some unnecessary uses of `**kwargs` in the `MDANSE` source.

**To test**
Should be no functional changes.
