### PR TITLE
Include molecules with deselected dummy atoms in COMT

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -72,9 +72,15 @@ class CenterOfMassesTrajectory(IJob):
 
         self.cluster_composition = {}
         original_atom_list = chemical_system.atom_list
-        nondummy_indices = {ind for ind, dummy in 
-        zip(chemical_system._atom_indices, chemical_system.atom_property("dummy"), strict=True)
-        if not dummy}
+        nondummy_indices = {
+            ind
+            for ind, dummy in zip(
+                chemical_system._atom_indices,
+                chemical_system.atom_property("dummy"),
+                strict=True,
+            )
+            if not dummy
+        }
         selected_indices = (
             set(self.trajectory._selection)
             if self.trajectory._selection

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -72,11 +72,9 @@ class CenterOfMassesTrajectory(IJob):
 
         self.cluster_composition = {}
         original_atom_list = chemical_system.atom_list
-        nondummy_indices = set(
-            np.array(chemical_system._atom_indices)[
-                np.logical_not(chemical_system.atom_property("dummy"))
-            ]
-        )
+        nondummy_indices = {ind for ind, dummy in 
+        zip(chemical_system._atom_indices, chemical_system.atom_property("dummy"), strict=True)
+        if not dummy}
         selected_indices = (
             set(self.trajectory._selection)
             if self.trajectory._selection
@@ -98,8 +96,7 @@ class CenterOfMassesTrajectory(IJob):
                         self.cluster_composition[cluster_name] = [
                             original_atom_list[ind] for ind in cluster
                         ]
-                    if cluster_name not in self.temp_clusters:
-                        self.temp_clusters[cluster_name] = []
+                    self.temp_clusters.setdefault(cluster_name, [])
                     new_element_list.append(cluster_name)
                     used_up_atoms.update(set(cluster))
                     self.temp_clusters[cluster_name].append(list(nondummy_cluster))

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -72,6 +72,11 @@ class CenterOfMassesTrajectory(IJob):
 
         self.cluster_composition = {}
         original_atom_list = chemical_system.atom_list
+        nondummy_indices = set(
+            np.array(chemical_system._atom_indices)[
+                np.logical_not(chemical_system.atom_property("dummy"))
+            ]
+        )
         selected_indices = (
             set(self.trajectory._selection)
             if self.trajectory._selection
@@ -80,15 +85,24 @@ class CenterOfMassesTrajectory(IJob):
         new_element_list = []
         used_up_atoms = set()
         new_chemical_system = ChemicalSystem()
+        self.temp_clusters = {}
         for cluster_name in chemical_system._clusters:
             for cluster in chemical_system._clusters[cluster_name]:
-                if selected_indices and set(cluster) <= selected_indices:
+                nondummy_cluster = nondummy_indices.intersection(cluster)
+                if (
+                    nondummy_cluster
+                    and selected_indices
+                    and nondummy_cluster <= selected_indices
+                ):
                     if cluster_name not in self.cluster_composition:
                         self.cluster_composition[cluster_name] = [
                             original_atom_list[ind] for ind in cluster
                         ]
+                    if cluster_name not in self.temp_clusters:
+                        self.temp_clusters[cluster_name] = []
                     new_element_list.append(cluster_name)
                     used_up_atoms.update(set(cluster))
+                    self.temp_clusters[cluster_name].append(list(nondummy_cluster))
         for index in selected_indices:
             if index not in used_up_atoms:
                 new_element_list.append(chemical_system.atom_list[index])
@@ -134,8 +148,8 @@ class CenterOfMassesTrajectory(IJob):
 
         com_coords = np.empty((n_coms, 3), dtype=np.float64)
         mol_index = 0
-        for cluster_name in chemical_system._clusters:
-            for cluster in chemical_system._clusters[cluster_name]:
+        for cluster_name in self.temp_clusters:
+            for cluster in self.temp_clusters[cluster_name]:
                 if not set(cluster).issubset(self.selected_indices):
                     continue
                 masses = [


### PR DESCRIPTION
**Description of work**
To partially address issue #1098 code of CenterOfMassesTrajectory is adjusted to accept and convert incompletely selected molecules, if the only atoms missing from the selection are dummy atoms. This is based on the assumption that dummy atoms should not affect the centre of mass of a molecule, and so it is safe to ignore them.

The dummy atoms are still included in the name of the output particle, not to implicitly rename molecules.

**Fixes**
1. Use only non-dummy atom indices in the COMT analysis.

**To test**
Load DL_POLY water trajectory with dummy atoms and run CentreOfMassesTrajectory. All the molecules should be replaced by artificial atoms.
