### PR TITLE
Convert Path to string for TOML writeout

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Session/Session.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Session/Session.py
@@ -91,7 +91,9 @@ class Session(QObject):
         gs.load_settings()
         paths = gs.group("paths")
         paths.set_group_comment("Lookup of working directory paths for the main GUI")
-        paths.add("root_directory", Path.home(), "Starting path for any file search")
+        paths.add(
+            "root_directory", str(Path.home()), "Starting path for any file search"
+        )
 
         units = gs.group("units")
         units.set_group_comment(


### PR DESCRIPTION
**Description of work**
Fixes the startup error caused by `Path` being put into TOML.

closes #1094 

**Fixes**
1. In `Session.py` convert the `Path` object to string in `populate_defaults`.

**To test**
Remove the settings from `~/.mdanse` and start the GUI. It should start and create new setting files.
