### PR TITLE
GUI selection undo update

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -550,6 +550,7 @@ class SelectionHelper(QDialog):
         if len(self.selection_model._clicked_atoms) == 1:
             self.disable_gui_selection_buttons()
         self.selection_model.atom_clicked_undo()
+        self.update_selection_textbox()
 
     @Slot()
     def confirm_manual_selection(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -344,7 +344,9 @@ class SelectionHelper(QDialog):
         self.mol_view.clicked_atom_index.connect(self.update_from_3d_view)
         self.mol_view.picked_atoms_changed.connect(self.update_picked_atom_count)
         self.mol_view.picked_atoms_changed.connect(self.enable_gui_selection_buttons)
-        self.selection_model.gui_selection_finalised.connect(self.disable_gui_selection_buttons)
+        self.selection_model.gui_selection_finalised.connect(
+            self.disable_gui_selection_buttons
+        )
 
         self.view_3d = View3D(self.mol_view)
         self.view_3d.update_panel(traj_data)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -459,8 +459,8 @@ class SelectionHelper(QDialog):
         """
         selection_panel = QWidget(self)
         panel_layout = QGridLayout(selection_panel)
-        undo_button = QPushButton("Undo", selection_panel)
-        redo_button = QPushButton("Redo", selection_panel)
+        undo_button = QPushButton("Undo selection", selection_panel)
+        redo_button = QPushButton("Redo selection", selection_panel)
         panel_layout.addWidget(undo_button, 0, 0)
         panel_layout.addWidget(redo_button, 0, 1)
         panel_layout.addWidget(self.selection_operations_view, 1, 0, 1, 2)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -193,6 +193,17 @@ class SelectionModel(QStandardItemModel):
         )
 
     @Slot()
+    def atom_clicked_undo(self):
+        self.can_redo.emit(False)
+        if len(self._clicked_atoms) <= 1:
+            self.clear_manual_selection()
+        else:
+            self._clicked_atoms.pop()
+            self._manual_selection_item.setText(
+                f"Manual selection IN PROGRESS: clicked on {self._clicked_atoms}",
+            )
+
+    @Slot()
     def clear_manual_selection(self):
         """Remove the placeholder item from the end of the list, clear clicked atoms."""
         if not self._clicked_atoms:
@@ -327,10 +338,10 @@ class SelectionHelper(QDialog):
         self.selection_textbox = QPlainTextEdit()
         self.selection_textbox.setReadOnly(True)
 
-        mol_view = MolecularViewerWithPicking()
-        mol_view.clicked_atom_index.connect(self.update_from_3d_view)
-        mol_view.picked_atoms_changed.connect(self.update_picked_atom_count)
-        self.view_3d = View3D(mol_view)
+        self.mol_view = MolecularViewerWithPicking()
+        self.mol_view.clicked_atom_index.connect(self.update_from_3d_view)
+        self.mol_view.picked_atoms_changed.connect(self.update_picked_atom_count)
+        self.view_3d = View3D(self.mol_view)
         self.view_3d.update_panel(traj_data)
 
         layouts = self.create_layouts()
@@ -510,9 +521,10 @@ class SelectionHelper(QDialog):
 
     @Slot()
     def undo_manual_selection(self):
-        """Remove all atoms (de)selected in the most recent manual selection."""
-        self.selection_model.clear_manual_selection()
-        self.recalculate_selection()
+        if len(self.selection_model._clicked_atoms) > 0:
+            idx = self.selection_model._clicked_atoms[-1]
+            self.mol_view.pick_atom(idx)
+        self.selection_model.atom_clicked_undo()
 
     @Slot()
     def recalculate_selection(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -105,6 +105,7 @@ class SelectionModel(QStandardItemModel):
     selection_changed = Signal()
     can_undo = Signal(bool)
     can_redo = Signal(bool)
+    gui_selection_finalised = Signal()
 
     def __init__(self, trajectory):
         """Assign the current trajectory to the model."""
@@ -268,6 +269,7 @@ class SelectionModel(QStandardItemModel):
             json_string = json.dumps(new_params)
             self._clicked_atoms = []
             self.accept_from_widget(json_string)
+        self.gui_selection_finalised.emit()
 
     @Slot(str)
     def accept_from_widget(self, json_string: str):
@@ -342,6 +344,8 @@ class SelectionHelper(QDialog):
         self.mol_view.clicked_atom_index.connect(self.update_from_3d_view)
         self.mol_view.picked_atoms_changed.connect(self.update_picked_atom_count)
         self.mol_view.picked_atoms_changed.connect(self.enable_gui_selection_buttons)
+        self.selection_model.gui_selection_finalised.connect(self.disable_gui_selection_buttons)
+
         self.view_3d = View3D(self.mol_view)
         self.view_3d.update_panel(traj_data)
 
@@ -369,7 +373,7 @@ class SelectionHelper(QDialog):
         if a1.type() == QEvent.WindowDeactivate:
             # confirm the manual selection if the user moves away from the
             # selection helper
-            self.confirm_manual_selection()
+            self.selection_model.finalise_manual_selection()
         return super().event(a1)
 
     def closeEvent(self, a0):
@@ -509,7 +513,7 @@ class SelectionHelper(QDialog):
             select_layout.addWidget(widget)
             if isinstance(widget, GUISelection):
                 self.confirm_gui_selection_button.clicked.connect(
-                    self.confirm_manual_selection,
+                    self.selection_model.finalise_manual_selection,
                 )
                 self.undo_gui_selection_button.clicked.connect(
                     self.undo_manual_selection
@@ -551,11 +555,6 @@ class SelectionHelper(QDialog):
             self.disable_gui_selection_buttons()
         self.selection_model.atom_clicked_undo()
         self.update_selection_textbox()
-
-    @Slot()
-    def confirm_manual_selection(self):
-        self.disable_gui_selection_buttons()
-        self.selection_model.finalise_manual_selection()
 
     @Slot()
     def recalculate_selection(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/AtomSelectionWidget.py
@@ -19,7 +19,7 @@ import json
 from enum import Enum
 from pathlib import Path
 
-from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtCore import QEvent, QObject, Qt, Signal, Slot
 from qtpy.QtGui import (
     QStandardItem,
     QStandardItemModel,
@@ -341,6 +341,7 @@ class SelectionHelper(QDialog):
         self.mol_view = MolecularViewerWithPicking()
         self.mol_view.clicked_atom_index.connect(self.update_from_3d_view)
         self.mol_view.picked_atoms_changed.connect(self.update_picked_atom_count)
+        self.mol_view.picked_atoms_changed.connect(self.enable_gui_selection_buttons)
         self.view_3d = View3D(self.mol_view)
         self.view_3d.update_panel(traj_data)
 
@@ -363,6 +364,13 @@ class SelectionHelper(QDialog):
         self.all_selection = True
         self.selected = set()
         self.reset()
+
+    def event(self, a1: QEvent | None) -> bool:
+        if a1.type() == QEvent.WindowDeactivate:
+            # confirm the manual selection if the user moves away from the
+            # selection helper
+            self.confirm_manual_selection()
+        return super().event(a1)
 
     def closeEvent(self, a0):
         """Hide the window instead of closing.
@@ -492,13 +500,20 @@ class SelectionHelper(QDialog):
             SphereSelection(self, self.trajectory, self.view_3d._viewer),
         ]
 
+        self.confirm_gui_selection_button = self.selection_widgets[
+            1
+        ].confirm_gui_selection
+        self.undo_gui_selection_button = self.selection_widgets[1].undo_gui_selection
+
         for widget in self.selection_widgets:
             select_layout.addWidget(widget)
             if isinstance(widget, GUISelection):
-                widget.confirm_gui_selection.clicked.connect(
-                    self.selection_model.finalise_manual_selection,
+                self.confirm_gui_selection_button.clicked.connect(
+                    self.confirm_manual_selection,
                 )
-                widget.undo_gui_selection.clicked.connect(self.undo_manual_selection)
+                self.undo_gui_selection_button.clicked.connect(
+                    self.undo_manual_selection
+                )
             else:
                 widget.new_selection.connect(self.selection_model.accept_from_widget)
 
@@ -519,12 +534,27 @@ class SelectionHelper(QDialog):
         self.selection_model.selection_changed.connect(self.recalculate_selection)
         return [scroll_area]
 
+    def enable_gui_selection_buttons(self):
+        self.confirm_gui_selection_button.setEnabled(True)
+        self.undo_gui_selection_button.setEnabled(True)
+
+    def disable_gui_selection_buttons(self):
+        self.confirm_gui_selection_button.setEnabled(False)
+        self.undo_gui_selection_button.setEnabled(False)
+
     @Slot()
     def undo_manual_selection(self):
         if len(self.selection_model._clicked_atoms) > 0:
             idx = self.selection_model._clicked_atoms[-1]
             self.mol_view.pick_atom(idx)
+        if len(self.selection_model._clicked_atoms) == 1:
+            self.disable_gui_selection_buttons()
         self.selection_model.atom_clicked_undo()
+
+    @Slot()
+    def confirm_manual_selection(self):
+        self.disable_gui_selection_buttons()
+        self.selection_model.finalise_manual_selection()
 
     @Slot()
     def recalculate_selection(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -1211,25 +1211,21 @@ class MolecularViewerWithPicking(MolecularViewer):
         picked_pos = np.array(picker.GetPickPosition())
         coords = self._reader.read_frame(self._current_frame)
         _, idx = KDTree(coords).query(picked_pos)
-        self.on_pick_atom(idx)
 
-    def on_pick_atom(self, picked_atom):
-        """Change the color of a selected atom"""
-        if self._reader is None:
+        if idx < 0 or idx >= self._n_atoms:
             return
 
-        if picked_atom < 0 or picked_atom >= self._n_atoms:
-            return
+        self.clicked_atom_index.emit(idx)
+        self.pick_atom(idx)
+        self.picked_atoms_changed.emit(self.picked_atoms)
 
-        self.clicked_atom_index.emit(picked_atom)
+    def pick_atom(self, picked_atom):
         if picked_atom in self.picked_atoms:
             self.picked_atoms.remove(picked_atom)
         else:
             self.picked_atoms.add(picked_atom)
-
         self.update_picked_polydata()
         self.update_renderer()
-        self.picked_atoms_changed.emit(self.picked_atoms)
 
     def change_picked(self, picked: set[int]):
         self.picked_atoms = picked

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
@@ -211,6 +211,8 @@ class GUISelection(BasicSelectionWidget):
         layout = self.layout()
         self.confirm_gui_selection = QPushButton("CONFIRM manual selection", self)
         self.undo_gui_selection = QPushButton("Undo GUI selection", self)
+        self.confirm_gui_selection.setEnabled(False)
+        self.undo_gui_selection.setEnabled(False)
         for button in [self.confirm_gui_selection, self.undo_gui_selection]:
             layout.addWidget(button)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
@@ -210,7 +210,7 @@ class GUISelection(BasicSelectionWidget):
         """Add GUI selection buttons, not connected."""
         layout = self.layout()
         self.confirm_gui_selection = QPushButton("CONFIRM manual selection", self)
-        self.undo_gui_selection = QPushButton("Undo atom selection", self)
+        self.undo_gui_selection = QPushButton("Undo previous action", self)
         self.confirm_gui_selection.setEnabled(False)
         self.undo_gui_selection.setEnabled(False)
         for button in [self.confirm_gui_selection, self.undo_gui_selection]:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/SelectionWidgets.py
@@ -210,7 +210,7 @@ class GUISelection(BasicSelectionWidget):
         """Add GUI selection buttons, not connected."""
         layout = self.layout()
         self.confirm_gui_selection = QPushButton("CONFIRM manual selection", self)
-        self.undo_gui_selection = QPushButton("Undo GUI selection", self)
+        self.undo_gui_selection = QPushButton("Undo atom selection", self)
         self.confirm_gui_selection.setEnabled(False)
         self.undo_gui_selection.setEnabled(False)
         for button in [self.confirm_gui_selection, self.undo_gui_selection]:


### PR DESCRIPTION
**Description of work**
The 3D view atom selection has been updated. After #1043 the 3D viewer selection undo button is now redundant since it also undos the entire 3D view selection. In this PR I have changed it so that the 3D view undo, undoes each atom selection at a time. #1020 Is fixed by confirming the 3D viewer selection whenever the user selects another window.

**Fixes**
Fixes #1020

**To test**
Test the 3D atom selection. The manual selection should be confirmed when the atom selection window deactivates. Check that the 3D view gui buttons confirm and undo grey out correctly.
