### PR TITLE
Add tab for viewing properties of `Trajectory`s in GUI

### DIFF
--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -207,7 +207,7 @@ class H5MDTrajectory(TrajectoryFile):
         """Mapping of property labels to units."""
         return ChainMap(
             self._units,
-            {"b_incoherent": "Ang", "b_coherent": "Ang"},
+            {"b_incoherent": "ang", "b_coherent": "ang"},
             ATOMS_DATABASE.units,
         )
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -38,6 +38,7 @@ from qtpy.QtWidgets import (
 )
 
 from MDANSE_GUI.MolecularViewer.MolecularViewer import MolecularViewer
+from MDANSE_GUI.MolecularViewer.PropertyWidget import PropertyWidget
 from MDANSE_GUI.MolecularViewer.TraceWidget import TraceWidget
 from MDANSE_GUI.Tabs.Views.Delegates import ColourPicker, RadiusSpinBox
 
@@ -189,6 +190,7 @@ class ViewerControls(QWidget):
         layout = QVBoxLayout(base)
         base.setLayout(layout)
         self._side_base.addTab(base, "Controls")
+
         # colour changes
         wrapper0 = QGroupBox("Colour settings", base)
         layout0 = QHBoxLayout(wrapper0)
@@ -199,6 +201,7 @@ class ViewerControls(QWidget):
         layout0.addWidget(bkg_button)
         layout0.addWidget(proj_button)
         layout.addWidget(wrapper0)
+
         # the table of chemical elements
         wrapper1 = QGroupBox("Atom properties", base)
         layout1 = QHBoxLayout(wrapper1)
@@ -213,6 +216,7 @@ class ViewerControls(QWidget):
         layout1.addWidget(self._atom_details)
         wrapper1.setLayout(layout1)
         layout.addWidget(wrapper1)
+
         # the widget selecting time per animation frame
         wrapper2 = QGroupBox("Time per frame (ms)", base)
         layout2 = QHBoxLayout(wrapper2)
@@ -225,6 +229,7 @@ class ViewerControls(QWidget):
         layout2.addWidget(frame_time_selector)
         wrapper2.setLayout(layout2)
         layout.addWidget(wrapper2)
+
         # the widget for frame skipping
         wrapper3 = QGroupBox("Show every N frames", base)
         layout3 = QHBoxLayout(wrapper3)
@@ -237,6 +242,7 @@ class ViewerControls(QWidget):
         layout3.addWidget(frame_skip)
         wrapper3.setLayout(layout3)
         layout.addWidget(wrapper3)
+
         # the widget for atom size scaling
         wrapper4 = QGroupBox("Atom size scaling", base)
         layout4 = QHBoxLayout(wrapper4)
@@ -310,6 +316,19 @@ class ViewerControls(QWidget):
         self._trace_widget.initialise_values(viewer)
         layout.addWidget(self._trace_widget)
         return self._trace_widget
+
+    def create_property_viewer(self, viewer):
+        """Adds widget for viewing trajectory properties."""
+        base = QWidget(self)
+        base.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum)
+        layout = QVBoxLayout(base)
+        base.setLayout(layout)
+        self._side_base.addTab(base, "Property viewer")
+        # colour changes
+        self._property_widget = PropertyWidget(viewer)
+        # self._property_widget.initialise_values(viewer)
+        layout.addWidget(self._property_widget)
+        return self._property_widget
 
     @Slot()
     def set_background_colour(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -144,6 +144,7 @@ class ViewerControls(QWidget):
     def setViewer(self, viewer: MolecularViewer):
         self._viewer = viewer
         self._splitter.addWidget(viewer)
+        self._splitter.setCollapsible(0, False)
         self._frame_slider.valueChanged.connect(viewer.set_coordinates)
         viewer.new_max_frames.connect(self._frame_slider.setMaximum)
         viewer.new_max_frames.connect(self._frame_selector.setMaximum)
@@ -184,7 +185,7 @@ class ViewerControls(QWidget):
     def createSidePanel(self):
         """Adds widgets for finer control of the playback"""
         absolute_base = QTabWidget(self)
-        absolute_base.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
+        absolute_base.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Expanding)
         self._side_base = absolute_base
         base = QWidget(self)
         layout = QVBoxLayout(base)
@@ -325,7 +326,8 @@ class ViewerControls(QWidget):
         base.setLayout(layout)
         self._side_base.addTab(base, "Property viewer")
         # colour changes
-        self._property_widget = PropertyWidget(viewer)
+        self._property_widget = PropertyWidget(viewer, self._side_base.indexOf(base))
+        self._side_base.currentChanged.connect(self._property_widget._active)
         # self._property_widget.initialise_values(viewer)
         layout.addWidget(self._property_widget)
         return self._property_widget

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -62,6 +62,7 @@ class MolecularViewer(QtWidgets.QWidget):
     of molecular structures, currently implemented in VTK."""
 
     new_max_frames = Signal(int)
+    frame_changed = Signal()
     changed_trace = Signal()
 
     def __init__(self):
@@ -986,6 +987,17 @@ class MolecularViewer(QtWidgets.QWidget):
         self._trace_dialog.remove_atom_trace.connect(self.delete_isosurface_from_dialog)
         self.changed_trace.connect(self._trace_dialog.update_limits)
 
+    def create_property_viewer_dialog(self, viewer_controls):
+        """Creates and connects an additional panel of the GUI which contains
+        an instance of PropertyWidget.
+
+        Parameters
+        ----------
+        viewer_controls : ViewerControls
+            instance of the ViewerControls widget from View3D
+        """
+        self._property_dialog = viewer_controls.create_property_viewer(self)
+
     @property
     def renderer(self):
         return self._renderer
@@ -1010,6 +1022,7 @@ class MolecularViewer(QtWidgets.QWidget):
 
         # Update the view.
         self.update_renderer()
+        self.frame_changed.emit()
 
     def set_reader(self, reader):
         """Sets the input object to be the new source of atom data for
@@ -1085,6 +1098,7 @@ class MolecularViewer(QtWidgets.QWidget):
         self._colour_manager.onNewValues()
         self.new_max_frames.emit(self._n_frames - 1)
         self._trace_dialog.update_limits()
+        self._property_dialog.extract_props(self._reader._trajectory)
 
     @Slot(object)
     def take_atom_properties(self, data):

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from collections import ChainMap
+from collections.abc import Callable, Sequence
+from functools import partial
+from itertools import count
+
+import h5py
+from more_itertools import prepend
+from qtpy.QtCore import Slot
+from qtpy.QtGui import QStandardItem, QStandardItemModel
+from qtpy.QtWidgets import QComboBox, QTableView, QVBoxLayout, QWidget
+
+from MDANSE.MolecularDynamics.Trajectory import Trajectory
+
+
+class PropertyWidget(QWidget):
+    def __init__(self, parent: QWidget):
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+        self.setLayout(layout)
+        self.viewer = self.parent()
+        self._last_prop = None
+        self._populate_layout()
+        self.viewer.frame_changed.connect(self.update_table)
+
+    def _populate_layout(self) -> None:
+        """Initialise layout.
+
+        Creates all the widgets, places them in the layout and
+        connects their signals and slots.
+        """
+        layout = self.layout()
+
+        self._prop_type = QComboBox(self)
+        self._prop_type.setEditable(False)
+        self._prop_type.addItems(["atoms", "trajectory"])
+        self._prop_type.setCurrentIndex(0)
+        self._prop_type.currentTextChanged.connect(self.get_props)
+
+        self._prop_selection = QComboBox(self)
+        self._prop_selection.setEditable(False)
+        self._prop_selection.currentTextChanged.connect(self.update_table)
+
+        self._prop_model = QStandardItemModel()
+        self._prop_table = QTableView(self)
+        self._prop_table.setModel(self._prop_model)
+
+        layout.addWidget(self._prop_type)
+        layout.addWidget(self._prop_selection)
+        layout.addWidget(self._prop_table)
+
+    def _extract_atom_prop(self, atom_prop: str) -> list:
+        return [
+            self._trajectory.get_atom_property(symbol, atom_prop)
+            for symbol in self._trajectory.atom_names
+        ]
+
+    def extract_props(self, trajectory: Trajectory) -> None:
+        self._prop_selection.clear()
+        self._trajectory = trajectory
+        self._atom_props: dict[str, Callable[[], Sequence]] = {
+            **{
+                property_name: partial(self._extract_atom_prop, property_name)
+                for property_name in trajectory.properties
+            },
+        }
+
+        self._raw_props: dict[str, Callable[[], Sequence]] = {
+            f"raw_{property_name}": partial(trajectory.variable, property_name)
+            for property_name in trajectory.variables()
+        }
+        self._frame_props: dict[str, Callable[[int], Sequence]] = {
+            prop: getattr(trajectory, prop)
+            for prop in ("charges", "coordinates", "unit_cell")
+        }
+
+        self._trajectory_props = ChainMap(self._frame_props, self._raw_props)
+
+        self.get_props()
+
+    @Slot()
+    def get_props(self) -> NOne:
+        self._prop_selection.clear()
+
+        match self._prop_type.currentText():
+            case "atoms":
+                self.curr_selection = self._atom_props
+            case "trajectory":
+                self.curr_selection = self._trajectory_props
+
+        self._last_prop = None
+        self._prop_selection.addItems(self.curr_selection.keys())
+
+    @staticmethod
+    def _make_items(*items) -> list[QStandardItem]:
+        items = [QStandardItem(str(item)) for item in items]
+        for item in items:
+            item.setEditable(False)
+        return items
+
+    def _set_horiz_labels(self, *items) -> None:
+        for i, label in enumerate(items):
+            idx = QStandardItem(str(label))
+            self._prop_model.setHorizontalHeaderItem(i, idx)
+
+
+    @Slot()
+    def update_table(self) -> None:
+        frame = self.viewer._current_frame
+        prop_name = self._prop_selection.currentText()
+        if not prop_name:
+            self._prop_model.clear()
+            return
+        prop_change = prop_name != self._last_prop
+
+        match self._prop_type.currentText():
+            case "atoms" if prop_change:
+                self._prop_model.clear()
+                for (i, name), prop in zip(
+                    enumerate(self._trajectory.atom_names),
+                    self.curr_selection[prop_name](),
+                    strict=True,
+                ):
+                    items = self._make_items(name, prop)
+                    self._prop_model.appendRow(items)
+
+                    idx = QStandardItem(str(i))
+                    self._prop_model.setVerticalHeaderItem(i, idx)
+
+                self._set_horiz_labels("name", prop_name)
+
+
+            case "trajectory" if prop_name in self._frame_props:
+
+                data = self.curr_selection[prop_name](frame)
+                self._prop_model.clear()
+
+                match prop_name:
+                    case "charges":
+                        for (i, name), prop in zip(
+                            enumerate(self._trajectory.atom_names),
+                            data,
+                            strict=True,
+                        ):
+                            items = self._make_items(name, prop)
+                            self._prop_model.appendRow(items)
+
+                            idx = QStandardItem(str(i))
+                            self._prop_model.setVerticalHeaderItem(i, idx)
+
+                        self._set_horiz_labels("name", "charge")
+
+                    case "coordinates":
+                        for (i, name), prop in zip(
+                            enumerate(self._trajectory.atom_names),
+                            data,
+                            strict=True,
+                        ):
+                            items = self._make_items(name, *prop)
+                            self._prop_model.appendRow(items)
+
+                            idx = QStandardItem(str(i))
+                            self._prop_model.setVerticalHeaderItem(i, idx)
+
+                        self._set_horiz_labels("name", "x", "y", "z")
+
+                    case "unit_cell":
+                        if not data:
+                            items = self._make_items("No unit cell")
+                            self._prop_model.appendRow(items)
+                            return
+
+                        for prop in data.direct:
+                            items = self._make_items(*prop)
+                            self._prop_model.appendRow(items)
+
+                        for i, label in enumerate("xyz"):
+                            idx = QStandardItem(label)
+                            self._prop_model.setVerticalHeaderItem(i, idx)
+                            idx = QStandardItem(label)
+                            self._prop_model.setHorizontalHeaderItem(i, idx)
+
+                self._prop_table.resizeColumnsToContents()
+
+            case "trajectory":
+                data = self.curr_selection[prop_name]()
+                if not isinstance(data, h5py.Dataset):
+                    return
+
+                match data.shape:
+                    case (
+                        self.viewer._n_frames,
+                        self.viewer._n_atoms,
+                        *_,
+                    ):  # Atom property?
+                        self._prop_model.clear()
+
+                        for (i, name), prop in zip(
+                            enumerate(self._trajectory.atom_names),
+                            data[frame, :, ...],
+                            strict=True,
+                        ):
+                            items = self._make_items(name, *prop)
+                            self._prop_model.appendRow(items)
+
+                            idx = QStandardItem(str(i))
+                            self._prop_model.setVerticalHeaderItem(i, idx)
+
+                    case self.viewer._n_atoms if prop_change:  # Constant atom property
+                        self._prop_model.clear()
+
+                        for (i, name), prop in zip(
+                            enumerate(self._trajectory.atom_names),
+                            data,
+                            strict=True,
+                        ):
+                            items = self._make_items(name, prop)
+                            self._prop_model.appendRow(items)
+
+                            idx = QStandardItem(str(i))
+                            self._prop_model.setVerticalHeaderItem(i, idx)
+
+                    case (self.viewer._n_frames, *_):  # System property
+                        self._prop_model.clear()
+
+                        for prop in data[frame, ...]:
+                            items = self._make_items(name, *prop)
+                            self._prop_model.appendRow(items)
+
+                    case _ if prop_change:  # Constant system property
+                        self._prop_model.clear()
+
+                        for prop in data:
+                            items = self._make_items(*prop)
+                            self._prop_model.appendRow(items)
+
+                self._set_horiz_labels(*range(self._prop_model.columnCount()))
+
+        self._last_prop = prop_name

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
@@ -4,15 +4,13 @@ from collections import ChainMap
 from collections.abc import Callable, Sequence
 from enum import Enum, auto
 from functools import partial
-from itertools import count
 from typing import Any
 
-import h5py
-from more_itertools import prepend
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtGui import QStandardItem, QStandardItemModel
 from qtpy.QtWidgets import QComboBox, QTableView, QVBoxLayout, QWidget
 
+from MDANSE.Chemistry import ATOMS_DATABASE
 from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
 
@@ -156,7 +154,8 @@ class PropertyWidget(QWidget):
                 self.curr_selection = self._trajectory_props
 
         self._last_prop = None
-        self._prop_selection.addItems(self.curr_selection.keys())
+
+        self._prop_selection.addItems(sorted(filter(None, self.curr_selection)))
 
     @staticmethod
     def _make_items(*items: Any) -> list[QStandardItem]:
@@ -190,7 +189,7 @@ class PropertyWidget(QWidget):
             idx = QStandardItem(str(label))
             self._prop_model.setHorizontalHeaderItem(i, idx)
 
-    def _set_vert_labels(self, *items: str) -> None:
+    def _set_vert_labels(self, *items) -> None:
         """Set vertical labels.
 
         Parameters
@@ -198,7 +197,7 @@ class PropertyWidget(QWidget):
         *items : str
             Labels to use, if not specified atom-indices are used.
         """
-        if items is None:
+        if not items:
             items = range(self.viewer._n_atoms)
 
         for i, label in enumerate(items):
@@ -239,8 +238,14 @@ class PropertyWidget(QWidget):
                     items = self._make_items(atom_name, prop)
                     self._prop_model.appendRow(items)
 
-                self._set_horiz_labels("name", name)
+                header = (
+                    name
+                    if (unit := self._trajectory.units.get(prop_name, "none")) == "none"
+                    else f"{name} ({unit})"
+                )
+                self._set_horiz_labels("name", header)
                 self._set_vert_labels()
+
             case ("trajectory", "charges"):
                 self.update = _Update.TRAJECTORY_ATOM_PROP
 
@@ -281,7 +286,7 @@ class PropertyWidget(QWidget):
                     self._prop_model.appendRow(items)
 
                 self._set_horiz_labels("x", "y", "z")
-                self._set_vert_labels("x", "y", "z")
+                self._set_vert_labels("a", "b", "c")
 
             case ("trajectory", _):
                 n_frames = Const(self.viewer._n_frames)
@@ -365,7 +370,7 @@ class PropertyWidget(QWidget):
                         self._prop_model.item(i, j).setText(str(elem))
             case _Update.TRAJECTORY_ATOM_PROP:
                 for i, elem in enumerate(data):
-                    self._prop_model.item(1, i).setText(str(elem))
+                    self._prop_model.item(i, 1).setText(str(elem))
 
             case _Update.RAW_ATOM_PROP:
                 for i, row in enumerate(data[frame, :, ...]):

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
@@ -2,20 +2,46 @@ from __future__ import annotations
 
 from collections import ChainMap
 from collections.abc import Callable, Sequence
+from enum import Enum, auto
 from functools import partial
 from itertools import count
+from typing import Any
 
 import h5py
 from more_itertools import prepend
-from qtpy.QtCore import Slot
+from qtpy.QtCore import Qt, Slot
 from qtpy.QtGui import QStandardItem, QStandardItemModel
 from qtpy.QtWidgets import QComboBox, QTableView, QVBoxLayout, QWidget
 
 from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
 
+class Const:
+    """Dummy namespace for ``match`` syntax."""
+
+    def __init__(self, value):
+        self.v = value
+
+
+class _Update(Enum):
+    """Scheme for update based on datatypes"""
+
+    NO_UPDATE = auto()
+    UNIT_CELL = auto()
+    TRAJECTORY_ATOM_PROP = auto()
+    TRAJECTORY_ATOM_VEC = auto()
+    RAW_ATOM_PROP = auto()
+    RAW_SYSTEM_PROP = auto()
+
+    ATOM_DATA = NO_UPDATE
+    RAW_CONSTANT_ATOM_PROP = NO_UPDATE
+    RAW_CONSTANT_SYSTEM_PROP = NO_UPDATE
+
+
 class PropertyWidget(QWidget):
-    def __init__(self, parent: QWidget):
+    """Widget to inspect trajectory properties."""
+
+    def __init__(self, parent: QWidget, index: int | None = None):
         super().__init__(parent)
 
         layout = QVBoxLayout(self)
@@ -23,7 +49,23 @@ class PropertyWidget(QWidget):
         self.viewer = self.parent()
         self._last_prop = None
         self._populate_layout()
+        self._index = index
+        self.active = False
         self.viewer.frame_changed.connect(self.update_table)
+
+    @Slot(int)
+    def _active(self, index: int):
+        self.active = index == self._index
+        if self.active:
+            self.update_table()
+
+    @Slot()
+    def _activate(self):
+        self.active = True
+
+    @Slot()
+    def _deactivate(self):
+        self.active = False
 
     def _populate_layout(self) -> None:
         """Initialise layout.
@@ -38,26 +80,48 @@ class PropertyWidget(QWidget):
         self._prop_type.addItems(["atoms", "trajectory"])
         self._prop_type.setCurrentIndex(0)
         self._prop_type.currentTextChanged.connect(self.get_props)
+        self._prop_type.currentTextChanged.connect(self._activate)
 
         self._prop_selection = QComboBox(self)
         self._prop_selection.setEditable(False)
         self._prop_selection.currentTextChanged.connect(self.update_table)
+        self._prop_selection.currentTextChanged.connect(self._activate)
 
         self._prop_model = QStandardItemModel()
         self._prop_table = QTableView(self)
         self._prop_table.setModel(self._prop_model)
+        self._prop_table.setTextElideMode(Qt.ElideNone)
 
         layout.addWidget(self._prop_type)
         layout.addWidget(self._prop_selection)
         layout.addWidget(self._prop_table)
 
     def _extract_atom_prop(self, atom_prop: str) -> list:
+        """Get per-atom properties in system.
+
+        Parameters
+        ----------
+        atom_prop : str
+            Propert to retrieve.
+
+        Returns
+        -------
+        list
+            List of properties per-atom.
+        """
         return [
             self._trajectory.get_atom_property(symbol, atom_prop)
             for symbol in self._trajectory.atom_names
         ]
 
     def extract_props(self, trajectory: Trajectory) -> None:
+        """Determine properties in system and create lazy getters.
+
+        Parameters
+        ----------
+        trajectory : Trajectory
+            Trajectory to process.
+        """
         self._prop_selection.clear()
         self._trajectory = trajectory
         self._atom_props: dict[str, Callable[[], Sequence]] = {
@@ -81,7 +145,8 @@ class PropertyWidget(QWidget):
         self.get_props()
 
     @Slot()
-    def get_props(self) -> NOne:
+    def get_props(self) -> None:
+        """Get the available properties for a given class of properties."""
         self._prop_selection.clear()
 
         match self._prop_type.currentText():
@@ -94,148 +159,255 @@ class PropertyWidget(QWidget):
         self._prop_selection.addItems(self.curr_selection.keys())
 
     @staticmethod
-    def _make_items(*items) -> list[QStandardItem]:
+    def _make_items(*items: Any) -> list[QStandardItem]:
+        """Build :class:`QStandardItem` s from arguments.
+
+        Parameters
+        ----------
+        *items : Any
+            Items to add
+
+        Returns
+        -------
+        list[QStandardItem]
+            List of ``items`` as :class:`QStandardItem`
+        """
+
         items = [QStandardItem(str(item)) for item in items]
         for item in items:
             item.setEditable(False)
         return items
 
-    def _set_horiz_labels(self, *items) -> None:
+    def _set_horiz_labels(self, *items: str) -> None:
+        """Set horizontal labels
+
+        Parameters
+        ----------
+        *items : Any
+            Labels to use.
+        """
         for i, label in enumerate(items):
             idx = QStandardItem(str(label))
             self._prop_model.setHorizontalHeaderItem(i, idx)
 
+    def _set_vert_labels(self, *items: str) -> None:
+        """Set vertical labels.
 
-    @Slot()
-    def update_table(self) -> None:
+        Parameters
+        ----------
+        *items : str
+            Labels to use, if not specified atom-indices are used.
+        """
+        if items is None:
+            items = range(self.viewer._n_atoms)
+
+        for i, label in enumerate(items):
+            idx = QStandardItem(str(label))
+            self._prop_model.setVerticalHeaderItem(i, idx)
+
+    def _construct_prop_table(self, prop_type: str, prop_name: str) -> None:
+        """Build property table.
+
+        This may be a long operation, the :meth:`_update_prop_table` should be faster
+        in principle.
+
+        Parameters
+        ----------
+        prop_type : str
+            Property type to extract.
+        prop_name : str
+            Name of property within prop_type.
+        """
+
+        self._prop_model.clear()
         frame = self.viewer._current_frame
-        prop_name = self._prop_selection.currentText()
-        if not prop_name:
-            self._prop_model.clear()
-            return
-        prop_change = prop_name != self._last_prop
+        data = (
+            self.curr_selection[prop_name](frame)
+            if prop_name in self._frame_props
+            else self.curr_selection[prop_name]()
+        )
 
-        match self._prop_type.currentText():
-            case "atoms" if prop_change:
-                self._prop_model.clear()
-                for (i, name), prop in zip(
-                    enumerate(self._trajectory.atom_names),
-                    self.curr_selection[prop_name](),
+        match prop_type, prop_name:
+            case ("atoms", name):
+                self.update = _Update.ATOM_DATA
+
+                for atom_name, prop in zip(
+                    self._trajectory.atom_names,
+                    data,
                     strict=True,
                 ):
-                    items = self._make_items(name, prop)
+                    items = self._make_items(atom_name, prop)
                     self._prop_model.appendRow(items)
 
-                    idx = QStandardItem(str(i))
-                    self._prop_model.setVerticalHeaderItem(i, idx)
+                self._set_horiz_labels("name", name)
+                self._set_vert_labels()
+            case ("trajectory", "charges"):
+                self.update = _Update.TRAJECTORY_ATOM_PROP
 
-                self._set_horiz_labels("name", prop_name)
+                for atom_name, prop in zip(
+                    self._trajectory.atom_names,
+                    data,
+                    strict=True,
+                ):
+                    items = self._make_items(atom_name, prop)
+                    self._prop_model.appendRow(items)
 
+                self._set_horiz_labels("name", "charge")
+                self._set_vert_labels()
 
-            case "trajectory" if prop_name in self._frame_props:
+            case ("trajectory", "coordinates"):
+                self.update = _Update.TRAJECTORY_ATOM_VEC
 
-                data = self.curr_selection[prop_name](frame)
-                self._prop_model.clear()
+                for atom_name, prop in zip(
+                    self._trajectory.atom_names,
+                    data,
+                    strict=True,
+                ):
+                    items = self._make_items(atom_name, *prop)
+                    self._prop_model.appendRow(items)
 
-                match prop_name:
-                    case "charges":
-                        for (i, name), prop in zip(
-                            enumerate(self._trajectory.atom_names),
-                            data,
-                            strict=True,
-                        ):
-                            items = self._make_items(name, prop)
-                            self._prop_model.appendRow(items)
+                self._set_horiz_labels("name", "x", "y", "z")
+                self._set_vert_labels()
 
-                            idx = QStandardItem(str(i))
-                            self._prop_model.setVerticalHeaderItem(i, idx)
-
-                        self._set_horiz_labels("name", "charge")
-
-                    case "coordinates":
-                        for (i, name), prop in zip(
-                            enumerate(self._trajectory.atom_names),
-                            data,
-                            strict=True,
-                        ):
-                            items = self._make_items(name, *prop)
-                            self._prop_model.appendRow(items)
-
-                            idx = QStandardItem(str(i))
-                            self._prop_model.setVerticalHeaderItem(i, idx)
-
-                        self._set_horiz_labels("name", "x", "y", "z")
-
-                    case "unit_cell":
-                        if not data:
-                            items = self._make_items("No unit cell")
-                            self._prop_model.appendRow(items)
-                            return
-
-                        for prop in data.direct:
-                            items = self._make_items(*prop)
-                            self._prop_model.appendRow(items)
-
-                        for i, label in enumerate("xyz"):
-                            idx = QStandardItem(label)
-                            self._prop_model.setVerticalHeaderItem(i, idx)
-                            idx = QStandardItem(label)
-                            self._prop_model.setHorizontalHeaderItem(i, idx)
-
-                self._prop_table.resizeColumnsToContents()
-
-            case "trajectory":
-                data = self.curr_selection[prop_name]()
-                if not isinstance(data, h5py.Dataset):
+            case ("trajectory", "unit_cell"):
+                self.update = _Update.UNIT_CELL
+                if not data:
+                    items = self._make_items("No unit cell")
+                    self._prop_model.appendRow(items)
                     return
 
-                match data.shape:
-                    case (
-                        self.viewer._n_frames,
-                        self.viewer._n_atoms,
-                        *_,
-                    ):  # Atom property?
-                        self._prop_model.clear()
+                for prop in data.direct:
+                    items = self._make_items(*prop)
+                    self._prop_model.appendRow(items)
 
-                        for (i, name), prop in zip(
-                            enumerate(self._trajectory.atom_names),
+                self._set_horiz_labels("x", "y", "z")
+                self._set_vert_labels("x", "y", "z")
+
+            case ("trajectory", _):
+                n_frames = Const(self.viewer._n_frames)
+                n_atoms = Const(self.viewer._n_atoms)
+
+                match data.shape:
+                    case (n_frames.v, n_atoms.v, *_):
+                        self.update = _Update.RAW_ATOM_PROP
+
+                        for atom_name, prop in zip(
+                            self._trajectory.atom_names,
                             data[frame, :, ...],
                             strict=True,
                         ):
-                            items = self._make_items(name, *prop)
+                            items = self._make_items(atom_name, *prop)
                             self._prop_model.appendRow(items)
 
-                            idx = QStandardItem(str(i))
-                            self._prop_model.setVerticalHeaderItem(i, idx)
+                    case (n_atoms.v, *_):
+                        self.update = _Update.RAW_CONSTANT_ATOM_PROP
 
-                    case self.viewer._n_atoms if prop_change:  # Constant atom property
-                        self._prop_model.clear()
-
-                        for (i, name), prop in zip(
-                            enumerate(self._trajectory.atom_names),
+                        for atom_name, prop in zip(
+                            self._trajectory.atom_names,
                             data,
                             strict=True,
                         ):
-                            items = self._make_items(name, prop)
+                            items = self._make_items(atom_name, prop)
                             self._prop_model.appendRow(items)
 
-                            idx = QStandardItem(str(i))
-                            self._prop_model.setVerticalHeaderItem(i, idx)
-
-                    case (self.viewer._n_frames, *_):  # System property
-                        self._prop_model.clear()
+                    case (n_frames.v, *_):
+                        self.update = _Update.RAW_SYSTEM_PROP
 
                         for prop in data[frame, ...]:
-                            items = self._make_items(name, *prop)
+                            items = self._make_items(*prop)
                             self._prop_model.appendRow(items)
 
-                    case _ if prop_change:  # Constant system property
-                        self._prop_model.clear()
+                    case _:
+                        self.update = _Update.RAW_CONSTANT_SYSTEM_PROP
 
                         for prop in data:
                             items = self._make_items(*prop)
                             self._prop_model.appendRow(items)
 
                 self._set_horiz_labels(*range(self._prop_model.columnCount()))
+                self._set_vert_labels(*range(self._prop_model.rowCount()))
+
+            case _:
+                self.update = _Update.NO_UPDATE
+
+        self._prop_table.resizeColumnsToContents()
+
+    def _update_prop_table(self, prop_name: str) -> None:
+        """Update values in existing table.
+
+        Parameters
+        ----------
+        prop_name : str
+            Name of data to extract.
+
+        Raises
+        ------
+        NotImplementedError
+            Unrecognised update type.
+        """
+        if self.update == _Update.NO_UPDATE:
+            return
+
+        frame = self.viewer._current_frame
+        data = (
+            self.curr_selection[prop_name](frame)
+            if prop_name in self._frame_props
+            else self.curr_selection[prop_name]()
+        )
+
+        match self.update:
+            case _Update.UNIT_CELL:
+                if not data:
+                    return
+
+                for i, row in enumerate(data.direct):
+                    for j, elem in enumerate(row):
+                        self._prop_model.item(i, j).setText(str(elem))
+            case _Update.TRAJECTORY_ATOM_PROP:
+                for i, elem in enumerate(data):
+                    self._prop_model.item(1, i).setText(str(elem))
+
+            case _Update.RAW_ATOM_PROP:
+                for i, row in enumerate(data[frame, :, ...]):
+                    for j, elem in enumerate(row, 1):
+                        self._prop_model.item(i, j).setText(str(elem))
+
+            case _Update.TRAJECTORY_ATOM_VEC:
+                for i, row in enumerate(data):
+                    for j, elem in enumerate(row, 1):
+                        self._prop_model.item(i, j).setText(str(elem))
+
+            case _Update.RAW_SYSTEM_PROP:
+                for i, row in enumerate(data[frame, ...]):
+                    for j, elem in enumerate(row):
+                        self._prop_model.item(i, j).setText(str(elem))
+
+            case _:
+                raise NotImplementedError(
+                    f"Prop {prop_name} has unrecognised update-schema {self.update}."
+                )
+
+    @Slot()
+    def update_table(self) -> None:
+        """Update table with data.
+
+        In case of property changing, reconstruct existing table otherwise
+        update values.
+        """
+        if not self.active:
+            return
+
+        prop_name = self._prop_selection.currentText()
+        prop_type = self._prop_type.currentText()
+
+        if not prop_name:
+            return
+
+        prop_change = prop_name != self._last_prop
+
+        if prop_change:
+            self._construct_prop_table(prop_type, prop_name)
+        else:
+            self._update_prop_table(prop_name)
 
         self._last_prop = prop_name

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/View3D.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/View3D.py
@@ -36,6 +36,7 @@ class View3D(QWidget):
         controls.setViewer(viewer)
         controls.createSidePanel()
         viewer.create_trace_dialog(controls)
+        viewer.create_property_viewer_dialog(controls)
         if hasattr(viewer, "clicked_atom_index"):
             viewer.clicked_atom_index.connect(controls._trace_widget.accept_atom_index)
         layout.addWidget(controls)


### PR DESCRIPTION
**Description of work**
Add a tab to the trajectory tab options which displays properties of trajectory.

**Fixes**
Fixes #962 

- Makes `MolecularViewer` not collapsible.
- Makes `Controls` tab expandable.
- `PropertyViewer` is made inactive when tab is deselected (but not when hidden...)
- `PropertyViewer` only updates when frame changes if (potentially) frame-dependent property

**To test**
Open trajectories and look at the properties.