### PR TITLE
Plot settings for 2D datasets in Single mode

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Single.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Single.py
@@ -224,6 +224,11 @@ class Single(Plotter):
                             linestyle=databundle.line_style,
                             color=tuple(main_colour),
                         )
+                        try:
+                            temp.set_marker(databundle.marker)
+                        except ValueError:
+                            with contextlib.suppress(Exception):
+                                temp.set_marker(int(databundle.marker))
                         self._active_curves.append(temp)
                         self._backup_curves.append([temp.get_xdata(), temp.get_ydata()])
                         self.height_max = max(self.height_max, temp.get_ydata().max())

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Single.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Single.py
@@ -20,6 +20,7 @@ from itertools import islice
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+from matplotlib.colors import to_rgb
 
 from MDANSE.MLogging import LOG
 from MDANSE_GUI.Tabs.Plotters.Plotter import Plotter
@@ -208,6 +209,10 @@ class Single(Plotter):
                 multi_curves = dataset.curves_vs_axis(
                     (best_unit, best_axis), max_limit=self._curve_limit_per_dataset
                 )
+                main_colour = np.array(to_rgb(databundle.colour))
+                colour_increment = (0.5 - main_colour) / min(
+                    self._curve_limit_per_dataset, len(multi_curves)
+                )
                 for key, value in islice(
                     multi_curves.items(), self._curve_limit_per_dataset
                 ):
@@ -216,6 +221,8 @@ class Single(Plotter):
                             dataset.x_axis(best_axis),
                             value,
                             label=plotlabel + ":" + dataset._curve_labels[key],
+                            linestyle=databundle.line_style,
+                            color=tuple(main_colour),
                         )
                         self._active_curves.append(temp)
                         self._backup_curves.append([temp.get_xdata(), temp.get_ydata()])
@@ -226,6 +233,7 @@ class Single(Plotter):
                         LOG.error(f"x_axis={dataset._axes[best_axis]}")
                         LOG.error(f"values={value}")
                         return
+                    main_colour += colour_increment
         if len(self._backup_curves) > 1:
             self.enable_slider(allow_slider=True)
         elif not self._backup_curves:


### PR DESCRIPTION
**Description of work**
At the moment it is not possible to customise the appearance of curves created from 2D datasets in `Single` plot mode. The main argument for ignoring the settings has been that it would make multiple curves from a single dataset appear exactly the same.

This PR makes 2D datasets use the plot settings (colour, line style and marker), introducing a colour gradient in each group of curves.

closes #569 

Example plot:
<img width="7326" height="3816" alt="sample_plot_multicurve" src="https://github.com/user-attachments/assets/656b9e76-afdd-4e3c-9678-d716e6c271a6" />


**Fixes**
1. Single plotter uses plot settings to change the appearance of curves.
2. The colour chosen by the user is used as a starting value, and then gradually changed.

**To test**
Please check if the plots are legible.
Other ideas for calculating the colour increment in a dataset are welcome.
