### PR TITLE
Fix results preview box size update

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -15,7 +15,6 @@
 #
 from __future__ import annotations
 
-import math
 import traceback
 from pathlib import Path
 
@@ -24,9 +23,10 @@ from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QCheckBox,
     QFileDialog,
+    QGroupBox,
     QHBoxLayout,
+    QLabel,
     QPushButton,
-    QTextEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -306,10 +306,10 @@ class Action(QWidget):
         self.check_inputs()
 
         if self._use_preview and "preview_box" not in self._widgets_in_layout:
-            self._preview_box = QTextEdit(self)
-            self._preview_box.setLineWrapMode(QTextEdit.NoWrap)
-            self._preview_box.setReadOnly(True)
-            self.layout.addWidget(self._preview_box)
+            box = QGroupBox("results preview")
+            self._preview_box = QLabel(self)
+            QHBoxLayout(box).addWidget(self._preview_box)
+            self.layout.addWidget(box)
             self._widgets_in_layout["preview_box"] = self._preview_box
 
         if "button_base" not in self._widgets_in_layout:
@@ -421,15 +421,7 @@ class Action(QWidget):
                     text += f"<p>{array} ({new_unit})</p>"
                 else:
                     text += f"<p>[{array[0]}, {array[1]}, {array[2]}, ..., {array[-1]}] ({new_unit})</p>"
-            self._preview_box.setHtml(text)
-            self._preview_box.document().adjustSize()
-            self._preview_box.setFixedHeight(
-                math.ceil(
-                    self._preview_box.document().size().height()
-                    + self._preview_box.contentsMargins().top()
-                    + self._preview_box.contentsMargins().bottom()
-                )
-            )
+            self._preview_box.setText(text)
 
     @Slot()
     def allow_execution(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -310,7 +310,7 @@ class Action(QWidget):
             self._preview_box = QLabel(self)
             QHBoxLayout(box).addWidget(self._preview_box)
             self.layout.addWidget(box)
-            self._widgets_in_layout["preview_box"] = self._preview_box
+            self._widgets_in_layout["preview_box"] = box
 
         if "button_base" not in self._widgets_in_layout:
             buttonbase = QWidget(self)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -307,6 +307,7 @@ class Action(QWidget):
 
         if self._use_preview and "preview_box" not in self._widgets_in_layout:
             self._preview_box = QTextEdit(self)
+            self._preview_box.setLineWrapMode(QTextEdit.NoWrap)
             self.layout.addWidget(self._preview_box)
             self._widgets_in_layout["preview_box"] = self._preview_box
 
@@ -420,16 +421,13 @@ class Action(QWidget):
                 else:
                     text += f"<p>[{array[0]}, {array[1]}, {array[2]}, ..., {array[-1]}] ({new_unit})</p>"
             self._preview_box.setHtml(text)
-            # need to use singleshot to ensure we get the right height
-            QTimer.singleShot(
-                0,
-                lambda: self._preview_box.setFixedHeight(
-                    math.ceil(
-                        self._preview_box.document().size().height()
-                        + self._preview_box.contentsMargins().top()
-                        + self._preview_box.contentsMargins().bottom()
-                    )
-                ),
+            self._preview_box.document().adjustSize()
+            self._preview_box.setFixedHeight(
+                math.ceil(
+                    self._preview_box.document().size().height()
+                    + self._preview_box.contentsMargins().top()
+                    + self._preview_box.contentsMargins().bottom()
+                )
             )
 
     @Slot()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -20,7 +20,7 @@ import traceback
 from pathlib import Path
 
 import numpy as np
-from qtpy.QtCore import QTimer, Signal, Slot
+from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QCheckBox,
     QFileDialog,
@@ -308,6 +308,7 @@ class Action(QWidget):
         if self._use_preview and "preview_box" not in self._widgets_in_layout:
             self._preview_box = QTextEdit(self)
             self._preview_box.setLineWrapMode(QTextEdit.NoWrap)
+            self._preview_box.setReadOnly(True)
             self.layout.addWidget(self._preview_box)
             self._widgets_in_layout["preview_box"] = self._preview_box
 


### PR DESCRIPTION
**Description of work**
The preview box size didn't update correctly when the trajectory was loaded with an analysis job already selected. This PR fixes this issue.

**To test**
Check that the results preview box size updates correctly.
