### PR TITLE
Add optional formatting of trajectory info

### DIFF
--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -61,7 +61,8 @@ class GroupingLevels(UCEnum):
         return self.name.title()
 
 
-def trajectory_summary(traj: Trajectory):
+def trajectory_summary(traj: Trajectory, use_html: bool = False):
+    head = []
     val = []
     try:
         time_axis = traj.time()
@@ -73,8 +74,12 @@ def trajectory_summary(traj: Trajectory):
         else:
             timeline = f"[{summarise_array(time_axis, maxlen=5)}]\n"
 
-    val.append("Path:")
-    val.append(f"{traj.filename}\n")
+    filename = html.escape(f"{traj.filename}")
+    if use_html:
+        head.append(f"Path: <pre>{filename}</pre>")
+    else:
+        head.append("Path:")
+        head.append(f"{filename}\n")
     val.append("Number of steps:")
     val.append(f"{len(traj)}\n")
     val.append("Configuration:")
@@ -106,9 +111,12 @@ def trajectory_summary(traj: Trajectory):
     for molname, mollist in traj.chemical_system._clusters.items():
         val.append(f"Molecule: {molname}; Count: {len(mollist)}")
 
+    head = "\n".join(head)
     val = "\n".join(val)
+    if use_html:
+        val = html.escape(val)
 
-    return html.escape(val)
+    return head + "\n" + val
 
 
 def chemical_system_summary(cs: ChemicalSystem) -> str:

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -61,7 +61,25 @@ class GroupingLevels(UCEnum):
         return self.name.title()
 
 
-def trajectory_summary(traj: Trajectory, use_html: bool = False):
+def trajectory_summary(traj: Trajectory, *, use_html: bool = False) -> str:
+    """Return information about the input trajectory as formatted text.
+
+    This function is used both in the CLI and in the GUI. For GUI use
+    use_html should be True to include tags that work with the HTML-enabled
+    text widget.
+
+    Parameters
+    ----------
+    traj : Trajectory
+        Trajectory object from which information will be extracted.
+    use_html : bool, optional
+        Set to True if the output will be shown in the GUI, by default False.
+
+    Returns
+    -------
+    str
+        A multi-line text string summarising the trajectory contents.
+    """
     head = []
     val = []
     try:

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -94,10 +94,9 @@ def trajectory_summary(traj: Trajectory, *, use_html: bool = False) -> str:
 
     filename = html.escape(f"{traj.filename}")
     if use_html:
-        head.append(f"Path: <pre>{filename}</pre>")
+        head = f"Path: <pre>{filename}</pre>"
     else:
-        head.append("Path:")
-        head.append(f"{filename}\n")
+        head = "Path:\n{filename}\n"
     val.append("Number of steps:")
     val.append(f"{len(traj)}\n")
     val.append("Configuration:")

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -96,7 +96,7 @@ def trajectory_summary(traj: Trajectory, *, use_html: bool = False) -> str:
     if use_html:
         head = f"Path: <pre>{filename}</pre>"
     else:
-        head = "Path:\n{filename}\n"
+        head = f"Path:\n{filename}\n"
     val.append("Number of steps:")
     val.append(f"{len(traj)}\n")
     val.append("Configuration:")
@@ -128,7 +128,6 @@ def trajectory_summary(traj: Trajectory, *, use_html: bool = False) -> str:
     for molname, mollist in traj.chemical_system._clusters.items():
         val.append(f"Molecule: {molname}; Count: {len(mollist)}")
 
-    head = "\n".join(head)
     val = "\n".join(val)
     if use_html:
         val = html.escape(val)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/TrajectoryTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/TrajectoryTab.py
@@ -15,7 +15,6 @@
 #
 from __future__ import annotations
 
-import os
 from functools import partial
 from pathlib import Path
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TrajectoryInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/TrajectoryInfo.py
@@ -33,10 +33,12 @@ class TrajectoryInfo(TextInfo):
     def update_panel(self, data: tuple):
         fullpath, incoming = data
         if incoming is None:
-            self.setHtml(self.filter(fullpath))
+            self.setHtml(self.filter(f"<pre>{fullpath}</pre>"))
             return
         try:
-            text = trajectory_summary(incoming)  # this is from a trajectory object
+            text = trajectory_summary(
+                incoming, use_html=True
+            )  # this is from a trajectory object
         except AttributeError as err:
             LOG.error(
                 "Could not summarise trajectory %s.\n Error: %s.\n Traceback: %s",


### PR DESCRIPTION
**Description of work**
HTML `<pre></pre>` tags have been added to the trajectory name in the GUI.
In the CLI output, `html.escape` is skipped, as it made it difficult to read lines containing single and double quotes. (These were shown e.g. as `&quot;type=h1o_ff&quot` in the terminal output.)

closes #1110

**Fixes**
1. Extra formatting added to `trajectory_summary`

**To test**
Load a trajectory with spaces in the name into the GUI. The spaces should be preserved and shown correctly.
Use `mdanse traj SOME_NAME` in the CLI. Check if the output contains only legible characters.
