### PR TITLE
Close matplotlib setting editor when MDANSE closes and update marker settings

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -63,7 +63,7 @@ def get_mpl_markers():
         key: mark
         for key, mark in MarkerStyle.markers.items()
         if isinstance(key, str)
-        and key.lower() not in {"", " ", "none"}
+        and key not in {"", " ", "none"}
         and not key.isdigit()
     }
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -62,9 +62,7 @@ def get_mpl_markers():
     return {
         key: mark
         for key, mark in MarkerStyle.markers.items()
-        if isinstance(key, str)
-        and key not in {"", " ", "none"}
-        and not key.isdigit()
+        if isinstance(key, str) and key not in {"", " ", "none"} and not key.isdigit()
     }
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -871,7 +871,7 @@ class PlottingContext(QStandardItemModel):
                 "",
                 self.next_colour(),
                 new_dataset._linestyle,
-                new_dataset._marker if new_dataset._marker else "",
+                new_dataset._marker if new_dataset._marker else "None",
                 "",
                 new_dataset._filename,
             ]

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
@@ -57,7 +57,7 @@ class PlotTab(GeneralTab):
             self.model.regenerate_colours
         )
         self._core._extra_visualiser.make_layout()
-        self.matplotlib_dialog = PlotSettingsEditor(settings=self._settings)
+        self.matplotlib_dialog = PlotSettingsEditor(self.parent(), settings=self._settings)
         self.matplotlib_dialog.values_changed.connect(self._visualiser.update_plots)
         self._core.add_button("Change matplotlib settings", self.edit_matplotlib)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
@@ -57,7 +57,9 @@ class PlotTab(GeneralTab):
             self.model.regenerate_colours
         )
         self._core._extra_visualiser.make_layout()
-        self.matplotlib_dialog = PlotSettingsEditor(self.parent(), settings=self._settings)
+        self.matplotlib_dialog = PlotSettingsEditor(
+            self.parent(), settings=self._settings
+        )
         self.matplotlib_dialog.values_changed.connect(self._visualiser.update_plots)
         self._core.add_button("Change matplotlib settings", self.edit_matplotlib)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/PlotSettingsDialog.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/PlotSettingsDialog.py
@@ -229,8 +229,8 @@ class PlotSettingsEditor(QDialog):
 
     values_changed = Signal()
 
-    def __init__(self, *args, settings=None, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, parent, *args, settings=None, **kwargs):
+        super().__init__(parent, *args, **kwargs)
 
         self.setWindowTitle("MDANSE Plot Settings Editor")
 


### PR DESCRIPTION
**Description of work**
Small fixes to the GUI related to the plotting tab. A None setting was missing from the markers.

<img width="264" height="539" alt="Screenshot 2025-10-29 at 17 21 53" src="https://github.com/user-attachments/assets/98709962-7e21-4f19-8d22-3f2a7546ee98" />

Matplotlib settings windows would remain open even if MDANSE is closed.

**Fixes**
Maplotlib setting window did not close when manse is closed.
Added None setting to the plotting markers selection and is set to the default. It looks like it was missing.

**To test**
Check that the matplotlib setting windows closes when MDANSE is closed. Check that the markers work as expected.
