### PR TITLE
Fix getting string properties from newer Trajectories

### DIFF
--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -436,6 +436,9 @@ class MdanseTrajectory(TrajectoryFile):
 
         data_type = self._data_types[index]
 
+        if data_type == b"str":
+            return ATOMS_DATABASE.get_atom_property(atom_symbol, atom_property)
+
         if index not in self._data_units:
             data_unit = "none"
             try:
@@ -466,11 +469,6 @@ class MdanseTrajectory(TrajectoryFile):
 
         elif data_type == b"int":
             out = int(value)
-
-        elif data_type == b"str":
-            if isinstance(value, bytes):
-                value = value.decode("utf-8")
-            out = value
 
         else:
             out = str_to_num(value)


### PR DESCRIPTION
**Description of work**
Currently string properties from newer Trajectory files return `-1.0` which is not right.

**Fixes**
If a string property is requested, revert to `ATOMS_DATABASE`.

**To test**
Ensure that getting string properties (e.g. `'url'`) from new trajectories works.
