### PR TITLE
Fix instruments tab

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/InstrumentTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/InstrumentTab.py
@@ -69,6 +69,7 @@ class InstrumentTab(GeneralTab):
                 instrument._configured = (
                     True  # instruments loaded from file are configured
                 )
+        self._visualiser.save_view_reference(self._view)
 
     @Slot()
     def load_trajectories(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/InstrumentList.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/InstrumentList.py
@@ -46,10 +46,12 @@ class InstrumentList(QListView):
         self._backup_instruments = {}
 
     def get_blocked_names(self) -> set[str]:
+        """Return a set of all names that are already present in the model."""
         model = self.model()
         return {model.index(row, 0).data() for row in range(model.rowCount())}
 
-    def all_names_are_unique(self):
+    def all_names_are_unique(self) -> bool:
+        """Return True is every name only appears once in the model, False otherwise."""
         return len(self.get_blocked_names()) == self.model().rowCount()
 
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/InstrumentList.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/InstrumentList.py
@@ -19,7 +19,7 @@ import os
 
 import tomlkit
 from qtpy.QtCore import QModelIndex, Signal, Slot
-from qtpy.QtGui import QContextMenuEvent, QStandardItem
+from qtpy.QtGui import QContextMenuEvent, QStandardItem, QValidator
 from qtpy.QtWidgets import QAbstractItemView, QListView, QMenu
 from tomlkit.parser import ParseError
 from tomlkit.toml_file import TOMLFile
@@ -45,14 +45,14 @@ class InstrumentList(QListView):
         self._all_instruments = set()
         self._backup_instruments = {}
 
-    def get_blocked_names(self) -> set[str]:
+    def get_existing_names(self) -> set[str]:
         """Return a set of all names that are already present in the model."""
         model = self.model()
         return {model.index(row, 0).data() for row in range(model.rowCount())}
 
     def all_names_are_unique(self) -> bool:
         """Return True is every name only appears once in the model, False otherwise."""
-        return len(self.get_blocked_names()) == self.model().rowCount()
+        return len(self.get_existing_names()) == self.model().rowCount()
 
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
         index = self.indexAt(event.pos())
@@ -148,7 +148,7 @@ class InstrumentList(QListView):
         model = self.model()
         if model is None:
             return
-        new_instrument = SimpleInstrument(blocked_names=self.get_blocked_names())
+        new_instrument = SimpleInstrument(existing_names=self.get_existing_names())
         LOG.debug(f"New instrument, name: {new_instrument._name}")
         new_name = new_instrument._name if optional_name is None else optional_name
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/InstrumentList.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/InstrumentList.py
@@ -45,6 +45,13 @@ class InstrumentList(QListView):
         self._all_instruments = set()
         self._backup_instruments = {}
 
+    def get_blocked_names(self) -> set[str]:
+        model = self.model()
+        return {model.index(row, 0).data() for row in range(model.rowCount())}
+
+    def all_names_are_unique(self):
+        return len(self.get_blocked_names()) == self.model().rowCount()
+
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
         index = self.indexAt(event.pos())
         if index.row() == -1:
@@ -139,7 +146,7 @@ class InstrumentList(QListView):
         model = self.model()
         if model is None:
             return
-        new_instrument = SimpleInstrument()
+        new_instrument = SimpleInstrument(blocked_names=self.get_blocked_names())
         LOG.debug(f"New instrument, name: {new_instrument._name}")
         new_name = new_instrument._name if optional_name is None else optional_name
 
@@ -205,6 +212,11 @@ class InstrumentList(QListView):
 
     @Slot()
     def save_to_file(self, filename: str | None = None):
+        if not self.all_names_are_unique():
+            LOG.error(
+                "Instruments will NOT be saved. Some instruments have conflicting names."
+            )
+            return
         if filename is None:
             filename = os.path.join(
                 PLATFORM.application_directory(), "InstrumentDefinitions.toml"

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/InstrumentList.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/InstrumentList.py
@@ -19,7 +19,7 @@ import os
 
 import tomlkit
 from qtpy.QtCore import QModelIndex, Signal, Slot
-from qtpy.QtGui import QContextMenuEvent, QStandardItem, QValidator
+from qtpy.QtGui import QContextMenuEvent, QStandardItem
 from qtpy.QtWidgets import QAbstractItemView, QListView, QMenu
 from tomlkit.parser import ParseError
 from tomlkit.toml_file import TOMLFile
@@ -30,6 +30,7 @@ from MDANSE_GUI.Tabs.Visualisers.InstrumentDetails import (
     InstrumentDetails,
     SimpleInstrument,
 )
+from MDANSE_GUI.Tabs.Visualisers.InstrumentInfo import generate_name
 
 
 class InstrumentList(QListView):
@@ -105,14 +106,16 @@ class InstrumentList(QListView):
         index = self.currentIndex()
         node_number = model.itemFromIndex(index).data()
         instrument = model._nodes[node_number]
-        new_instrument_name = instrument._name + " (Copy)"
-        new_instrument = self.add_instrument(new_instrument_name)
+        new_unique_name = generate_name(
+            self.get_existing_names(), prefix=f"{instrument._name} (Copy ", suffix=")"
+        )
+        new_instrument = self.add_instrument(new_unique_name)
         for line in new_instrument.inputs():
             attr_name = line[0]
             setattr(new_instrument, attr_name, getattr(instrument, attr_name, None))
-        new_instrument._name = instrument._name + " (Copy)"
+        new_instrument._name = new_unique_name
         if new_instrument._list_item is not None:
-            new_instrument._list_item.setText(new_instrument_name)
+            new_instrument._list_item.setText(new_unique_name)
 
     @Slot()
     def restoreNode(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
@@ -15,6 +15,8 @@
 #
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtGui import QDoubleValidator, QIntValidator, QValidator
 from qtpy.QtWidgets import (
@@ -28,6 +30,9 @@ from qtpy.QtWidgets import (
 from MDANSE.MLogging import LOG
 from MDANSE_GUI.Tabs.Visualisers.InstrumentInfo import InstrumentInfo, SimpleInstrument
 from MDANSE_GUI.Widgets.VectorWidget import VectorWidget
+
+if TYPE_CHECKING:
+    from MDANSE_GUI.Tabs.Views.InstrumentList import InstrumentList
 
 
 class FreeNameValidator(QValidator):
@@ -61,11 +66,15 @@ class FreeNameValidator(QValidator):
             Cursor position.
 
         """
-        state = QValidator.State.Acceptable if (
-            input_string 
-            and self.instrument_list 
-            and input_string not in self.instrument_list.get_blocked_names()
-        ) else QValidator.State.Invalid
+        state = (
+            QValidator.State.Acceptable
+            if (
+                input_string
+                and self.instrument_list
+                and input_string not in self.instrument_list.get_existing_names()
+            )
+            else QValidator.State.Invalid
+        )
         return state, input_string, position
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from qtpy.QtCore import Signal, Slot
-from qtpy.QtGui import QDoubleValidator, QIntValidator
+from qtpy.QtGui import QDoubleValidator, QIntValidator, QValidator
 from qtpy.QtWidgets import (
     QComboBox,
     QGridLayout,
@@ -30,6 +30,46 @@ from MDANSE_GUI.Tabs.Visualisers.InstrumentInfo import InstrumentInfo, SimpleIns
 from MDANSE_GUI.Widgets.VectorWidget import VectorWidget
 
 
+class FreeNameValidator(QValidator):
+    def __init__(self, *args, instrument_list=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.instrument_list = instrument_list
+
+    def validate(self, input_string: str, position: int) -> tuple[int, str]:
+        """Check the input string from a widget.
+
+        Implementation of the virtual method of QValidator.
+        It takes in the string from a QLineEdit and the cursor position,
+        and an enum value of the validator state. Widgets will reject
+        inputs which change the state to Invalid.
+
+        Parameters
+        ----------
+        input_string : str
+            current contents of a text input field
+        position : int
+            position of the cursor in the text input field
+
+        Returns
+        -------
+        int
+            Validator state.
+        str
+            Original input string.
+        int
+            Cursor position.
+
+        """
+        state = QValidator.State.Intermediate
+        if self.instrument_list is None:
+            return QValidator.State.Acceptable, input_string, position
+        if not input_string or input_string in self.instrument_list.get_blocked_names():
+            state = QValidator.State.Invalid
+        else:
+            state = QValidator.State.Acceptable
+        return state, input_string, position
+
+
 class InstrumentDetails(QWidget):
     instrument_details_changed = Signal(int)
 
@@ -38,11 +78,17 @@ class InstrumentDetails(QWidget):
         self.setLayout(QGridLayout(self))
         self._widgets = {}
         self._values = {}
+        self._view_reference = None
         self._current_instrument = None
         self.populate_panel(SimpleInstrument)
         self.add_visualiser()
         for attr in ["_sample", "_technique"]:
             self._widgets[attr].currentTextChanged.connect(self.reset_qvector_combobox)
+
+    def save_view_reference(self, view):
+        self._view_reference = view
+        self._name_validator = FreeNameValidator(instrument_list=self._view_reference)
+        self._widgets["_name"].setValidator(self._name_validator)
 
     def add_visualiser(self):
         layout = self.layout()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
@@ -37,7 +37,7 @@ class FreeNameValidator(QValidator):
     present in the input set.
     """
 
-    def __init__(self, *args, instrument_list=None, **kwargs):
+    def __init__(self, *args, instrument_list: InstrumentList | None = None, **kwargs):
         super().__init__(*args, **kwargs)
         self.instrument_list = instrument_list
 
@@ -61,13 +61,11 @@ class FreeNameValidator(QValidator):
             Cursor position.
 
         """
-        state = QValidator.State.Intermediate
-        if self.instrument_list is None:
-            return QValidator.State.Acceptable, input_string, position
-        if not input_string or input_string in self.instrument_list.get_blocked_names():
-            state = QValidator.State.Invalid
-        else:
-            state = QValidator.State.Acceptable
+        state = QValidator.State.Acceptable if (
+            input_string 
+            and self.instrument_list 
+            and input_string not in self.instrument_list.get_blocked_names()
+        ) else QValidator.State.Invalid
         return state, input_string, position
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
@@ -31,17 +31,18 @@ from MDANSE_GUI.Widgets.VectorWidget import VectorWidget
 
 
 class FreeNameValidator(QValidator):
+    """Validator which compares the input text to the stored set of strings.
+
+    The intention is not to allow the user to type in a name that is already
+    present in the input set.
+    """
+
     def __init__(self, *args, instrument_list=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.instrument_list = instrument_list
 
     def validate(self, input_string: str, position: int) -> tuple[int, str]:
-        """Check the input string from a widget.
-
-        Implementation of the virtual method of QValidator.
-        It takes in the string from a QLineEdit and the cursor position,
-        and an enum value of the validator state. Widgets will reject
-        inputs which change the state to Invalid.
+        """Prevent the user from typing a name that is present in the input set.
 
         Parameters
         ----------
@@ -86,6 +87,11 @@ class InstrumentDetails(QWidget):
             self._widgets[attr].currentTextChanged.connect(self.reset_qvector_combobox)
 
     def save_view_reference(self, view):
+        """Save a reference to InstrumentList.
+
+        InstrumentList is then used by the input validator to look up the
+        current list of instrument names in the model.
+        """
         self._view_reference = view
         self._name_validator = FreeNameValidator(instrument_list=self._view_reference)
         self._widgets["_name"].setValidator(self._name_validator)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
@@ -15,6 +15,8 @@
 #
 from __future__ import annotations
 
+from itertools import count
+
 from more_itertools import first_true
 from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtGui import QStandardItem
@@ -28,7 +30,7 @@ from MDANSE_GUI.Widgets.ResolutionWidget import ResolutionCalculator, widget_tex
 
 
 def generate_name(
-    blocked_names: set[str] | None, name_root: str = "Generic neutron instrument"
+    existing_names: set[str] | None, name_root: str = "Generic neutron instrument"
 ) -> str:
     """Create a text string different to those in the input set, if provided.
 
@@ -36,7 +38,7 @@ def generate_name(
 
     Parameters
     ----------
-    blocked_names : set[str] | None
+    existing_names : set[str] | None
         Set of all the names that are already in use.
     name_root : str, optional
         Starting name, by default "Generic neutron instrument".
@@ -46,10 +48,10 @@ def generate_name(
     str
         First name root plus number that is not already in the input set.
     """
-    if blocked_names is None:
+    if existing_names is None:
         return name_root
-    name_generator = (f"{name_root} {number" for number in range(1, 2048))
-    return first_true(name_generator, pred=lambda x: x not in blocked_names)
+    name_generator = (f"{name_root} {number}" for number in count(1))
+    return first_true(name_generator, pred=lambda x: x not in existing_names)
 
 
 class SimpleInstrument:
@@ -63,10 +65,10 @@ class SimpleInstrument:
     def __init__(
         self,
         optional_qitem_reference: QStandardItem = None,
-        blocked_names: set[str] | None = None,
+        existing_names: set[str] | None = None,
     ) -> None:
         self._list_item = optional_qitem_reference
-        self._name = generate_name(blocked_names)
+        self._name = generate_name(existing_names)
         self._name_is_fixed = False
         self._sample = "isotropic"
         self._technique = "QENS"

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
@@ -28,8 +28,26 @@ from MDANSE_GUI.Widgets.ResolutionWidget import ResolutionCalculator, widget_tex
 
 
 def generate_name(
-    blocked_names: set[str], name_root: str = "Generic neutron instrument"
+    blocked_names: set[str] | None, name_root: str = "Generic neutron instrument"
 ) -> str:
+    """Create a text string different to those in the input set, if provided.
+
+    This function adds numbers to the text string which is the root of the new name.
+
+    Parameters
+    ----------
+    blocked_names : set[str] | None
+        Set of all the names that are already in use.
+    name_root : str, optional
+        Starting name, by default "Generic neutron instrument".
+
+    Returns
+    -------
+    str
+        First name root plus number that is not already in the input set.
+    """
+    if blocked_names is None:
+        return name_root
     name_generator = (" ".join([name_root, str(number)]) for number in range(1, 2048))
     return first_true(name_generator, pred=lambda x: x not in blocked_names)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
@@ -30,7 +30,9 @@ from MDANSE_GUI.Widgets.ResolutionWidget import ResolutionCalculator, widget_tex
 
 
 def generate_name(
-    existing_names: set[str] | None, name_root: str = "Generic neutron instrument"
+    existing_names: set[str] | None,
+    prefix: str = "Generic neutron instrument ",
+    suffix: str = "",
 ) -> str:
     """Create a text string different to those in the input set, if provided.
 
@@ -40,17 +42,19 @@ def generate_name(
     ----------
     existing_names : set[str] | None
         Set of all the names that are already in use.
-    name_root : str, optional
-        Starting name, by default "Generic neutron instrument".
+    prefix : str, optional
+        Part of the name before the number, by default "Generic neutron instrument".
+    suffix : str, optional
+        Part of the name after the number, by default "".
 
     Returns
     -------
     str
-        First name root plus number that is not already in the input set.
+        Name composed of prefix, number, suffix using the lowest positive number possible.
     """
     if existing_names is None:
-        return name_root
-    name_generator = (f"{name_root} {number}" for number in count(1))
+        return f"{prefix}{suffix}"
+    name_generator = (f"{prefix}{number}{suffix}" for number in count(1))
     return first_true(name_generator, pred=lambda x: x not in existing_names)
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+from more_itertools import first_true
 from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtGui import QStandardItem
 from qtpy.QtWidgets import QTextBrowser
@@ -26,6 +27,13 @@ from MDANSE.MolecularDynamics.UnitCell import UnitCell
 from MDANSE_GUI.Widgets.ResolutionWidget import ResolutionCalculator, widget_text_map
 
 
+def generate_name(
+    blocked_names: set[str], name_root: str = "Generic neutron instrument"
+) -> str:
+    name_generator = (" ".join([name_root, str(number)]) for number in range(1, 2048))
+    return first_true(name_generator, pred=lambda x: x not in blocked_names)
+
+
 class SimpleInstrument:
     sample_options = ("isotropic", "crystal")
     technique_options = ("QENS", "INS")
@@ -34,9 +42,13 @@ class SimpleInstrument:
     energy_units = ("meV", "1/cm", "THz")
     momentum_units = ("1/ang", "1/nm", "1/Bohr")
 
-    def __init__(self, optional_qitem_reference: QStandardItem = None) -> None:
+    def __init__(
+        self,
+        optional_qitem_reference: QStandardItem = None,
+        blocked_names: set[str] | None = None,
+    ) -> None:
         self._list_item = optional_qitem_reference
-        self._name = "Generic neutron instrument"
+        self._name = generate_name(blocked_names)
         self._name_is_fixed = False
         self._sample = "isotropic"
         self._technique = "QENS"

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
@@ -48,7 +48,7 @@ def generate_name(
     """
     if blocked_names is None:
         return name_root
-    name_generator = (" ".join([name_root, str(number)]) for number in range(1, 2048))
+    name_generator = (f"{name_root} {number" for number in range(1, 2048))
     return first_true(name_generator, pred=lambda x: x not in blocked_names)
 
 


### PR DESCRIPTION
**Description of work**
Minimal changes meant to ensure that every instrument in the instrument database has a unique name.

closes #1091 

**Fixes**
1. Instrument database can't be saved if the instrument names are not unique.
2. A validator prevents the user from typing an instrument name that is already in use.
3. New instruments get numbers appended to the name to avoid name conflicts.

**To test**
Try adding new instrument, copying existing instruments and deleting the new instruments. Save the instrument database and check if it loads correctly on startup. It should not be possible to create a new instrument with a duplicate name, or to save a database with duplicate names.

