### PR TITLE
Update the MDANSE save scripts

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/UnitCellConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/UnitCellConfigurator.py
@@ -85,6 +85,8 @@ class UnitCellConfigurator(IConfigurator):
         else:
             self.recommended_cell = (first_cell + last_cell) / 2.0
 
+        self.recommended_cell = self.recommended_cell.tolist()
+
     def configure(self, value):
         """
         Configure the unit cell as a 3x3 array.
@@ -112,7 +114,7 @@ class UnitCellConfigurator(IConfigurator):
                     self.error_status = "Input shape must be 3x3"
                     return
 
-            self["value"] = input_array
+            self["value"] = value[0]
         else:
-            self["value"] = np.eye(3)
+            self["value"] = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
@@ -98,7 +98,7 @@ class ASE(Converter):
     settings["output_files"] = (
         "OutputTrajectoryConfigurator",
         {
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
             "formats": ["MDTFormat"],
             "root": "trajectory_file",
         },

--- a/MDANSE/Src/MDANSE/Framework/Converters/CASTEP.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/CASTEP.py
@@ -60,7 +60,7 @@ class CASTEP(Converter):
         {
             "formats": ["MDTFormat"],
             "root": "castep_file",
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
         },
     )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/CP2K.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/CP2K.py
@@ -106,7 +106,7 @@ class CP2K(Converter):
         {
             "formats": ["MDTFormat"],
             "root": "pos_file",
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
         },
     )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/DCD.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DCD.py
@@ -81,7 +81,7 @@ class DCD(Converter):
         {
             "formats": ["MDTFormat"],
             "root": "pdb_file",
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
         },
     )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/DFTB.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DFTB.py
@@ -62,6 +62,6 @@ class DFTB(Forcite):
         {
             "formats": ["MDTFormat"],
             "root": "xtd_file",
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
         },
     )

--- a/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
@@ -83,7 +83,7 @@ class DL_POLY(Converter):
         {
             "formats": ["MDTFormat"],
             "root": "history_file",
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
         },
     )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/Forcite.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Forcite.py
@@ -72,7 +72,7 @@ class Forcite(Converter):
         {
             "formats": ["MDTFormat"],
             "root": "xtd_file",
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
         },
     )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
@@ -74,7 +74,7 @@ class Gromacs(Converter):
         {
             "formats": ["MDTFormat"],
             "root": "pdb_file",
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
         },
     )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/ImprovedASE.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/ImprovedASE.py
@@ -101,7 +101,7 @@ class ImprovedASE(Converter):
     settings["output_files"] = (
         "OutputTrajectoryConfigurator",
         {
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
             "formats": ["MDTFormat"],
             "root": "trajectory_file",
         },

--- a/MDANSE/Src/MDANSE/Framework/Converters/LAMMPS.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/LAMMPS.py
@@ -183,7 +183,7 @@ class LAMMPS(Converter):
         {
             "formats": ["MDTFormat"],
             "root": "config_file",
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
         },
     )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
@@ -95,7 +95,7 @@ class MDAnalysis(Converter):
     settings["output_files"] = (
         "OutputTrajectoryConfigurator",
         {
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
             "formats": ["MDTFormat"],
             "root": "config_file",
         },

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -91,7 +91,7 @@ class MDTraj(Converter):
     settings["output_files"] = (
         "OutputTrajectoryConfigurator",
         {
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
             "formats": ["MDTFormat"],
             "root": "config_file",
         },

--- a/MDANSE/Src/MDANSE/Framework/Converters/VASP.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/VASP.py
@@ -93,7 +93,7 @@ class VASP(Converter):
         {
             "formats": ["MDTFormat"],
             "root": "xdatcar_file",
-            "label": "MDANSE trajectory (filename, format)",
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
         },
     )
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -304,8 +304,8 @@ class IJob(Configurable, metaclass=SubclassFactory):
             if (
                 isinstance(v, str)
                 and len(str_v) > 40
-                and str_v[0] == "{"
-                and str_v[-1] == "}"
+                and str_v.startswith("{")
+                and str_v.endswith("}")
             ):
                 # if it's a long json string then try to make a multiline
                 # string and format it

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -324,14 +324,16 @@ class IJob(Configurable, metaclass=SubclassFactory):
             )
 
         with open(jobFile, "w") as f:
-            f.write(RUNSCRIPT.format(
-                executable=sys.executable,
-                import_line=cls.runscript_import_line,
-                param_str=param_str,
-                parent=cls.runscript_import_line.split(" ")[-1],
-                var_name=cls.__name__.lower(),
-                job_name=cls.__name__,
-            ))
+            f.write(
+                RUNSCRIPT.format(
+                    executable=sys.executable,
+                    import_line=cls.runscript_import_line,
+                    param_str=param_str,
+                    parent=cls.runscript_import_line.split(" ")[-1],
+                    var_name=cls.__name__.lower(),
+                    job_name=cls.__name__,
+                )
+            )
 
         os.chmod(jobFile, stat.S_IRWXU)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -320,14 +320,16 @@ class IJob(Configurable, metaclass=SubclassFactory):
             )
 
         with open(jobFile, "w") as f:
-            f.write(RUNSCRIPT.format(
-                executable=sys.executable,
-                import_line=cls.runscript_import_line,
-                param_str=param_str,
-                parent=cls.runscript_import_line.split(" ")[-1],
-                var_name=cls.__name__.lower(),
-                job_name=cls.__name__,
-            ))
+            f.write(
+                RUNSCRIPT.format(
+                    executable=sys.executable,
+                    import_line=cls.runscript_import_line,
+                    param_str=param_str,
+                    parent=cls.runscript_import_line.split(" ")[-1],
+                    var_name=cls.__name__.lower(),
+                    job_name=cls.__name__,
+                )
+            )
 
         os.chmod(jobFile, stat.S_IRWXU)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -311,7 +311,7 @@ class IJob(Configurable, metaclass=SubclassFactory):
                 # string and format it
                 try:
                     json_data = json.loads(str_v)
-                    repr_v = '"""' + json.dumps(json_data, indent=4) + '"""'
+                    repr_v = f'"""{json.dumps(json_data, indent=4)}"""'
                     repr_v = repr_v.replace("\n", "\n    ")
                 except json.decoder.JSONDecodeError:
                     repr_v = repr(v)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -19,6 +19,7 @@ import abc
 import json
 import multiprocessing
 import os
+import pprint
 import queue
 import random
 import stat
@@ -301,7 +302,7 @@ class IJob(Configurable, metaclass=SubclassFactory):
             str_v = str(v)
             if (
                 isinstance(v, str)
-                and len(str_v) > 40
+                and len(str_v) > 72
                 and str_v.startswith("{")
                 and str_v.endswith("}")
             ):
@@ -309,27 +310,28 @@ class IJob(Configurable, metaclass=SubclassFactory):
                 # string and format it
                 try:
                     json_data = json.loads(str_v)
-                    repr_v = f'"""{json.dumps(json_data, indent=4)}"""'
-                    repr_v = repr_v.replace("\n", "\n    ")
+                    param = f'"""{json.dumps(json_data, indent=4)}"""'
+                    param = param.replace("\n", "\n    ")
                 except json.decoder.JSONDecodeError:
-                    repr_v = repr(v)
+                    param = repr(v)
+            elif isinstance(v, (tuple, list, dict)):
+                param = pprint.pformat(v, indent=0, width=72)
+                param = param.replace("\n", "\n        ")
             else:
-                repr_v = repr(v)
+                param = repr(v)
             param_str += (
-                f"    {k!r}: {repr_v},  " + ("# " + label if label else "") + "\n"
+                f"    {k!r}: {param},  " + ("# " + label if label else "") + "\n"
             )
 
         with open(jobFile, "w") as f:
-            f.write(
-                RUNSCRIPT.format(
-                    executable=sys.executable,
-                    import_line=cls.runscript_import_line,
-                    param_str=param_str,
-                    parent=cls.runscript_import_line.split(" ")[-1],
-                    var_name=cls.__name__.lower(),
-                    job_name=cls.__name__,
-                )
-            )
+            f.write(RUNSCRIPT.format(
+                executable=sys.executable,
+                import_line=cls.runscript_import_line,
+                param_str=param_str,
+                parent=cls.runscript_import_line.split(" ")[-1],
+                var_name=cls.__name__.lower(),
+                job_name=cls.__name__,
+            ))
 
         os.chmod(jobFile, stat.S_IRWXU)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -139,6 +139,48 @@ def key_generator(
             prefix = new_prefix
 
 
+def _format_params(parameters: dict) -> str:
+    """Format the job parameters.
+
+    Parameters
+    ----------
+    parameters : dict
+        The jobs parameter dictionary.
+
+    Returns
+    -------
+    str
+        A formatted string of parameter used in the runscripts.
+    """
+    param_str = ""
+    for k, (v, label) in parameters.items():
+        str_v = str(v)
+        if (
+                isinstance(v, str)
+                and len(str_v) > 72
+                and str_v.startswith("{")
+                and str_v.endswith("}")
+        ):
+            # if it's a long json string then try to make a multiline
+            # string and format it
+            try:
+                json_data = json.loads(str_v)
+                param = f'"""{json.dumps(json_data, indent=4)}"""'
+                param = param.replace("\n", "\n    ")
+            except json.decoder.JSONDecodeError:
+                param = repr(v)
+        elif isinstance(v, (tuple, list, dict)):
+            param = pprint.pformat(v, indent=0, width=72)
+            param = param.replace("\n", "\n        ")
+        else:
+            param = repr(v)
+        param_str += (
+                f"    {k!r}: {param},  " + (
+            "# " + label if label else "") + "\n"
+        )
+    return param_str
+
+
 class IJob(Configurable, metaclass=SubclassFactory):
     """The parent class for any MDANSE job.
 
@@ -297,38 +339,12 @@ class IJob(Configurable, metaclass=SubclassFactory):
             for key, (val, label) in sorted(parameters.items())
         }
 
-        param_str = ""
-        for k, (v, label) in parameters.items():
-            str_v = str(v)
-            if (
-                isinstance(v, str)
-                and len(str_v) > 72
-                and str_v.startswith("{")
-                and str_v.endswith("}")
-            ):
-                # if it's a long json string then try to make a multiline
-                # string and format it
-                try:
-                    json_data = json.loads(str_v)
-                    param = f'"""{json.dumps(json_data, indent=4)}"""'
-                    param = param.replace("\n", "\n    ")
-                except json.decoder.JSONDecodeError:
-                    param = repr(v)
-            elif isinstance(v, (tuple, list, dict)):
-                param = pprint.pformat(v, indent=0, width=72)
-                param = param.replace("\n", "\n        ")
-            else:
-                param = repr(v)
-            param_str += (
-                f"    {k!r}: {param},  " + ("# " + label if label else "") + "\n"
-            )
-
         with open(jobFile, "w") as f:
             f.write(
                 RUNSCRIPT.format(
                     executable=sys.executable,
                     import_line=cls.runscript_import_line,
-                    param_str=param_str,
+                    param_str=_format_params(parameters),
                     parent=cls.runscript_import_line.split(" ")[-1],
                     var_name=cls.__name__.lower(),
                     job_name=cls.__name__,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import abc
+import json
 import multiprocessing
 import os
 import queue
@@ -32,6 +33,7 @@ from multiprocessing import Queue
 from pathlib import Path
 from typing import Any
 
+import black
 from more_itertools import consumer, first_true
 
 from MDANSE import PLATFORM
@@ -296,22 +298,34 @@ class IJob(Configurable, metaclass=SubclassFactory):
             for key, (val, label) in sorted(parameters.items())
         }
 
-        param_str = "\n".join(
-            f"    {k!r}: {v!r}," + ("# " + label if label else "")
-            for k, (v, label) in parameters.items()
-        )
+        param_str = ""
+        for k, (v, label) in parameters.items():
+            str_v = str(v)
+            if len(str_v) > 40 and str_v[0] == "{" and str_v[-1] == "}":
+                # if it's a long json string then try to make a multiline
+                # string and format it
+                try:
+                    json_data = json.loads(str_v)
+                    repr_v = '"""' + json.dumps(json_data, indent=4) + '"""'
+                    repr_v = repr_v.replace("\n", "\n    ")
+                except json.decoder.JSONDecodeError:
+                    repr_v = repr(v)
+            else:
+                repr_v = repr(v)
+            param_str += (
+                f"    {k!r}: {repr_v},  " + ("# " + label if label else "") + "\n"
+            )
 
         with open(jobFile, "w") as f:
-            f.write(
-                RUNSCRIPT.format(
-                    executable=sys.executable,
-                    import_line=cls.runscript_import_line,
-                    param_str=param_str,
-                    parent=cls.runscript_import_line.split(" ")[-1],
-                    var_name=cls.__name__.lower(),
-                    job_name=cls.__name__,
-                )
+            script = RUNSCRIPT.format(
+                executable=sys.executable,
+                import_line=cls.runscript_import_line,
+                param_str=param_str,
+                parent=cls.runscript_import_line.split(" ")[-1],
+                var_name=cls.__name__.lower(),
+                job_name=cls.__name__,
             )
+            f.write(black.format_str(script, mode=black.Mode()))
 
         os.chmod(jobFile, stat.S_IRWXU)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -156,10 +156,10 @@ def _format_params(parameters: dict) -> str:
     for k, (v, label) in parameters.items():
         str_v = str(v)
         if (
-                isinstance(v, str)
-                and len(str_v) > 72
-                and str_v.startswith("{")
-                and str_v.endswith("}")
+            isinstance(v, str)
+            and len(str_v) > 72
+            and str_v.startswith("{")
+            and str_v.endswith("}")
         ):
             # if it's a long json string then try to make a multiline
             # string and format it
@@ -174,10 +174,7 @@ def _format_params(parameters: dict) -> str:
             param = param.replace("\n", "\n        ")
         else:
             param = repr(v)
-        param_str += (
-                f"    {k!r}: {param},  " + (
-            "# " + label if label else "") + "\n"
-        )
+        param_str += f"    {k!r}: {param},  " + ("# " + label if label else "") + "\n"
     return param_str
 
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -301,7 +301,12 @@ class IJob(Configurable, metaclass=SubclassFactory):
         param_str = ""
         for k, (v, label) in parameters.items():
             str_v = str(v)
-            if len(str_v) > 40 and str_v[0] == "{" and str_v[-1] == "}":
+            if (
+                isinstance(v, str)
+                and len(str_v) > 40
+                and str_v[0] == "{"
+                and str_v[-1] == "}"
+            ):
                 # if it's a long json string then try to make a multiline
                 # string and format it
                 try:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -33,7 +33,6 @@ from multiprocessing import Queue
 from pathlib import Path
 from typing import Any
 
-import black
 from more_itertools import consumer, first_true
 
 from MDANSE import PLATFORM
@@ -58,8 +57,7 @@ RUNSCRIPT = """\
 ########################################################
 
 parameters = {{
-{param_str}
-}}
+{param_str}}}
 
 ########################################################
 # Setup and run the analysis                           #
@@ -322,15 +320,14 @@ class IJob(Configurable, metaclass=SubclassFactory):
             )
 
         with open(jobFile, "w") as f:
-            script = RUNSCRIPT.format(
+            f.write(RUNSCRIPT.format(
                 executable=sys.executable,
                 import_line=cls.runscript_import_line,
                 param_str=param_str,
                 parent=cls.runscript_import_line.split(" ")[-1],
                 var_name=cls.__name__.lower(),
                 job_name=cls.__name__,
-            )
-            f.write(black.format_str(script, mode=black.Mode()))
+            ))
 
         os.chmod(jobFile, stat.S_IRWXU)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -58,7 +58,10 @@ class TrajectoryEditor(IJob):
     )
     settings["unit_cell"] = (
         "UnitCellConfigurator",
-        {"dependencies": {"trajectory": "trajectory"}, "default": (np.eye(3), False)},
+        {
+            "dependencies": {"trajectory": "trajectory"},
+            "default": ([[1, 0, 0], [0, 1, 0], [0, 0, 1]], False),
+        },
     )
     settings["atom_selection"] = (
         "AtomSelectionConfigurator",
@@ -88,7 +91,10 @@ class TrajectoryEditor(IJob):
     )
     settings["output_files"] = (
         "OutputTrajectoryConfigurator",
-        {"format": "MDTFormat"},
+        {
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
+            "format": "MDTFormat",
+        },
     )
 
     def initialize(self):
@@ -104,7 +110,9 @@ class TrajectoryEditor(IJob):
         ].chemical_system
 
         if self.configuration["unit_cell"]["apply"]:
-            self._new_unit_cell = UnitCell(self.configuration["unit_cell"]["value"])
+            self._new_unit_cell = UnitCell(
+                np.array(self.configuration["unit_cell"]["value"])
+            )
             self._input_trajectory._trajectory._unit_cells = [
                 self._new_unit_cell for _ in range(len(self._input_trajectory))
             ]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -95,7 +95,10 @@ class TrajectoryFilter(IJob):
     )
     settings["output_files"] = (
         "OutputTrajectoryConfigurator",
-        {"format": "MDTFormat"},
+        {
+            "label": "MDANSE trajectory (filename, datatype, chunk size, compression, logfile output)",
+            "format": "MDTFormat",
+        },
     )
     settings["running_mode"] = ("RunningModeConfigurator", {})
 

--- a/MDANSE/Tests/UnitTests/TrajectoryEditor/test_editor.py
+++ b/MDANSE/Tests/UnitTests/TrajectoryEditor/test_editor.py
@@ -64,7 +64,7 @@ def test_jumps_removed_correctly():
      ("chemical_system.number_of_atoms", "__len__()",
       ("unit_cell(0)._unit_cell", np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))),
      {"trajectory": short_traj, "frames": (0, 501, 1),
-      "unit_cell": (np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), True)},
+      "unit_cell": ([[1, 2, 3], [4, 5, 6], [7, 8, 9]], True)},
      ),
 
     (("/configuration/coordinates", "/time"),

--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "mdtraj",
     "networkx",
     "more-itertools",
-    "black",
 ]
 
 [project.optional-dependencies]

--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "mdtraj",
     "networkx",
     "more-itertools",
+    "black",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
**Description of work**
Updated the save scripts so that they are formatted with black, long JSON strings are saved as multiline strings, and are formatted. Basically, this should stop the MDANSE save script from writing very long lines.

Updated the MDANSE trajectory configurator label. Fixed the trajectory editor save script.

**Fixes**
Trajectory editor saved scripts used a numpy array, but did not include the numpy import in the script. Updated the unit cell configurator so it uses a list of floats. 

**To test**
Save scripts for trajectory and analysis jobs and run them. Test the save script for the trajectory editor.
