### PR TITLE
Use Frames settings to set time steps for TrajectoryFilter

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
@@ -40,6 +40,7 @@ class TrajectoryFilterConfigurator(IConfigurator):
     _default_filter = DEFAULT_FILTER
 
     _settings = filter_default_attributes()
+    time_axis = {"n_steps": 10, "time_step_ps": 0.001}
 
     @classmethod
     def get_default(cls) -> str:
@@ -68,6 +69,10 @@ class TrajectoryFilterConfigurator(IConfigurator):
             return
 
         self._settings = value
+        self.time_axis = {
+            "n_steps": self.configurable[self.dependencies["frames"]]["n_frames"],
+            "time_step_ps": self.configurable[self.dependencies["frames"]]["time_step"],
+        }
 
         try:
             dict_value = json.loads(value)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -71,7 +71,7 @@ class TrajectoryFilter(IJob):
     )
     settings["trajectory_filter"] = (
         "TrajectoryFilterConfigurator",
-        {"dependencies": {"trajectory": "trajectory"}},
+        {"dependencies": {"trajectory": "trajectory", "frames": "frames"}},
     )
     settings["atom_selection"] = (
         "AtomSelectionConfigurator",
@@ -117,6 +117,9 @@ class TrajectoryFilter(IJob):
         self.atomic_trajectory_array = np.zeros(
             (len(self._selected_atoms), 3, len(self.configuration["frames"]["value"]))
         )
+
+        self.n_time_steps = self.configuration["frames"]["n_steps"]
+        self.time_step_ps = self.configuration["frames"]["time_step"]
 
     def run_step(self, index):
         """Run the filter for a single atom.
@@ -169,14 +172,9 @@ class TrajectoryFilter(IJob):
             filter_config["attributes"],
         )
 
-        filter_attributes.setdefault(
-            "n_steps", self.configuration["trajectory"]["length"]
-        )
-        filter_attributes.setdefault(
-            "time_step_ps", self.configuration["trajectory"]["md_time_step"]
-        )
+        time_axis = {"n_steps": self.n_time_steps, "time_step_ps": self.time_step_ps}
 
-        filter = filter_class(**filter_attributes)
+        filter = filter_class(**filter_attributes, **time_axis)
 
         trajectories = copy.deepcopy(self.atomic_trajectory_array)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -118,7 +118,7 @@ class TrajectoryFilter(IJob):
             (len(self._selected_atoms), 3, len(self.configuration["frames"]["value"]))
         )
 
-        self.n_time_steps = self.configuration["frames"]["n_steps"]
+        self.n_time_steps = self.configuration["frames"]["number"]
         self.time_step_ps = self.configuration["frames"]["time_step"]
 
     def run_step(self, index):
@@ -199,7 +199,7 @@ class TrajectoryFilter(IJob):
         self._output_trajectory = TrajectoryWriter(
             self.configuration["output_files"]["file"],
             output_chemical_system,
-            filter_attributes["n_steps"],
+            time_axis["n_steps"],
             None,
             positions_dtype=self.configuration["output_files"]["dtype"],
             compression=self.configuration["output_files"]["compression"],
@@ -208,7 +208,7 @@ class TrajectoryFilter(IJob):
         # Write trajectory
         write_filtered_trajectory(
             parent_configuration=self.configuration,
-            nsteps=filter_attributes["n_steps"],
+            nsteps=time_axis["n_steps"],
             filtered_coordinates=filtered_coords,
             output_trajectory=self._output_trajectory,
         )

--- a/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
+++ b/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
@@ -243,8 +243,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Butterworth",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "order": 1,
                 "attenuation_type": "lowpass",
                 "cutoff_freq": 19.635,
@@ -257,8 +255,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Butterworth",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "order": 1,
                 "attenuation_type": "highpass",
                 "cutoff_freq": 31.416,
@@ -271,8 +267,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "ChebyshevTypeII",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "order": 1,
                 "min_attenuation": 12.7,
                 "attenuation_type": "bandpass",
@@ -286,8 +280,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Bessel",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "order": 1,
                 "norm": "phase",
                 "attenuation_type": "bandstop",
@@ -301,8 +293,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "ChebyshevTypeII",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "order": 2,
                 "min_attenuation": 20.0,
                 "attenuation_type": "bandpass",
@@ -316,8 +306,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "ChebyshevTypeII",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "order": 2,
                 "min_attenuation": 2.0,
                 "attenuation_type": "bandpass",
@@ -331,8 +319,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Notch",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "fundamental_freq": 6.875,
                 "quality_factor": 1.6,
             },
@@ -344,8 +330,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Peak",
             "attributes": {
-                "n_steps": 1000,
-                "time_step_ps": 0.01,
                 "fundamental_freq": 5.7,
                 "quality_factor": 1.5,
             },
@@ -357,8 +341,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Comb",
             "attributes": {
-                "n_steps": 1000,
-                "time_step_ps": 0.01,
                 "fundamental_freq": 5.0,
                 "quality_factor": 30.0,
                 "comb_type": "notch",
@@ -372,8 +354,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "ChebyshevTypeII",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "order": 1,
                 "min_attenuation": 10.0,
                 "attenuation_type": "bandstop",
@@ -387,8 +367,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Elliptical",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "order": 2,
                 "max_ripple": 1.0,
                 "min_attenuation": 20.0,
@@ -403,8 +381,6 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "ChebyshevTypeI",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "order": 1,
                 "max_ripple": 5.0,
                 "attenuation_type": "bandstop",
@@ -472,8 +448,11 @@ def test_convolution(
     # Retrieve filter configuration dict
     filter_class = FILTER_MAP[filter_config["filter"]]
 
+    trajectory_instance = Trajectory(CONV_DIR / trajectory_name)
+    time_axis = trajectory_instance.time()
+    time_step = time_axis[1] - time_axis[0]
     # Instantiate filter object
-    filter_object = filter_class(**filter_config["attributes"])
+    filter_object = filter_class(**filter_config["attributes"], n_steps = frames[1], time_step_ps=time_step)
 
     # Supply frequencies against which to calculate response H(w)
     filter_object.custom_freq_range = u_x_axis
@@ -533,8 +512,6 @@ def test_convolution(
             "frames": [0, 25, 1, 13],
             "filter": "Butterworth",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "cutoff_freq": 0.000377,
             },
         },
@@ -543,8 +520,6 @@ def test_convolution(
             "frames": [0, 25, 1, 13],
             "filter": "ChebyshevTypeI",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "cutoff_freq": 0.000377,
             },
         },
@@ -553,8 +528,6 @@ def test_convolution(
             "frames": [0, 25, 1, 13],
             "filter": "ChebyshevTypeII",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "cutoff_freq": 0.000377,
                 "min_attenuation": 10.0,
             },
@@ -564,8 +537,6 @@ def test_convolution(
             "frames": [0, 25, 1, 13],
             "filter": "Elliptical",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "attenuation_type": "bandpass",
                 "cutoff_freq": [0.000377, 0.000577],
             },
@@ -575,8 +546,6 @@ def test_convolution(
             "frames": [0, 25, 1, 13],
             "filter": "Bessel",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "attenuation_type": "bandpass",
                 "cutoff_freq": [0.000377, 0.000577],
             },
@@ -586,8 +555,6 @@ def test_convolution(
             "frames": [0, 25, 1, 13],
             "filter": "Notch",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "fundamental_freq": 0.000125,
             },
         },
@@ -596,8 +563,6 @@ def test_convolution(
             "frames": [0, 25, 1, 13],
             "filter": "Peak",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "fundamental_freq": 0.000125,
             },
         },
@@ -606,8 +571,6 @@ def test_convolution(
             "frames": [0, 25, 1, 13],
             "filter": "Comb",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "fundamental_freq": 6.25e-05,
                 "comb_type": "notch",
             },
@@ -617,8 +580,6 @@ def test_convolution(
             "frames": [0, 25, 1, 13],
             "filter": "Comb",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "fundamental_freq": 6.25e-05,
             },
         },
@@ -651,8 +612,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Butterworth",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "order": 1,
                 "attenuation_type": "highpass",
                 "cutoff_freq": 19.635,
@@ -665,8 +624,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Butterworth",
             "attributes": {
-                "n_steps": 160,
-                "time_step_ps": 0.005,
                 "order": 1,
                 "attenuation_type": "highpass",
                 "cutoff_freq": 19.635,
@@ -679,8 +636,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Butterworth",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "order": 2,
                 "attenuation_type": "bandpass",
                 "cutoff_freq": [19.635, 31.416],
@@ -693,8 +648,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "ChebyshevTypeII",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "order": 1,
                 "min_attenuation": 12.7,
                 "attenuation_type": "highpass",
@@ -708,8 +661,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Comb",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "fundamental_freq": 10.0,
                 "quality_factor": 2.0,
             },
@@ -721,8 +672,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Comb",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "fundamental_freq": 10.0,
                 "quality_factor": 20.0,
                 "comb_type": "peak",
@@ -735,8 +684,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Comb",
             "attributes": {
-                "n_steps": 320,
-                "time_step_ps": 0.005,
                 "fundamental_freq": 10.0,
                 "quality_factor": 20.0,
                 "comb_type": "peak",
@@ -750,8 +697,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Peak",
             "attributes": {
-                "n_steps": 1000,
-                "time_step_ps": 0.01,
                 "fundamental_freq": 5.7,
                 "quality_factor": 1.5,
             },
@@ -763,8 +708,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Comb",
             "attributes": {
-                "n_steps": 1000,
-                "time_step_ps": 0.01,
                 "fundamental_freq": 5.0,
                 "quality_factor": 30.0,
                 "comb_type": "notch",
@@ -778,8 +721,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "ChebyshevTypeII",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "order": 4,
                 "min_attenuation": 10.0,
                 "attenuation_type": "highpass",
@@ -793,8 +734,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "ChebyshevTypeII",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "order": 2,
                 "min_attenuation": 0.1,
                 "attenuation_type": "lowpass",
@@ -808,8 +747,6 @@ def test_default_settings(
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "ChebyshevTypeI",
             "attributes": {
-                "n_steps": 25,
-                "time_step_ps": 4000.0,
                 "order": 1,
                 "max_ripple": 0.4,
                 "attenuation_type": "bandpass",

--- a/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
+++ b/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
@@ -661,6 +661,20 @@ def test_default_settings(
         {
             "trajectory": SRTIO3_TRAJ,
             "max_frequency": (626, 0),
+            "frames": [0, 320, 2, 80],
+            "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
+            "filter": "Butterworth",
+            "attributes": {
+                "n_steps": 160,
+                "time_step_ps": 0.005,
+                "order": 1,
+                "attenuation_type": "highpass",
+                "cutoff_freq": 19.635,
+            },
+        },
+        {
+            "trajectory": SRTIO3_TRAJ,
+            "max_frequency": (626, 0),
             "frames": [0, 320, 1, 160],
             "atom_selection": '{"0": {"function_name": "select_all", "operation_type": "union"}, "1": {"function_name": "select_atoms", "index_range": [0, 6], "operation_type": "intersection"}}',
             "filter": "Butterworth",

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -116,7 +116,15 @@ class ConstrainedDoubleSpinBox(QDoubleSpinBox):
 
     """
 
-    def __init__(self, minimum: float, maximum: float, step: float, value: float):
+    def __init__(
+        self,
+        minimum: float,
+        maximum: float,
+        step: float,
+        value: float,
+        *,
+        use_snap: bool = True,
+    ):
         """
         Parameters
         ----------
@@ -140,6 +148,7 @@ class ConstrainedDoubleSpinBox(QDoubleSpinBox):
         self.setMaximum(maximum)
         self.setSingleStep(step)
         self.setValue(value)
+        self.use_snap = use_snap
 
     def reset_connections(self):
         """Reset all connections to custom slots."""
@@ -260,6 +269,19 @@ class ConstrainedDoubleSpinBox(QDoubleSpinBox):
 
         # Update with constrained value
         self.setValue(x)
+
+    @Slot(object)
+    def update_step_and_limits(self, step_vmax: tuple[float, float, float]):
+        current_value = self.value()
+        bin_width, vmax, time_step = step_vmax
+        self.setMinimum(bin_width)
+        self.setMaximum(vmax)
+        self.setSingleStep(bin_width)
+        if self.use_snap:
+            self.set_snap(snap_to=bin_width)
+        else:
+            self.set_search(constraint_func=lambda x: ((1 / time_step) % x) == 0)
+        self.setValue(current_value)
 
     @staticmethod
     def to_float(value: Any) -> float:
@@ -474,7 +496,7 @@ class FilterSettingGroup(QObject):
     # Signal: emitted when a setting has changed
     _setting_changed = Signal()
 
-    new_bin_width = Signal(float)
+    new_bin_width_vmax_tstep = Signal(object)
 
     def __init__(
         self,
@@ -549,7 +571,11 @@ class FilterSettingGroup(QObject):
             Filter.frequency_resolution(new_values[0], new_values[1], units=self.units),
             FLOAT_SPINBOX_DECIMALS,
         )
-        self.new_bin_width.emit(bin_width)
+        vmax = np.round(
+            Filter.nyquist(new_values[1], units=self.units) - bin_width,
+            FLOAT_SPINBOX_DECIMALS,
+        )
+        self.new_bin_width_vmax_tstep.emit((bin_width, vmax, new_values[1]))
 
     def load_from_schema(self) -> None:
         """Load the attributes from the filter setting schema."""
@@ -708,6 +734,7 @@ class FilterSettingGroup(QObject):
                         maximum=vmax,
                         step=bin_width,
                         value=bin_width,
+                        use_snap=False,
                     )
                     widget.set_search(
                         constraint_func=lambda x: ((1 / time_step) % x) == 0
@@ -720,7 +747,7 @@ class FilterSettingGroup(QObject):
                         value=bin_width,
                     )
                     widget.set_snap(snap_to=bin_width)
-                self.new_bin_width.connect(widget.setSingleStep)
+                self.new_bin_width_vmax_tstep.connect(widget.update_step_and_limits)
             else:
                 # Other data spinbox
                 widget = QDoubleSpinBox()
@@ -931,6 +958,7 @@ class BoundedFilterSettingsGroup(FilterSettingGroup):
         widget.set_snap(snap_to=step)
         widget.setEnabled(False)
         widget.valueChanged.connect(self.notify)
+        self.new_bin_width_vmax_tstep.connect(widget.update_step_and_limits)
         self.store_widget("bound_freq", widget)
         grid.addWidget(widget, grid_pos[1][0] + 1, grid_pos[1][1])
 
@@ -1639,6 +1667,7 @@ class TrajectoryFilterWidget(WidgetBase):
             self.filter_designer.close()
         else:
             self.filter_designer.update_pps()
+            self.update_time_axis()
             self.filter_designer.show()
 
     @Slot()

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -544,11 +544,11 @@ class FilterSettingGroup(QObject):
     @Slot(object)
     def accept_time_axis(self, new_values: tuple[int, float]):
         self.time_axis["n_steps"] = new_values[0]
-        self.time_axis["time_step_ps"] = new_values[1]               
+        self.time_axis["time_step_ps"] = new_values[1]
         bin_width = np.round(
-                    Filter.frequency_resolution(new_values[0], new_values[1], units=self.units),
-                    FLOAT_SPINBOX_DECIMALS,
-                )
+            Filter.frequency_resolution(new_values[0], new_values[1], units=self.units),
+            FLOAT_SPINBOX_DECIMALS,
+        )
         self.new_bin_width.emit(bin_width)
 
     def load_from_schema(self) -> None:

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -474,9 +474,12 @@ class FilterSettingGroup(QObject):
     # Signal: emitted when a setting has changed
     _setting_changed = Signal()
 
+    new_bin_width = Signal(float)
+
     def __init__(
         self,
         parent_attributes: dict,
+        time_axis: dict,
         schema: dict,
         render_func: Callable,
         flags: set = frozenset(),
@@ -521,11 +524,10 @@ class FilterSettingGroup(QObject):
         # Schema for the filter settings
         self.schema = schema
         self.load_from_schema()
+        self.time_axis = time_axis
 
         freq_key = [key for key in self.schema if key.endswith("_freq")]
-        initial_value = 1 / (
-            self.parent_attributes["time_step_ps"] * self.parent_attributes["n_steps"]
-        )
+        initial_value = 1 / (time_axis["n_steps"] * time_axis["time_step_ps"])
         if self.units is Filter.FrequencyUnits.ANGULAR:
             initial_value *= Filter._cyclic_to_angular
         self.attributes.update({freq_key.pop(): initial_value})
@@ -538,6 +540,16 @@ class FilterSettingGroup(QObject):
 
         # Connection: when the settings have been updated, re-render the filter designer
         self._settings_updated.connect(render_func)
+
+    @Slot(object)
+    def accept_time_axis(self, new_values: tuple[int, float]):
+        self.time_axis["n_steps"] = new_values[0]
+        self.time_axis["time_step_ps"] = new_values[1]               
+        bin_width = np.round(
+                    Filter.frequency_resolution(new_values[0], new_values[1], units=self.units),
+                    FLOAT_SPINBOX_DECIMALS,
+                )
+        self.new_bin_width.emit(bin_width)
 
     def load_from_schema(self) -> None:
         """Load the attributes from the filter setting schema."""
@@ -676,10 +688,8 @@ class FilterSettingGroup(QObject):
         if isinstance(setting, float):
             if setting_key in {"cutoff_freq", "fundamental_freq"}:
                 # Filter frequency spinbox with constrained values
-                n_steps = self.parent_attributes.get("n_steps", DEFAULT_N_STEPS)
-                time_step = self.parent_attributes.get(
-                    "time_step_ps", DEFAULT_TIME_STEP
-                )
+                n_steps = self.time_axis.get("n_steps", DEFAULT_N_STEPS)
+                time_step = self.time_axis.get("time_step_ps", DEFAULT_TIME_STEP)
 
                 bin_width = np.round(
                     Filter.frequency_resolution(n_steps, time_step, units=self.units),
@@ -710,6 +720,7 @@ class FilterSettingGroup(QObject):
                         value=bin_width,
                     )
                     widget.set_snap(snap_to=bin_width)
+                self.new_bin_width.connect(widget.setSingleStep)
             else:
                 # Other data spinbox
                 widget = QDoubleSpinBox()
@@ -784,6 +795,7 @@ class BoundedFilterSettingsGroup(FilterSettingGroup):
     def __init__(
         self,
         parent_attributes: dict,
+        time_axis: dict,
         schema: dict,
         render_func: Callable,
         flags: set = frozenset(),
@@ -802,7 +814,7 @@ class BoundedFilterSettingsGroup(FilterSettingGroup):
             Set of flags associated with the current filter that can be used to invoke certain rules about settings.
 
         """
-        super().__init__(parent_attributes, schema, render_func, flags)
+        super().__init__(parent_attributes, time_axis, schema, render_func, flags)
 
         # Generate an extra index for the frequency bound widget in the grid layout
         last_index = self.indices[-1]
@@ -944,6 +956,7 @@ class FilterDesigner(QDialog):
     _helper_title = "Filter designer"
     _canvas_dimensions = {"width": 700, "height": 500}
     _trajectory_power_spectrum = None
+    new_time_axis = Signal(object)
 
     def __init__(
         self,
@@ -957,6 +970,8 @@ class FilterDesigner(QDialog):
         self.setWindowTitle(self._helper_title)
         self.field = field
         self.configurator = configurator
+        self.n_steps = 10
+        self.time_step_ps = 0.001
 
         self.graph_ready = False
 
@@ -974,6 +989,11 @@ class FilterDesigner(QDialog):
         self.set_filter(self.configurator._default_filter.__name__)
         self.create_designer()
         self.preferences_group.pps_checkbox.checkStateChanged.connect(self.update_pps)
+
+    def update_time_axis(self, n_steps: int = 10, time_step_ps: float = 0.001):
+        self.n_steps = n_steps
+        self.time_step_ps = time_step_ps
+        self.new_time_axis.emit((n_steps, time_step_ps))
 
     def find_configuration(self) -> dict[str, str]:
         """Find the configuration of the main filter job.
@@ -1015,16 +1035,7 @@ class FilterDesigner(QDialog):
         """
         self.settings = {
             "filter": filter_type,
-            "attributes": {
-                # Number of simulation steps
-                "n_steps": self.configurator.configurable.settings["trajectory"][1][
-                    "configurator"
-                ]["length"],
-                # Simulation time step in picoseconds
-                "time_step_ps": self.configurator.configurable.settings["trajectory"][
-                    1
-                ]["configurator"]["md_time_step"],
-            },
+            "attributes": {},
         }
 
     def create_designer(self) -> None:
@@ -1236,10 +1247,12 @@ class FilterDesigner(QDialog):
             )
             group_obj = template(
                 parent_attributes=copy.deepcopy(self.settings["attributes"]),
+                time_axis={"n_steps": self.n_steps, "time_step_ps": self.time_step_ps},
                 schema=filter_class.default_settings,
                 render_func=self.render_canvas_assets,
                 flags=filter_class.flags,
             )
+            self.new_time_axis.connect(group_obj.accept_time_axis)
             self.settings_group[name] = group_obj
             widget = QWidget()
             layout = self.settings_group[name].as_grid()
@@ -1422,7 +1435,11 @@ class FilterDesigner(QDialog):
 
         # Preview instantiation of the selected filter
         filter_class = FILTER_MAP[self.settings["filter"]]
-        filter_preview = filter_class(**self.settings["attributes"])
+        filter_preview = filter_class(
+            n_steps=self.n_steps,
+            time_step_ps=self.time_step_ps,
+            **self.settings["attributes"],
+        )
 
         # Check if we are displaying trajectory power spectral attenuation alongside filter response
         ps, attenuated_ps = None, None
@@ -1539,8 +1556,6 @@ class FilterDesigner(QDialog):
 
     def apply(self) -> None:
         """Pass the filter parameters to the main widget."""
-        self.configurator.configure(self.settings)
-
         filter_class = FILTER_MAP[self.settings["filter"]]
 
         # update widget field text to reflect filter designer
@@ -1596,6 +1611,16 @@ class TrajectoryFilterWidget(WidgetBase):
         self.update_labels()
         self.updateValue()
         self._field.setToolTip(self._tooltip_text)
+        for widget in self.parent()._widgets:
+            if (
+                widget._configurator
+                is self._configurator.configurable[
+                    self._configurator.dependencies["frames"]
+                ]
+            ):
+                self._frame_widget = widget
+                break
+        self._frame_widget.value_changed.connect(self.update_time_axis)
 
     def create_helper(self) -> FilterDesigner:
         """
@@ -1615,6 +1640,15 @@ class TrajectoryFilterWidget(WidgetBase):
         else:
             self.filter_designer.update_pps()
             self.filter_designer.show()
+
+    @Slot()
+    def update_time_axis(self):
+        n_steps = self._frame_widget._configurator["n_frames"]
+        time_step_ps = self._frame_widget._configurator["time_step"]
+        self.filter_designer.update_time_axis(
+            n_steps=n_steps, time_step_ps=time_step_ps
+        )
+        self.filter_designer.render_canvas_assets()
 
     def get_widget_value(self) -> str:
         """


### PR DESCRIPTION
**Description of work**
At the moment, the `TrajectoryFilter` uses the total number of trajectory frames as input. This causes conflicts with the actual inputs if the user has changed the parameters in `Frames`.

closes #1086

**Fixes**
1. `TrajectoryFilter` takes time step information directly from `Frames` and not from the trajectory.
2. The spinbox widgets update their step settings when frame parameters are changed.
3. `n_steps` and `time_step_ps` are not included as filter parameters.

**To test**
1. Confirm that the output of `TrajectoryFilter` is still the same for the default input parameters.
2. Try running the filter with "in steps of" larger than 1. Compare atom positions at specific timesteps to those of the trajectory with "in steps of"=1.
