### PR TITLE
Update frames for TrajectoryFilter

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -200,7 +200,7 @@ class TrajectoryFilter(IJob):
         self._output_trajectory = TrajectoryWriter(
             self.configuration["output_files"]["file"],
             output_chemical_system,
-            filtered_coords.shape[2],
+            filter_attributes["n_steps"],
             None,
             positions_dtype=self.configuration["output_files"]["dtype"],
             compression=self.configuration["output_files"]["compression"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -201,7 +201,7 @@ class TrajectoryFilter(IJob):
         self._output_trajectory = TrajectoryWriter(
             self.configuration["output_files"]["file"],
             output_chemical_system,
-            filter_attributes["n_steps"],
+            filtered_coords.shape[2],
             None,
             positions_dtype=self.configuration["output_files"]["dtype"],
             compression=self.configuration["output_files"]["compression"],
@@ -210,7 +210,6 @@ class TrajectoryFilter(IJob):
         # Write trajectory
         write_filtered_trajectory(
             parent_configuration=self.configuration,
-            nsteps=filter_attributes["n_steps"],
             filtered_coordinates=filtered_coords,
             output_trajectory=self._output_trajectory,
         )
@@ -271,7 +270,6 @@ def apply(filter: Filter, trajectories: np.ndarray, apply_offsets: bool) -> np.n
 
 def write_filtered_trajectory(
     parent_configuration: _Configuration,
-    nsteps: int,
     filtered_coordinates: np.ndarray,
     output_trajectory: TrajectoryWriter,
 ) -> None:
@@ -281,14 +279,13 @@ def write_filtered_trajectory(
     ----------
     parent_configuration : _Configuration
         Parent configuration.
-    nsteps : int
-        Number of simulation steps.
     filtered_coordinates : np.ndarray
         Coordinates of the filtered atomic trajectories.
     output_trajectory : TrajectoryWriter
         Trajectory writer object to write the output trajectory.
 
     """
+    nsteps = filtered_coordinates.shape[2]
     time = parent_configuration["frames"]["time"]
     dt = time[1] - time[0]
     for index in range(nsteps):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -169,11 +169,10 @@ class TrajectoryFilter(IJob):
             filter_config["attributes"],
         )
 
-        filter_attributes.setdefault(
-            "n_steps", self.configuration["trajectory"]["length"]
-        )
-        filter_attributes.setdefault(
-            "time_step_ps", self.configuration["trajectory"]["md_time_step"]
+        update_frames(
+            filter_attributes,
+            self.configuration["frames"]["n_frames"],
+            self.configuration["frames"]["time_step"],
         )
 
         filter = filter_class(**filter_attributes)
@@ -210,6 +209,7 @@ class TrajectoryFilter(IJob):
         # Write trajectory
         write_filtered_trajectory(
             parent_configuration=self.configuration,
+            nsteps=filter_attributes["n_steps"],
             filtered_coordinates=filtered_coords,
             output_trajectory=self._output_trajectory,
         )
@@ -233,6 +233,11 @@ class TrajectoryFilter(IJob):
         outputFile.close()
 
         super().finalize()
+
+
+def update_frames(attributes: dict, nsteps: int, step: np.float64) -> None:
+    """ """
+    attributes.update({"n_steps": nsteps, "time_step_ps": step})
 
 
 def apply(filter: Filter, trajectories: np.ndarray, apply_offsets: bool) -> np.ndarray:
@@ -270,6 +275,7 @@ def apply(filter: Filter, trajectories: np.ndarray, apply_offsets: bool) -> np.n
 
 def write_filtered_trajectory(
     parent_configuration: _Configuration,
+    nsteps: int,
     filtered_coordinates: np.ndarray,
     output_trajectory: TrajectoryWriter,
 ) -> None:
@@ -279,13 +285,14 @@ def write_filtered_trajectory(
     ----------
     parent_configuration : _Configuration
         Parent configuration.
+    nsteps : int
+        Number of simulation steps.
     filtered_coordinates : np.ndarray
         Coordinates of the filtered atomic trajectories.
     output_trajectory : TrajectoryWriter
         Trajectory writer object to write the output trajectory.
 
     """
-    nsteps = filtered_coordinates.shape[2]
     time = parent_configuration["frames"]["time"]
     dt = time[1] - time[0]
     for index in range(nsteps):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -1113,6 +1113,16 @@ class FilterDesigner(QDialog):
         """Make the checkbox clickable after the calculation thread has finshed."""
         self.preferences_group.enable_pps(True)
 
+    def update_frames(self) -> None:
+        """ """
+        config = self.configurator.configurable._configuration
+        self.settings["attributes"].update(
+            {
+                "n_steps": config["frames"]["n_frames"],
+                "time_step_ps": config["frames"]["time_step"],
+            }
+        )
+
     def update_pps(self):
         """Run another PositionPowerSpectrum calculation.
 
@@ -1408,6 +1418,8 @@ class FilterDesigner(QDialog):
             Filter attributes dictionary.
 
         """
+        self.update_frames()
+
         if not self.graph_ready:
             return
 
@@ -1614,6 +1626,7 @@ class TrajectoryFilterWidget(WidgetBase):
             self.filter_designer.close()
         else:
             self.filter_designer.update_pps()
+            self.filter_designer.render_canvas_assets()
             self.filter_designer.show()
 
     def get_widget_value(self) -> str:


### PR DESCRIPTION
**Description of work**
This PR aims to simplify the link between simulation frames as configured in the TrajectoryFilter job, and how they are used, 

**Fixes**
Closes #1086

**To test**
Run test suite for the trajectory filter, as well as manual testing of various trajectories using different values for "in steps of"
