### PR TITLE
Do not allow spaces in atom and property names

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/ElementsDatabaseEditor.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/ElementsDatabaseEditor.py
@@ -41,7 +41,11 @@ from MDANSE.Chemistry import ATOMS_DATABASE
 from MDANSE.Chemistry.Databases import AtomsDatabaseError
 from MDANSE.MLogging import LOG
 from MDANSE_GUI.Tabs.Views.Delegates import ColourPicker
-from MDANSE_GUI.Widgets.GeneralWidgets import InputDialog, InputVariable
+from MDANSE_GUI.Widgets.GeneralWidgets import (
+    InputDialog,
+    InputVariable,
+    WhitespaceValidator,
+)
 
 
 class ComplexValidator(QValidator):
@@ -322,6 +326,8 @@ class NewElementDialog(QDialog):
 
         layout = QVBoxLayout(self)
         edit = QLineEdit(self)
+        self.validator = WhitespaceValidator(self, default_name="NewAtom")
+        edit.setValidator(self.validator)
         layout.addWidget(edit)
         self.setLayout(layout)
         self.textedit = edit
@@ -424,7 +430,8 @@ class ElementModel(QStandardItemModel):
                     "format": str,
                     "label": "New element name",
                     "tooltip": "Type the name of the new chemical element here.",
-                    "value": "",
+                    "value": "NewAtom",
+                    "default_text": "NewAtom",
                 }
             )
         ]
@@ -447,7 +454,8 @@ class ElementModel(QStandardItemModel):
                     "format": str,
                     "label": "New property name",
                     "tooltip": "Type the name of the new property here; it will be added to the table.",
-                    "value": "",
+                    "value": "NewProperty",
+                    "default_text": "NewProperty",
                 },
             ),
             InputVariable(
@@ -488,7 +496,8 @@ class ElementModel(QStandardItemModel):
                     "format": str,
                     "label": f'Rename custom atom "{self.parent().viewer.mouse_atm}" to',
                     "tooltip": "Type the new name of the chemical element here.",
-                    "value": "",
+                    "value": f"{self.parent().viewer.mouse_atm}",
+                    "default_text": "NewAtom",
                 },
             ),
         ]
@@ -536,7 +545,8 @@ class ElementModel(QStandardItemModel):
                     "format": str,
                     "label": f'Rename custom property "{self.parent().viewer.mouse_prop}" to',
                     "tooltip": "Type the new name of the atom property here.",
-                    "value": "",
+                    "value": f"{self.parent().viewer.mouse_prop}",
+                    "default_text": "NewProperty",
                 },
             ),
         ]
@@ -613,13 +623,13 @@ class ElementModel(QStandardItemModel):
 
         for _, idx in row_idxs:
             atm_sym = self.verticalHeaderItem(idx).text()
-            atm_sym_copy = atm_sym + " (copy)"
+            atm_sym_copy = atm_sym + "(copy)"
             while True:
                 if atm_sym_copy not in self.database.atoms:
                     self.database.add_atom(atm_sym_copy)
                     self.copy_row_in_database(atm_sym_copy, atm_sym)
                     break
-                atm_sym_copy += " (copy)"
+                atm_sym_copy += "(copy)"
         self.save_changes()
 
     @Slot(dict)
@@ -737,7 +747,7 @@ class ElementModel(QStandardItemModel):
         col_idx.sort()
         for idx in col_idx:
             prop_label = self.horizontalHeaderItem(idx).text()
-            prop_label_copy = prop_label + " (copy)"
+            prop_label_copy = prop_label + "(copy)"
             prop_type = self.database._properties[prop_label]
             prop_unit = self.database._units[prop_label]
             while True:
@@ -746,7 +756,7 @@ class ElementModel(QStandardItemModel):
                         prop_label_copy, prop_label, prop_type, prop_unit
                     )
                     break
-                prop_label_copy += " (copy)"
+                prop_label_copy += "(copy)"
         self.save_changes()
 
     @Slot()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Widgets/GeneralWidgets.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Widgets/GeneralWidgets.py
@@ -25,6 +25,7 @@ from qtpy.QtGui import (
     QDoubleValidator,
     QIntValidator,
     QPalette,
+    QValidator,
 )
 from qtpy.QtWidgets import (
     QCheckBox,
@@ -58,6 +59,29 @@ from MDANSE.MLogging import LOG
 # 4. The information gathered is shown to the user,
 # with a possibility of correcting the entries.
 # 5. The corrected parameters are passed to the converter, and the job is started.
+
+
+class WhitespaceValidator(QValidator):
+    """Does not allow empty or whitespace names."""
+
+    EXCLUDED_CHARACTERS = [" ", "\n", "\t", "\\"]
+
+    def __init__(self, *args, default_name: str = "DEFAULT", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.default_name = default_name
+
+    def validate(self, input_string: str, position: int):
+        state = (
+            QValidator.State.Invalid
+            if not input_string
+            or any(char in input_string for char in self.EXCLUDED_CHARACTERS)
+            else QValidator.State.Acceptable
+        )
+        return state, input_string, position
+
+    def fixup(self, invalid_string: str):
+        invalid_string = self.default_name
+        return super().fixup(invalid_string)
 
 
 class GeneralInput(QObject):
@@ -641,6 +665,10 @@ class InputDialog(QDialog):
                     validator = QIntValidator(temp_base)
                 elif format is float:
                     validator = QDoubleValidator(temp_base)
+                elif hasattr(var, "default_text"):
+                    validator = WhitespaceValidator(
+                        temp_base, default_name=var.default_text
+                    )
                 else:
                     validator = None
                 widget_instance.setText(str(value))


### PR DESCRIPTION
**Description of work**
The atom property editor will not allow the users to input an atom name or atom property containing spaces.

closes #1100

While the original issue was dealing with problems caused by names beginning or ending with a whitespace, this PR proposed to remove whitespaces from names altogether, which has been the convention for all the names in the atom database anyway.

Note: the changes here prevent the user from adding invalid entries through the GUI, and did nothing to prevent it from being done using a script.

**Fixes**
1. Added a new input validator to `GeneralWidgets`.
2. Introduced default names without spaces for new atoms and new properties.

**To test**
Try to add/copy/rename atoms and properties using the GUI editor. It should not be possible to use an empty string or a string containing spaces.
