### PR TITLE
Show each dataset's scaling factor in plot details table

### DIFF
--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -71,7 +71,7 @@ def trajectory_summary(traj: Trajectory):
         if len(time_axis) < 1:
             timeline = "N/A\n"
         else:
-            timeline = f"[{summarise_array(time_axis, maxlen=5)}]\n"
+            timeline = f"[{summarise_array(time_axis, maxlen=5, arr_fmt='5.4f')}]\n"
 
     val.append("Path:")
     val.append(f"{traj.filename}\n")

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
 NUMBERS_FOR_SLICE = 3
 NUMBERS_FOR_RANGE = 2
+SCALE_FACTOR_ROUNDING = 3
 
 
 class PlotArgs(NamedTuple):
@@ -889,7 +890,9 @@ class PlottingContext(QStandardItemModel):
                 self.next_colour(),
                 new_dataset._linestyle,
                 new_dataset._marker if new_dataset._marker else "None",
-                "",
+                round(new_dataset._scaling_factor, SCALE_FACTOR_ROUNDING)
+                if isinstance(new_dataset._scaling_factor, float)
+                else f"{round(new_dataset._scaling_factor[0], SCALE_FACTOR_ROUNDING)}, ..., {round(new_dataset._scaling_factor[-1], SCALE_FACTOR_ROUNDING)}",
                 new_dataset._filename,
             ]
         ]

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -36,6 +36,7 @@ from more_itertools import nth_product
 from qtpy.QtCore import QModelIndex, Qt, Signal, Slot
 from qtpy.QtGui import QColor, QStandardItem, QStandardItemModel
 
+from MDANSE.IO.IOUtils import summarise_array
 from MDANSE.MLogging import LOG
 
 if TYPE_CHECKING:
@@ -43,7 +44,7 @@ if TYPE_CHECKING:
 
 NUMBERS_FOR_SLICE = 3
 NUMBERS_FOR_RANGE = 2
-SCALE_FACTOR_ROUNDING = 3
+SCALE_FACTOR_FORMAT = "3.3f"
 
 
 class PlotArgs(NamedTuple):
@@ -890,9 +891,11 @@ class PlottingContext(QStandardItemModel):
                 self.next_colour(),
                 new_dataset._linestyle,
                 new_dataset._marker if new_dataset._marker else "None",
-                round(new_dataset._scaling_factor, SCALE_FACTOR_ROUNDING)
+                format(new_dataset._scaling_factor, SCALE_FACTOR_FORMAT)
                 if isinstance(new_dataset._scaling_factor, float)
-                else f"{round(new_dataset._scaling_factor[0], SCALE_FACTOR_ROUNDING)}, ..., {round(new_dataset._scaling_factor[-1], SCALE_FACTOR_ROUNDING)}",
+                else summarise_array(
+                    new_dataset._scaling_factor, show=1, arr_fmt=SCALE_FACTOR_FORMAT
+                ),
                 new_dataset._filename,
             ]
         ]

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -422,7 +422,7 @@ class Action(QWidget):
             for label, old_array, unit in axes:
                 scale_factor, new_unit = self._parent_tab.conversion_factor(unit)
                 array = np.array(old_array) * scale_factor
-                text += f"<p>{label}: [{summarise_array(array)}] ({new_unit})</p>"
+                text += f"<p>{label}: [{summarise_array(array, arr_fmt='5.3f')}] ({new_unit})</p>"
             self._preview_box.setText(text)
 
     @Slot()


### PR DESCRIPTION
**Description of work**
Adds a fixed text to the "Apply weights?" field, showing the scaling factor of the dataset. For an array of scaling factors, it shows a string of `f"{first_value}, ..., {last_value}"`.

closes #1115

**Fixes**
1. Replaced the empty string in `PlottingContext.add_dataset()` with values from `SingleDataset._scaling_factor`.
2. Applied rounding to the values with `SCALE_FACTOR_ROUNDING=3` precision.

**To test**
Create plots of different analysis results. Check if numbers are shown next to the checkbox in the "Apply weights?" field. If the number is `1.0`, checking/unchecking the box should not affect the plot.
Run `XrayStaticStructureFactor` on a trajectory and plot the results. Check if text in "Apply weights?" is showing the first and last elements of a larger array.
