### PR TITLE
Improve output file widget

### DIFF
--- a/MDANSE/Src/MDANSE/IO/IOUtils.py
+++ b/MDANSE/Src/MDANSE/IO/IOUtils.py
@@ -25,9 +25,11 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from more_itertools import value_chain
+from more_itertools import first_true, value_chain
 
 from MDANSE.MLogging import LOG
+
+MAX_FILE_COUNT = 2048
 
 
 class UCEnum(Enum):
@@ -285,3 +287,37 @@ def summarise_array(array: Sequence, *, maxlen: int = 6, show: int = 3) -> str:
         return ", ".join(map(str, array))
 
     return ", ".join(map(str, value_chain(array[:show], "...", array[-1])))
+
+
+def unused_standard_output_filename(
+    path_stem: Path, job_name: str, extra_text: str = "_result", extension: str = ".mda"
+):
+    """Return the first unused output file name following the default naming pattern.
+
+    This function suggests the filename given as:
+    /directory/of/input/trajectory/JobName_resultN
+    where N is a positive integer number.
+
+    Parameters
+    ----------
+    path_stem : Path
+        Output directory with a placeholder name.
+    job_name : str
+        Name of the analysis that will produce this output file.
+    extra_text : str, optional
+        Additional text before the file number, by default "_result".
+    extension : str, optional
+        File name extension, by default ".mda".
+
+    Returns
+    -------
+    Path
+        The first file name generated which does not currently exist.
+    """
+    temp_name_generator = (
+        path_stem.with_name("".join((job_name, extra_text, str(number + 1))))
+        for number in range(MAX_FILE_COUNT)
+    )
+    return first_true(
+        temp_name_generator, pred=lambda x: not x.with_suffix(extension).exists()
+    )

--- a/MDANSE/Src/MDANSE/IO/IOUtils.py
+++ b/MDANSE/Src/MDANSE/IO/IOUtils.py
@@ -291,7 +291,7 @@ def summarise_array(array: Sequence, *, maxlen: int = 6, show: int = 3) -> str:
 
 def unused_standard_output_filename(
     path_stem: Path, job_name: str, extra_text: str = "_result", extension: str = ".mda"
-):
+) -> Path | None:
     """Return the first unused output file name following the default naming pattern.
 
     This function suggests the filename given as:
@@ -311,8 +311,8 @@ def unused_standard_output_filename(
 
     Returns
     -------
-    Path
-        The first file name generated which does not currently exist.
+    Path | None
+        The first file name which does not exist. None if all names are taken.
     """
     temp_name_generator = (
         path_stem.with_name("".join((job_name, extra_text, str(number + 1))))

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputFilesWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputFilesWidget.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 
 import os
 import os.path
-from pathlib import PurePath
+from pathlib import Path
 
+from more_itertools import first_true
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QComboBox, QFileDialog, QLabel, QLineEdit, QPushButton
 
@@ -30,6 +31,20 @@ from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
 
 from .CheckableComboBox import CheckableComboBox
 
+MAX_FILE_COUNT = 2048
+
+
+def unused_standard_output_filename(
+    path_stem: Path, job_name: str, extension: str = ".mda"
+):
+    temp_name_generator = (
+        path_stem.with_name(job_name + "_result" + str(number + 1))
+        for number in range(MAX_FILE_COUNT)
+    )
+    return first_true(
+        temp_name_generator, pred=lambda x: not x.with_suffix(extension).exists()
+    )
+
 
 class OutputFilesWidget(WidgetBase):
     def __init__(self, *args, **kwargs):
@@ -37,27 +52,20 @@ class OutputFilesWidget(WidgetBase):
         default_value = self._configurator.default
         try:
             self._parent = kwargs.get("parent")
-            self.default_path = PurePath(self._parent._default_path)
-        except KeyError:
-            self.default_path = PurePath(os.path.abspath("."))
-            LOG.error("KeyError in OutputFilesWidget - can't get default path.")
-        except AttributeError:
-            self.default_path = PurePath(os.path.abspath("."))
-            LOG.error("AttributeError in OutputFilesWidget - can't get default path.")
+            self.default_path = Path(self._parent._default_path)
+        except (KeyError, AttributeError) as e:
+            self.default_path = Path(".").absolute()
+            LOG.error("%s in OutputFilesWidget - can't get default path.", str(e))
         else:
             self._session = self._parent._parent_tab._session
         try:
             self._parent = kwargs.get("parent")
             jobname = str(self._parent._job_instance.label).replace(" ", "")
-            guess_name = str(
-                PurePath(os.path.join(self.default_path, jobname + "_result1"))
-            )
         except Exception:
-            guess_name = str(PurePath(default_value[0]))
+            jobname = "MDANSE_analysis"
             LOG.error("It was not possible to get the job name from the parent")
-        while os.path.exists(guess_name + ".mda"):
-            prefix, number = guess_name.split("_result")
-            guess_name = prefix + "_result" + str(1 + int(number))
+        self.default_path = self.default_path / "output"
+        guess_name = unused_standard_output_filename(self.default_path, jobname)
         self.file_association = "Output file name (*)"
         self._value = default_value
         self._field = QLineEdit(str(guess_name), self._base)
@@ -114,9 +122,9 @@ class OutputFilesWidget(WidgetBase):
         and emit a signal to update the value show by the GUI.
         """
         try:
-            self.default_path = PurePath(self._parent._default_path)
+            self.default_path = Path(self._parent._default_path)
         except AttributeError:
-            self.default_path = PurePath(os.path.abspath("."))
+            self.default_path = Path(".").absolute()
         new_value = QFileDialog.getSaveFileName(
             self._base,  # the parent of the dialog
             "Save files",  # the label of the window
@@ -124,7 +132,7 @@ class OutputFilesWidget(WidgetBase):
             self.file_association,  # text string specifying the file name filter.
         )
         if len(new_value[0]) > 0:
-            self._field.setText(str(PurePath(new_value[0])))
+            self._field.setText(str(Path(new_value[0])))
             self.updateValue()
 
     def get_widget_value(self):
@@ -136,4 +144,4 @@ class OutputFilesWidget(WidgetBase):
         formats = self.type_box.checked_values()
         log_level = self.logs_combo.currentText()
 
-        return (str(PurePath(os.path.abspath(filename))), formats, log_level)
+        return (str(Path(os.path.abspath(filename))), formats, log_level)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputFilesWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputFilesWidget.py
@@ -15,35 +15,19 @@
 #
 from __future__ import annotations
 
-import os
-import os.path
 from pathlib import Path
 
-from more_itertools import first_true
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QComboBox, QFileDialog, QLabel, QLineEdit, QPushButton
 
 from MDANSE.Framework.Configurators.OutputFilesConfigurator import (
     OutputFilesConfigurator,
 )
+from MDANSE.IO.IOUtils import unused_standard_output_filename
 from MDANSE.MLogging import LOG
 from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
 
 from .CheckableComboBox import CheckableComboBox
-
-MAX_FILE_COUNT = 2048
-
-
-def unused_standard_output_filename(
-    path_stem: Path, job_name: str, extension: str = ".mda"
-):
-    temp_name_generator = (
-        path_stem.with_name(job_name + "_result" + str(number + 1))
-        for number in range(MAX_FILE_COUNT)
-    )
-    return first_true(
-        temp_name_generator, pred=lambda x: not x.with_suffix(extension).exists()
-    )
 
 
 class OutputFilesWidget(WidgetBase):
@@ -144,4 +128,4 @@ class OutputFilesWidget(WidgetBase):
         formats = self.type_box.checked_values()
         log_level = self.logs_combo.currentText()
 
-        return (str(Path(os.path.abspath(filename))), formats, log_level)
+        return (str(Path(filename).absolute()), formats, log_level)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputStructureWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputStructureWidget.py
@@ -15,9 +15,7 @@
 #
 from __future__ import annotations
 
-import os
-import os.path
-from pathlib import PurePath
+from pathlib import Path
 
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QComboBox, QFileDialog, QLabel, QLineEdit, QPushButton
@@ -35,20 +33,15 @@ class OutputStructureWidget(WidgetBase):
         default_value = self._configurator.default
         try:
             parent = kwargs.get("parent")
-            self.default_path = PurePath(parent.default_path)
-        except KeyError:
-            self.default_path = PurePath(os.path.abspath("."))
-            LOG.error("KeyError in OutputTrajectoryWidget - can't get default path.")
-        except AttributeError:
-            self.default_path = PurePath(os.path.abspath("."))
-            LOG.error(
-                "AttributeError in OutputTrajectoryWidget - can't get default path."
-            )
+            self.default_path = Path(parent.default_path)
+        except (KeyError, AttributeError) as e:
+            self.default_path = Path(".").absolute()
+            LOG.error("%s in OutputTrajectoryWidget - can't get default path.", str(e))
         try:
             parent = kwargs.get("parent")
-            guess_name = str(PurePath(os.path.join(self.default_path, "POSCAR")))
+            guess_name = self.default_path / "POSCAR"
         except Exception:
-            guess_name = str(PurePath(default_value[0]))
+            guess_name = self.default_path / default_value
             LOG.error("It was not possible to get the job name from the parent")
         else:
             self._session = parent._parent_tab._session
@@ -113,7 +106,7 @@ class OutputStructureWidget(WidgetBase):
             self.file_association,  # text string specifying the file name filter.
         )
         if len(new_value[0]) > 0:
-            self._field.setText(str(PurePath(new_value[0])))
+            self._field.setText(str(Path(new_value[0])))
             self.updateValue()
 
     def get_widget_value(self):
@@ -123,4 +116,4 @@ class OutputStructureWidget(WidgetBase):
             filename = self._default_value[0]
         format = self.format_box.currentText()
         log_level = self.logs_combo.currentText()
-        return (os.path.abspath(filename), format, log_level)
+        return (str(Path(filename).absolute()), format, log_level)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
@@ -15,9 +15,7 @@
 #
 from __future__ import annotations
 
-import os
-import os.path
-from pathlib import PurePath
+from pathlib import Path
 
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import (
@@ -32,6 +30,7 @@ from qtpy.QtWidgets import (
 from MDANSE.Framework.Configurators.OutputTrajectoryConfigurator import (
     OutputTrajectoryConfigurator,
 )
+from MDANSE.IO.IOUtils import unused_standard_output_filename
 from MDANSE.MLogging import LOG
 from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
 
@@ -44,29 +43,22 @@ class OutputTrajectoryWidget(WidgetBase):
         default_value = self._configurator.default
         try:
             self._parent = kwargs.get("parent")
-            self.default_path = PurePath(self._parent._default_path)
-        except KeyError:
-            self.default_path = PurePath(os.path.abspath("."))
-            LOG.error("KeyError in OutputTrajectoryWidget - can't get default path.")
-        except AttributeError:
-            self.default_path = PurePath(os.path.abspath("."))
-            LOG.error(
-                "AttributeError in OutputTrajectoryWidget - can't get default path."
-            )
+            self.default_path = Path(self._parent._default_path)
+        except (KeyError, AttributeError) as e:
+            self.default_path = Path(".").absolute()
+            LOG.error("%s in OutputTrajectoryWidget - can't get default path.", str(e))
         else:
             self._session = self._parent._parent_tab._session
         try:
             self._parent = kwargs.get("parent")
             jobname = str(self._parent._job_instance.label).replace(" ", "")
-            guess_name = str(
-                PurePath(os.path.join(self.default_path, jobname + "_trajectory1"))
-            )
         except Exception:
-            guess_name = str(PurePath(default_value[0]))
+            jobname = "converted_trajectory"
             LOG.error("It was not possible to get the job name from the parent")
-        while os.path.exists(guess_name + ".mdt"):
-            prefix, number = guess_name.split("_trajectory")
-            guess_name = str(PurePath(prefix + "_trajectory" + str(1 + int(number))))
+        self.default_path = self.default_path / "trajectory"
+        guess_name = unused_standard_output_filename(
+            self.default_path, jobname, extra_text="_trajectory", extension=".mdt"
+        )
         self.file_association = "MDT trajectory (*.mdt)"
         self._value = default_value
         self._field = QLineEdit(str(guess_name), self._base)
@@ -151,7 +143,7 @@ class OutputTrajectoryWidget(WidgetBase):
             self.file_association,  # text string specifying the file name filter.
         )
         if len(new_value[0]) > 0:
-            self._field.setText(str(PurePath(new_value[0])))
+            self._field.setText(str(Path(new_value[0])))
             self.updateValue()
 
     def get_widget_value(self):


### PR DESCRIPTION
**Description of work**
The code that generates standard output file names had been moved out of the GUI widgets. It now generates file names without string splitting operations.

closes #1075 

**Fixes**
1. A new function in `MDANSE.IO.IOUtils` generates file names for the GUI widgets, without splitting strings.

**To test**
Create testing directory named "trajectory_result" and copy a short trajectory there. Try converting it multiple times from the GUI and check that a new name is suggested correctly each time.
Try running an analysis on that trajectory. Again, check that a new output file name is suggested by the GUI if the output files already exist.
