### PR TITLE
Fix issue with GUI tests

### DIFF
--- a/MDANSE_GUI/Tests/UnitTests/test_jobs_tabs.py
+++ b/MDANSE_GUI/Tests/UnitTests/test_jobs_tabs.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+import logging
+from pathlib import Path
+
 import pytest
+from qtpy.QtCore import QMessageLogger
+from qtpy.QtWidgets import QMainWindow
+
 from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Jobs.IJob import IJob
+from MDANSE.MolecularDynamics.Trajectory import Trajectory
 from MDANSE_GUI.Session.Session import LocalSession
 from MDANSE_GUI.Session.Settings import LocalSettings
 from MDANSE_GUI.Tabs.ConverterTab import ConverterTab
 from MDANSE_GUI.Tabs.JobTab import JobTab
 from MDANSE_GUI.Tabs.Models.JobTree import JobTree
 from MDANSE_GUI.Tabs.Models.TrajectoryModel import TrajectoryModel
-from qtpy.QtCore import QMessageLogger
-from qtpy.QtWidgets import QMainWindow
 
 CONVERTER_SUBCLASSES = Converter.indirect_subclass_dictionary()
 ENABLED_CONVERTERS = {
@@ -18,6 +23,15 @@ ENABLED_CONVERTERS = {
 }
 IJOB_SUBCLASSES = IJob.indirect_subclass_dictionary()
 ENABLED_JOBS = {key: val for key, val in IJOB_SUBCLASSES.items() if val.enabled}
+
+
+DATA_DIR = Path(__file__).parents[3] / "MDANSE/Tests/UnitTests/Converted"
+
+
+@pytest.fixture
+def trajectory():
+    traj_path = DATA_DIR / "lammps.mdt"
+    yield traj_path, "dummy"
 
 
 @pytest.mark.parametrize(
@@ -40,7 +54,7 @@ def test_jobtree(typ, exp):
 def test_converter_widgets_load(qapp, qtbot, caplog, index):
     """
     Test there are no major errors in constructing job widgets.
-    
+
     This includes raises in the construction of widgets and missing widgets.
     """
     window = QMainWindow()
@@ -75,10 +89,10 @@ def test_converter_widgets_load(qapp, qtbot, caplog, index):
 @pytest.mark.parametrize(
     "index", enumerate(sorted(ENABLED_JOBS), 1), ids=lambda x: x[1]
 )
-def test_job_widgets_load(qapp, qtbot, caplog, index):
+def test_job_widgets_load(qapp, qtbot, caplog, trajectory, index):
     """
     Test there are no major errors in constructing job widgets.
-    
+
     This includes raises in the construction of widgets and missing widgets.
     """
     window = QMainWindow()
@@ -90,9 +104,20 @@ def test_job_widgets_load(qapp, qtbot, caplog, index):
         settings=LocalSettings(),
         logger=QMessageLogger(),
         model=JobTree(parent_class=IJob),
-        combo_model=TrajectoryModel()
+        combo_model=TrajectoryModel(),
     )
     widget._core.setParent(window)
+
+    traj_model = widget._trajectory_combo.model()
+
+    with qtbot.waitSignal(traj_model.finished_loading):
+        traj_model.append_object(trajectory)
+
+    widget._trajectory_combo.setCurrentIndex(0)
+
+    # Clear warnings from loading trajectory
+    caplog.clear()
+
     window.show()
     qtbot.addWidget(window)
 
@@ -105,6 +130,8 @@ def test_job_widgets_load(qapp, qtbot, caplog, index):
     item = model._nodes[index]
     ind = model.indexFromItem(item)
     view.on_select_action(ind)
+
+    print(caplog.text)
 
     assert "Traceback" not in caplog.text, "Error raised with traceback."
     assert "WARNING" not in caplog.text, "Warning raised."


### PR DESCRIPTION
**Description of work**
GUI tests previously weren't running due to switch to disable loading widgets if no trajectory present.

**Fixes**
Forces GUI to load small trajectory before selecting GUI button.

**To test**
GUI tests should detect when invalid widgets in Job definitions.

Running `pytest -rP` should display logs of actually generating GUI widgets.