### PR TITLE
Always create plot legend, even if not visible

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Grid.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Grid.py
@@ -20,6 +20,8 @@ import math
 from itertools import islice
 from typing import TYPE_CHECKING, Any
 
+from matplotlib import rcParams
+
 from MDANSE.MLogging import LOG
 from MDANSE_GUI.Tabs.Plotters.Plotter import Plotter
 
@@ -39,6 +41,7 @@ class Grid(Plotter):
         self._active_curves = []
         self._backup_curves = []
         self._plot_limit = 8
+        self._title_length_limit = 30
 
     def slider_labels(self) -> list[str]:
         """Return labels to show that sliders are not used."""
@@ -84,6 +87,25 @@ class Grid(Plotter):
             self._toolbar.update()
             self._toolbar.push_current()
 
+    def title_fontsize(self, title_text: str) -> int:
+        normal_size = rcParams["font.size"]
+        new_size = (
+            normal_size
+            if len(title_text) < self._title_length_limit
+            else normal_size - round(len(title_text) / self._title_length_limit)
+        )
+        return new_size
+
+    def toggle_legend(self, enabled: bool) -> None:
+        if self._figure is None:
+            return
+        for plot_index, axes in enumerate(self._axes):
+            axes.set_title(
+                self._axes_titles[plot_index] if enabled else "",
+                fontsize=self.title_fontsize(self._axes_titles[plot_index]),
+            )
+        self._figure.canvas.draw()
+
     def plot(
         self,
         plotting_context: PlottingContext,
@@ -116,6 +138,7 @@ class Grid(Plotter):
             return
         self._figure = target
         self._axes = []
+        self._axes_titles = []
         self._backup_curves = []
         self._active_curves = []
         self._normalisation_errors = []
@@ -169,8 +192,13 @@ class Grid(Plotter):
                     with contextlib.suppress(Exception):
                         temp_curve.set_marker(int(databundle.marker))
                 axes.set_xlabel(x_axis_label)
-                if plotting_context.use_legend:
-                    axes.legend()
+                self._axes_titles.append(plotlabel)
+                axes.set_title(
+                    plotlabel if plotting_context.use_legend else "",
+                    fontsize=self.title_fontsize(plotlabel),
+                )
+                legend = axes.legend()
+                legend.set_visible(False)
                 axes.grid(plotting_context.use_grid)
                 startnum += 1
                 self._active_curves.append(temp_curve)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Heatmap.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Heatmap.py
@@ -349,8 +349,8 @@ class Heatmap(Plotter):
             axes.set_ylabel(", ".join(np.unique(y_axis_labels)))
             self._backup_images[databundle.row] = image
         if startnum > 1:
-            if plotting_context.use_legend:
-                axes.legend()
+            legend = axes.legend()
+            legend.set_visible(plotting_context.use_legend)
             axes.grid(plotting_context.use_grid)
         self.check_curve_lengths()
         self.request_slider_values()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Single.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Single.py
@@ -266,8 +266,8 @@ class Single(Plotter):
             xlimits, ylimits = axes.get_xlim(), axes.get_ylim()
             self._backup_limits = [xlimits[0], xlimits[1], ylimits[0], ylimits[1]]
         axes.set_xlabel(", ".join(np.unique(x_axis_labels)))
-        if plotting_context.use_legend:
-            axes.legend()
+        legend = axes.legend()
+        legend.set_visible(plotting_context.use_legend)
         axes.grid(plotting_context.use_grid)
         self.check_curve_lengths()
         self.offset_curves()


### PR DESCRIPTION
**Description of work**
Makes sure that legend is always created, so that toggling the legend checkbox always works.

Also, for `Grid` plots this PR replaces legend with subplot title, which should be valid since `Grid` always shows a single curve per plot. You are welcome to comment if this is meaningful or not.

<img width="1210" height="251" alt="Screenshot 2026-01-21 at 16 44 33" src="https://github.com/user-attachments/assets/737a329b-7221-4ebe-81ab-cc181eb7a25b" />

closes #1092

**Fixes**
1. Every plotter creates a legend, which can then be set to visible or not.
2. `Grid` plotter puts the single legend entry into the subplot title instead.

**To test**
Try toggling the legend on and off and change plotters in different order. Check if any errors are triggered.
