### PR TITLE
Check for warnings after changing instrument profiles

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/JobTab.py
@@ -184,6 +184,7 @@ class JobTab(GeneralTab):
             # we only update the widget if a job is selected from the
             # actions tree
             self.action.apply_instrument()
+            self.action.allow_execution()
 
     @Slot(int)
     def update_action_after_instrument_change(self, index: int):


### PR DESCRIPTION
**Description of work**
An additional check is performed after changing to a different instrument profile. The QVectorsWidget will show a warning immediately after the change if one of the generated q-vector shells is empty.

closes #1104

**Fixes**
- call `Action.allow_execution` again after changing the instrument profile.

**To test**
Load a trajectory. Pick an analysis that uses q vector generators (DISF, DCSF). Start changing instrument profiles. If no warning is shown after instrument change, manually change the random seed and check if the warning appears. (We expect the warning either to be there all the time, or not to be there at all. The current main branch fails to show the warning at first, and then keeps showing it after the first change of the random seed, which is not the correct behaviour.)
