### PR TITLE
Correct atom transmutation configurator error status

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomTransmutationConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomTransmutationConfigurator.py
@@ -127,6 +127,7 @@ class AtomTransmutationConfigurator(IConfigurator):
         # if the input value is None, do not perform any transmutation
         if value in {None, "", "{}"}:
             self.transmutation = {}
+            self.error_status = "OK"
             return
 
         if not isinstance(value, str):


### PR DESCRIPTION
**Description of work**
Set error status to OK when no transmutations are carried out

**Fixes**
Fixes #988

**To test**
In the GUI manually edit the atom transmutation line and check that the error clears correctly.
