### PR TITLE
Extract properties from `Trajectory`s for `unit_info` more consistently

### DIFF
--- a/MDANSE/Src/MDANSE/IO/AtomInfo.py
+++ b/MDANSE/Src/MDANSE/IO/AtomInfo.py
@@ -20,6 +20,8 @@ from collections import defaultdict
 from MDANSE.Chemistry import ATOMS_DATABASE, AtomsDatabase
 from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
+WIDTH = 70
+
 
 def atom_info(atom: str, database: AtomsDatabase | Trajectory | None = None) -> str:
     """Return as string all the information about the input atom.
@@ -39,11 +41,8 @@ def atom_info(atom: str, database: AtomsDatabase | Trajectory | None = None) -> 
     """
     if database is None:
         database = ATOMS_DATABASE
-    if isinstance(database, AtomsDatabase):
-        units = database.units
-    else:
-        units = defaultdict(lambda: "none")
 
+    units = database.units
     properties = database.properties
     atoms = database.atoms
 
@@ -60,23 +59,21 @@ def atom_info(atom: str, database: AtomsDatabase | Trajectory | None = None) -> 
             prop_name: database.get_atom_property(atom, prop_name)
             for prop_name in properties
         }
+
     # A delimiter line.
-    delimiter = "-" * 70
-    tab_fmt = "{:<20}{!s:>40}{!s:>10}"
+    delimiter = "-" * WIDTH
+    tab_fmt = f"{{:<20}}{{!s:>40}}{{!s:>{WIDTH - 60}}}"
 
     info = [
         delimiter,
-        f"{atom:^70}",
+        f"{atom:^{WIDTH}}",
         tab_fmt.format("property", "value", "unit"),
         delimiter,
     ]
 
     # The values for all element's properties
-    for pname in sorted(properties):
-        if pname.strip():
-            info.append(
-                tab_fmt.format(pname, property_dict.get(pname), units.get(pname))
-            )
+    for pname in sorted(prop for prop in properties if prop.strip()):
+        info.append(tab_fmt.format(pname, property_dict.get(pname), units.get(pname)))
 
     info.append(delimiter)
     info = "\n".join(info)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import copy
 import math
 from collections import Counter, defaultdict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from enum import auto
 import html
 from operator import itemgetter
@@ -425,6 +425,11 @@ class Trajectory:
 
     def __len__(self):
         return len(self._trajectory)
+
+    @property
+    def units(self) -> Mapping[str, str]:
+        """Mapping of property labels to units."""
+        return self._trajectory.units
 
     def charges(self, frame: int) -> npt.NDArray[float]:
         """Return the electrical charge of atoms at a given frame.

--- a/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
+++ b/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
@@ -16,12 +16,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import h5py
 import numpy as np
 import numpy.typing as npt
 
+from MDANSE.Chemistry import ATOMS_DATABASE
 from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
 from MDANSE.MolecularDynamics.Configuration import (
     _Configuration,
@@ -119,6 +121,11 @@ class TrajectoryFile(ABC):
     def get_atom_property(
         self, atom_symbol: str, atom_property: str
     ) -> int | float | complex | str: ...
+
+    @property
+    def units(self) -> Mapping[str, str]:
+        """Mapping of property labels to units."""
+        return ATOMS_DATABASE.units
 
     def read_configuration_trajectory(
         self,

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -205,7 +205,11 @@ class H5MDTrajectory(TrajectoryFile):
     @property
     def units(self) -> Mapping[str, str]:
         """Mapping of property labels to units."""
-        return ChainMap(self._units, ATOMS_DATABASE.units)
+        return ChainMap(
+            self._units,
+            {"b_incoherent": "Ang", "b_coherent": "Ang"},
+            ATOMS_DATABASE.units,
+        )
 
     @classmethod
     def file_is_right(self, filename: Path | str) -> bool:

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -15,6 +15,8 @@
 #
 from __future__ import annotations
 
+from collections import ChainMap
+from collections.abc import Mapping
 from enum import Enum
 from pathlib import Path
 
@@ -181,7 +183,8 @@ class H5MDTrajectory(TrajectoryFile):
 
     def _load_units(self) -> None:
         """Load units from h5 file."""
-        self.units = {}
+        self.unit_conv = {}
+        self._units = {}
 
         for name, loc in self.KEYS.items():
             if loc not in self._h5_file:
@@ -192,10 +195,17 @@ class H5MDTrajectory(TrajectoryFile):
                 unit = d["unit"]
                 for orig, rep in self.UNIT_MAP.items():
                     unit = unit.replace(orig, rep)
-                self.units[name] = measure(1.0, unit).toval(self.UNIT_CONV[name])
+                self.unit_conv[name] = measure(1.0, unit).toval(self.UNIT_CONV[name])
+                self._units[name] = unit
             else:
                 LOG.warning("No units for %s, using default of 1.0.", name)
-                self.units[name] = 1.0
+                self.unit_conv[name] = 1.0
+                self._units[name] = "none"
+
+    @property
+    def units(self) -> Mapping[str, str]:
+        """Mapping of property labels to units."""
+        return ChainMap(self._units, ATOMS_DATABASE.units)
 
     @classmethod
     def file_is_right(self, filename: Path | str) -> bool:
@@ -243,13 +253,13 @@ class H5MDTrajectory(TrajectoryFile):
         grp = self.positions
 
         configuration = {
-            "coordinates": grp[frame, :, :] * self.units["position"],
+            "coordinates": grp[frame, :, :] * self.unit_conv["position"],
             "time": self.time()[frame],
         }
 
         if self.vel_key in self._h5_file:
             configuration["velocities"] = (
-                self.velocities[frame, :, :] * self.units["velocity"]
+                self.velocities[frame, :, :] * self.unit_conv["velocity"]
             )
 
         if self._unit_cells is not None:
@@ -312,7 +322,7 @@ class H5MDTrajectory(TrajectoryFile):
 
         retval = self.positions[frame, atom_indices, :]
 
-        return retval.astype(np.float64) * self.units["position"]
+        return retval.astype(np.float64) * self.unit_conv["position"]
 
     def configuration(self, frame: int = 0) -> _Configuration:
         """Build and return a configuration at a given frame.
@@ -356,7 +366,7 @@ class H5MDTrajectory(TrajectoryFile):
         self._unit_cells = []
 
         try:
-            cells = self._h5_file[self.box_key][:] * self.units["box"]
+            cells = self._h5_file[self.box_key][:] * self.unit_conv["box"]
         except KeyError:
             self._unit_cells = None
             self.unit_cell_warning = NO_CELL
@@ -391,7 +401,7 @@ class H5MDTrajectory(TrajectoryFile):
         """Time timesteps from file."""
 
         try:
-            time = self._h5_file[self.time_key][:] * self.units["time"]
+            time = self._h5_file[self.time_key][:] * self.unit_conv["time"]
         except Exception:
             LOG.warning("Time may be invalid in H5MD file.")
             time = np.array([], dtype=np.float64)

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -15,6 +15,8 @@
 #
 from __future__ import annotations
 
+from collections import ChainMap, defaultdict
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 import h5py
@@ -502,6 +504,23 @@ class MdanseTrajectory(TrajectoryFile):
         return [
             key for key in self._h5_file["/atom_database"] if "property_" not in key
         ]
+
+    @property
+    def units(self) -> Mapping[str, str]:
+        """Mapping of property labels to units."""
+        if "atom_database/property_units" not in self._h5_file:
+            return ATOMS_DATABASE.units
+
+        return ChainMap(
+            dict(
+                zip(
+                    self._h5_file["/atom_database/property_labels"].asstr(),
+                    self._h5_file["/atom_database/property_units"].asstr(),
+                    strict=True,
+                ),
+            ),
+            ATOMS_DATABASE.units,
+        )
 
     def properties(self) -> list[str]:
         """Return the list of all the properties in the trajectory's database.

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections import ChainMap, defaultdict
 from collections.abc import Iterable, Mapping
+from functools import cached_property
 from pathlib import Path
 
 import h5py
@@ -505,13 +506,18 @@ class MdanseTrajectory(TrajectoryFile):
             key for key in self._h5_file["/atom_database"] if "property_" not in key
         ]
 
-    @property
+    @cached_property
     def units(self) -> Mapping[str, str]:
         """Mapping of property labels to units."""
-        if "atom_database/property_units" not in self._h5_file:
-            return ATOMS_DATABASE.units
+        unit_map = ChainMap(
+            {"b_incoherent": "ang", "b_coherent": "ang"},  # Inject old, weird units.
+            ATOMS_DATABASE.units,
+        )
 
-        return ChainMap(
+        if "atom_database/property_units" not in self._h5_file:
+            return unit_map
+
+        return unit_map.new_child(  # Inject units from file.
             dict(
                 zip(
                     self._h5_file["/atom_database/property_labels"].asstr(),
@@ -519,7 +525,6 @@ class MdanseTrajectory(TrajectoryFile):
                     strict=True,
                 ),
             ),
-            ATOMS_DATABASE.units,
         )
 
     def properties(self) -> list[str]:


### PR DESCRIPTION
**Description of work**
- Add a `units` property to `Trajectory`, `MdanseTrajectory` and `H5MDTrajectory` which try units defined in file, followed by `ATOMS_DATABASE` (which is a `defaultdict` and thus is total).
- General clean up of atom_info

**Fixes**
Fixes needed for #1024 

**To test**
Standard tests should pass as should `mdanse element -t ... []`
