### PR TITLE
Report trajectory loading failure in the GUI

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
@@ -15,15 +15,13 @@
 #
 from __future__ import annotations
 
-import os
 from functools import partial
-from pathlib import PurePath
 
-from qtpy.QtCore import Slot
-from qtpy.QtWidgets import QComboBox, QLabel, QWidget
+from qtpy.QtCore import Qt, Slot
+from qtpy.QtGui import QFontMetrics
+from qtpy.QtWidgets import QApplication, QComboBox, QLabel, QProxyStyle, QStyle, QWidget
 
 from MDANSE.MLogging import LOG
-from MDANSE_GUI.InputWidgets.MoleculeWidget import MoleculeWidget
 from MDANSE_GUI.Session.Session import Session
 from MDANSE_GUI.Tabs.GeneralTab import GeneralTab
 from MDANSE_GUI.Tabs.Layouts.MultiPanel import MultiPanel
@@ -48,6 +46,20 @@ will be used as initial values when you switch to a new analysis type.
 """
 
 
+class ComboStyle(QProxyStyle):
+    """Style stopping the QComboBox from expanding to the longest string length."""
+
+    def __init__(self, *args, metrics: QFontMetrics | None = None, **kwargs):
+        self.metrics = metrics
+        super().__init__(*args, **kwargs)
+
+    def drawItemText(self, painter, rect, flags, pal, enabled, text, textRole):
+        elided_text = self.metrics.elidedText(text, Qt.TextElideMode.ElideRight, 200)
+        return super().drawItemText(
+            painter, rect, flags, pal, enabled, elided_text, textRole
+        )
+
+
 class JobTab(GeneralTab):
     """The tab for choosing and starting a new job."""
 
@@ -66,6 +78,10 @@ class JobTab(GeneralTab):
         self._instrument_index = -1
         self._trajectory_combo = QComboBox()
         self._trajectory_combo.setEditable(False)
+        self._combo_style = ComboStyle(
+            QApplication.style().name(), metrics=self._trajectory_combo.fontMetrics()
+        )
+        self._trajectory_combo.setStyle(self._combo_style)
         self._trajectory_combo.currentIndexChanged.connect(self.set_current_trajectory)
         if combo_model is not None:
             self._trajectory_combo.setModel(combo_model)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
@@ -19,7 +19,14 @@ from functools import partial
 
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtGui import QFontMetrics
-from qtpy.QtWidgets import QApplication, QComboBox, QLabel, QProxyStyle, QStyle, QWidget
+from qtpy.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QLabel,
+    QProxyStyle,
+    QSizePolicy,
+    QWidget,
+)
 
 from MDANSE.MLogging import LOG
 from MDANSE_GUI.Session.Session import Session
@@ -44,6 +51,8 @@ in your analysis by setting the "instrument" name to the
 one you defined. The parameters saved under the instrument name
 will be used as initial values when you switch to a new analysis type.
 """
+
+COMBO_BOX_LENGTH = 32
 
 
 class ComboStyle(QProxyStyle):
@@ -78,16 +87,23 @@ class JobTab(GeneralTab):
         self._instrument_index = -1
         self._trajectory_combo = QComboBox()
         self._trajectory_combo.setEditable(False)
-        self._combo_style = ComboStyle(
-            QApplication.style().name(), metrics=self._trajectory_combo.fontMetrics()
+        self._trajectory_combo.setMinimumContentsLength(COMBO_BOX_LENGTH)
+        self._trajectory_combo.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred
         )
-        self._trajectory_combo.setStyle(self._combo_style)
+        self._trajectory_combo.setStyle(
+            ComboStyle(
+                QApplication.style().name(),
+                metrics=self._trajectory_combo.fontMetrics(),
+            )
+        )
         self._trajectory_combo.currentIndexChanged.connect(self.set_current_trajectory)
         if combo_model is not None:
             self._trajectory_combo.setModel(combo_model)
         combo_model.finished_loading.connect(self.reload_trajectory)
         self._instrument_combo = QComboBox()
         self._instrument_combo.setEditable(False)
+        self._instrument_combo.setMinimumContentsLength(COMBO_BOX_LENGTH)
         self._instrument_combo.currentIndexChanged.connect(self.set_current_instrument)
 
         if instrument_model is not None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
@@ -181,7 +181,7 @@ class TrajectoryModel(QStandardItemModel):
         retcode = super().removeRow(row, parent)
         instance = self._trajectory_instances.pop(node_number)
         filename = self._trajectory_paths.pop(node_number)
-        _ = self._trajectory_status.pop(node_number)
+        self._trajectory_status.pop(node_number)
         if instance:
             instance.close()
         self.free_name.emit(str(filename))

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
@@ -181,6 +181,7 @@ class TrajectoryModel(QStandardItemModel):
         retcode = super().removeRow(row, parent)
         instance = self._trajectory_instances.pop(node_number)
         filename = self._trajectory_paths.pop(node_number)
+        _ = self._trajectory_status.pop(node_number)
         if instance:
             instance.close()
         self.free_name.emit(str(filename))

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
@@ -16,6 +16,8 @@
 from __future__ import annotations
 
 import itertools
+import traceback
+from enum import Enum, auto
 
 from qtpy.QtCore import (
     QDeadlineTimer,
@@ -33,8 +35,16 @@ from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
 
+class LoadStatus(Enum):
+    LOADING = auto()
+    READY = auto()
+    FAILED = auto()
+    EMPTY = auto()
+
+
 class LoaderThread(QThread):
     results = Signal(object)
+    failure = Signal(int)
 
     def __init__(
         self,
@@ -52,12 +62,28 @@ class LoaderThread(QThread):
         self._target_label = target_label
 
     def run(self):
-        trajectory = Trajectory(self._filename)
-        self.results.emit((trajectory, self._target_index))
-        if self._display_item is not None and self._target_label is not None:
-            self._display_item.setData(
-                self._target_label, role=Qt.ItemDataRole.DisplayRole
+        try:
+            trajectory = Trajectory(self._filename)
+        except Exception as e:
+            LOG.error(
+                "Failed loading file %s, exception %s traceback %s",
+                self._filename,
+                str(e),
+                traceback.format_exc(),
             )
+            self.failure.emit(self._target_index)
+            if self._display_item is not None and self._target_label is not None:
+                self._display_item.setData(
+                    f"Failed to load {self._target_label}. See the log for details.",
+                    role=Qt.ItemDataRole.DisplayRole,
+                )
+        else:
+            self.results.emit((trajectory, self._target_index))
+            if self._display_item is not None and self._target_label is not None:
+                self._display_item.setData(
+                    self._target_label, role=Qt.ItemDataRole.DisplayRole
+                )
+                self._display_item.setEnabled(True)
 
 
 class TrajectoryModel(QStandardItemModel):
@@ -75,6 +101,7 @@ class TrajectoryModel(QStandardItemModel):
         self._node_numbers = []
         self._trajectory_paths = {}
         self._trajectory_instances = {}
+        self._trajectory_status = {}
         self._loading_threads = {}
         self._next_number = itertools.count()
 
@@ -85,8 +112,10 @@ class TrajectoryModel(QStandardItemModel):
         self._node_numbers.append(retval)
         self._trajectory_paths[retval] = full_name
         self._trajectory_instances[retval] = None
+        self._trajectory_status[retval] = LoadStatus.LOADING
         item = QStandardItem(f"Loading {label}...")
         item.setData(retval)
+        item.setEnabled(False)
         self.appendRow(item)
         self.launch_loader(full_name, retval, display_item=item, target_label=label)
         return retval
@@ -102,6 +131,7 @@ class TrajectoryModel(QStandardItemModel):
             None, filename, index, display_item=display_item, target_label=target_label
         )
         thread.results.connect(self.accept_results)
+        thread.failure.connect(self.accept_failure)
         self._loading_threads[index] = thread
         thread.start()
 
@@ -120,16 +150,25 @@ class TrajectoryModel(QStandardItemModel):
         if index not in self._trajectory_instances:
             return
         self._trajectory_instances[index] = trajectory
+        self._trajectory_status[index] = LoadStatus.READY
         self.finished_loading.emit(index)
         # self._loading_threads[index].wait()
 
-    def item_is_ready(self, row: int) -> bool:
+    @Slot(int)
+    def accept_failure(self, index) -> None:
+        if index not in self._trajectory_instances:
+            return
+        self._trajectory_status[index] = LoadStatus.FAILED
+        self.free_name.emit(self._trajectory_paths[index])
+        self.finished_loading.emit(index)
+        # self._loading_threads[index].wait()
+
+    def item_status(self, row: int) -> LoadStatus:
         try:
             node_number = self.item(row).data()
         except AttributeError:
-            return False
-        traj = self.get_trajectory(node_number)
-        return isinstance(traj, Trajectory)
+            return LoadStatus.EMPTY
+        return self._trajectory_status[node_number]
 
     def removeRow(self, row: int, parent: QModelIndex | None = None) -> bool:
         if parent is None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/TrajectoryTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/TrajectoryTab.py
@@ -22,7 +22,6 @@ from pathlib import PurePath
 from qtpy.QtCore import Slot
 from qtpy.QtWidgets import QFileDialog, QWidget
 
-from MDANSE.MolecularDynamics.Trajectory import Trajectory
 from MDANSE_GUI.MolecularViewer.MolecularViewer import MolecularViewerExtended
 from MDANSE_GUI.Session.Session import Session
 from MDANSE_GUI.Tabs.GeneralTab import GeneralTab

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/TrajectoryView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/TrajectoryView.py
@@ -19,6 +19,7 @@ from qtpy.QtCore import QModelIndex, Signal, Slot
 from qtpy.QtGui import QContextMenuEvent, QStandardItem
 from qtpy.QtWidgets import QAbstractItemView, QListView, QMenu
 
+from MDANSE_GUI.Tabs.Models.TrajectoryModel import LoadStatus
 from MDANSE_GUI.Tabs.Visualisers.TrajectoryInfo import TrajectoryInfo
 from MDANSE_GUI.Tabs.Visualisers.View3D import View3D
 
@@ -32,6 +33,7 @@ class TrajectoryView(QListView):
         super().__init__(*args, **kwargs)
         self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.clicked.connect(self.item_picked)
+        self.context_menu_item = None
 
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
         index = self.indexAt(event.pos())
@@ -39,14 +41,15 @@ class TrajectoryView(QListView):
             # block right click when it's not on a trajectory
             return
         model = self.model()
-        if not model.item_is_ready(index.row()):
+        if model.item_status(index.row()) in (LoadStatus.EMPTY, LoadStatus.LOADING):
             return
-        item = model.itemData(index)
+        item = model.itemFromIndex(index)
         menu = QMenu()
         self.populateMenu(menu, item)
         menu.exec_(event.globalPos())
 
     def populateMenu(self, menu: QMenu, item: QStandardItem):
+        self.context_menu_item = item
         for action, method in [("Delete", self.deleteNode)]:
             temp_action = menu.addAction(action)
             temp_action.triggered.connect(method)
@@ -54,7 +57,7 @@ class TrajectoryView(QListView):
     @Slot()
     def deleteNode(self):
         model = self.model()
-        index = self.currentIndex()
+        index = self.context_menu_item.index()
         model.removeRow(index.row())
         self.item_details.emit(("", None))
 


### PR DESCRIPTION
**Description of work**
Gives more feedback to the user if an invalid file has been picked as a trajectory.

closes #1022

**Fixes**
- invalid items in TrajectoryModel are now disabled,
- replaced the True/False 'is_ready' status of trajectories in the model with an enum,
- files that failed to load are labelled in the trajectory list and can be deleted,
- a QProxyStyle prevents the combo box in JobTab from resizing to the length of the longest text string.

**To test**
Load all kinds of files as trajectories. See which failed and which can be used. Please check if the `Action` in JobTab updates correctly when switching from one trajectory to another.
