### PR TITLE
Add fixup call to FreeNameValidator

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/InstrumentList.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/InstrumentList.py
@@ -51,6 +51,15 @@ class InstrumentList(QListView):
         model = self.model()
         return {model.index(row, 0).data() for row in range(model.rowCount())}
 
+    def get_other_names(self) -> set[str]:
+        """Return a set of names in the model excluding the current item."""
+        model = self.model()
+        return {
+            model.index(row, 0).data()
+            for row in range(model.rowCount())
+            if row != self.currentIndex().row()
+        }
+
     def all_names_are_unique(self) -> bool:
         """Return True is every name only appears once in the model, False otherwise."""
         return len(self.get_existing_names()) == self.model().rowCount()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
@@ -75,15 +75,34 @@ class FreeNameValidator(QValidator):
             if (
                 input_string
                 and self.instrument_list
-                and input_string not in self.instrument_list.get_existing_names()
+                and input_string not in self.instrument_list.get_other_names()
             )
             else QValidator.State.Invalid
         )
         return state, input_string, position
 
-    def fixup(self, a0):
+    def fixup(self, invalid_string: str) -> str:
+        """Modify the current input string so it can pass validation.
+
+        This method will be called on the input string if the user stops editing
+        leaving the text in invalid state. Since this validator prevents duplicate
+        names from being entered, it will append a tag to the current name with
+        a number that is incremented as needed to find a name that does not
+        currently appear on the list.
+
+        Parameters
+        ----------
+        invalid_string : str
+            Contents of the text input field, currently not passing validation.
+
+        Returns
+        -------
+        str
+            Modified string which will be passed to validate method again.
+        """
         new_name = generate_name(
-            self.instrument_list.get_existing_names(), prefix=f"{a0}_duplicate"
+            self.instrument_list.get_other_names(),
+            prefix=f"{invalid_string}_duplicate",
         )
         return super().fixup(new_name)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
@@ -28,7 +28,11 @@ from qtpy.QtWidgets import (
 )
 
 from MDANSE.MLogging import LOG
-from MDANSE_GUI.Tabs.Visualisers.InstrumentInfo import InstrumentInfo, SimpleInstrument
+from MDANSE_GUI.Tabs.Visualisers.InstrumentInfo import (
+    InstrumentInfo,
+    SimpleInstrument,
+    generate_name,
+)
 from MDANSE_GUI.Widgets.VectorWidget import VectorWidget
 
 if TYPE_CHECKING:
@@ -76,6 +80,12 @@ class FreeNameValidator(QValidator):
             else QValidator.State.Invalid
         )
         return state, input_string, position
+
+    def fixup(self, a0):
+        new_name = generate_name(
+            self.instrument_list.get_existing_names(), prefix=f"{a0}_duplicate"
+        )
+        return super().fixup(new_name)
 
 
 class InstrumentDetails(QWidget):


### PR DESCRIPTION
**Description of work**
It is still possible to give instruments conflicting names. This PR extends the validator for the name field to catch invalid inputs after the user has finished editing.

closes #1091

**Fixes**
`FreeNameValidator.fixup` will add a `"_duplicate{number}"` tag to the instrument name if the user stops editing on a duplicate name.

**To test**
Try to input a duplicate name using all possible methods. The name should get corrected once the QLineEdit loses focus.

