### PR TITLE
Improve handling of dummy atoms

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -66,6 +66,11 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
             return
         self.extract_information(trajectory_instance)
         self.error_status = "OK"
+        if not trajectory_instance.non_dummy_elements:
+            self.warning_status = (
+                "This trajectory contains only dummy atoms. "
+                "Analysis runs will fail or produce meaningless results."
+            )
 
     def extract_information(self, trajectory_instance: Trajectory):
         self["instance"] = trajectory_instance

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
@@ -62,14 +62,10 @@ class Density(IJob):
 
         self._n_frames = self.numberOfSteps
 
-        real_atoms = {
-            at_symbol
-            for at_symbol in self.trajectory.unique_elements
-            if not self.trajectory.get_atom_property(at_symbol, "dummy")
-        }
-
         self._n_atoms = ilen(
-            symbol for symbol in self.trajectory.atom_types if symbol in real_atoms
+            symbol
+            for symbol in self.trajectory.atom_types
+            if symbol in self.trajectory.non_dummy_elements
         )
 
         self._symbols = self.configuration["trajectory"][

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Density.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import numpy as np
+from more_itertools import ilen
 
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Units import measure
@@ -61,9 +62,15 @@ class Density(IJob):
 
         self._n_frames = self.numberOfSteps
 
-        self._n_atoms = self.configuration["trajectory"][
-            "instance"
-        ].chemical_system.number_of_atoms
+        real_atoms = {
+            at_symbol
+            for at_symbol in self.trajectory.unique_elements
+            if not self.trajectory.get_atom_property(at_symbol, "dummy")
+        }
+
+        self._n_atoms = ilen(
+            symbol for symbol in self.trajectory.atom_types if symbol in real_atoms
+        )
 
         self._symbols = self.configuration["trajectory"][
             "instance"

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
@@ -20,6 +20,7 @@ from more_itertools import always_iterable
 
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Geometry import center_of_mass, moment_of_inertia
+from MDANSE.MLogging import LOG
 
 
 class Eccentricity(IJob):
@@ -103,6 +104,11 @@ class Eccentricity(IJob):
         conf = conf.contiguous_configuration()
         series = conf["coordinates"][self._indices, :]
 
+        if np.sum(np.abs(self._selectionMasses)) == 0.0:
+            LOG.warning(
+                "All atoms have 0 mass. Replacing mass with 1 to allow eccentricity calculation."
+            )
+            self._selectionMasses = np.ones(len(series))
         com = center_of_mass(series, masses=self._selectionMasses)
 
         # calculate the inertia moments

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
@@ -104,7 +104,7 @@ class Eccentricity(IJob):
         conf = conf.contiguous_configuration()
         series = conf["coordinates"][self._indices, :]
 
-        if np.sum(np.abs(self._selectionMasses)) == 0.0:
+        if np.allclose(self._selectionMasses, 0.0):
             LOG.warning(
                 "All atoms have 0 mass. Replacing mass with 1 to allow eccentricity calculation."
             )

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MolecularTrace.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MolecularTrace.py
@@ -57,10 +57,6 @@ class MolecularTrace(IJob):
         "AtomSelectionConfigurator",
         {
             "dependencies": {"trajectory": "trajectory"},
-            "default": """\
-{
-   "0": {"function_name": "select_all", "operation_type": "union"}
-}""",
         },
     )
     settings["spatial_resolution"] = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -87,14 +87,17 @@ class RootMeanSquareFluctuation(IJob):
             main_result=True,
         )
 
-        self.group_indices = {}
         if self.group_molecules:
-            for grp in self.trajectory.group_lookup:
-                self.group_indices[grp] = {
+            self.group_indices = {
+                grp: {
                     job_i: at_i
                     for job_i, at_i in enumerate(self.trajectory.atom_indices)
                     if f"<{grp}>" in self._names[job_i]
                 }
+                for grp in self.trajectory.group_lookup
+             }
+         else:
+             self.group_indices = {}
 
         for name in self.trajectory.unique_names:
             idxs = [

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -70,7 +70,9 @@ class RootMeanSquareFluctuation(IJob):
         self.group_molecules = self.configuration["grouping_level"]["value"] != "atom"
         self.ele_idxs = {}
 
-        self._names = self.trajectory.atom_names
+        self._names = [
+            self.trajectory.atom_names[index] for index in self.trajectory.atom_indices
+        ]
 
         self._outputData.add(
             "rmsf/axes/indices/all",
@@ -86,19 +88,46 @@ class RootMeanSquareFluctuation(IJob):
             main_result=True,
         )
 
-        for names in self.trajectory.unique_names:
-            idxs = [i for i in self.trajectory.atom_indices if names == self._names[i]]
-            self.ele_idxs[names] = idxs
+        self.group_indices = {}
+        if self.group_molecules:
+            for grp in self.trajectory.group_lookup:
+                self.group_indices[grp] = {
+                    job_i: at_i
+                    for job_i, at_i in enumerate(self.trajectory.atom_indices)
+                    if f"<{grp}>" in self._names[job_i]
+                }
+
+        for name in self.trajectory.unique_names:
+            idxs = [
+                at_i
+                for job_i, at_i in enumerate(self.trajectory.atom_indices)
+                if self._names[job_i] == name
+            ]
+            self.ele_idxs[name] = 0
             self._outputData.add(
-                f"rmsf/axes/indices/{names}",
+                f"rmsf/axes/indices/{name}",
                 "LineOutputVariable",
                 idxs,
             )
             self._outputData.add(
-                f"rmsf/{names}",
+                f"rmsf/{name}",
                 "LineOutputVariable",
                 (len(idxs),),
-                axis=f"rmsf/axes/indices/{names}",
+                axis=f"rmsf/axes/indices/{name}",
+                units="nm",
+            )
+
+        for grp, index_dict in self.group_indices.items():
+            self._outputData.add(
+                f"rmsf/axes/indices/<{grp}>/all",
+                "LineOutputVariable",
+                index_dict.values(),
+            )
+            self._outputData.add(
+                f"rmsf/<{grp}>/all",
+                "LineOutputVariable",
+                (len(index_dict),),
+                axis=f"rmsf/axes/indices/<{grp}>/all",
                 units="nm",
             )
 
@@ -138,36 +167,19 @@ class RootMeanSquareFluctuation(IJob):
         """
         self._outputData["rmsf/all"][index] = x
         name = self._names[index]
-        idxs = self.ele_idxs[name]
-        self._outputData[f"rmsf/{name}"][idxs.index(index)] = x
+        self._outputData[f"rmsf/{name}"][self.ele_idxs[name]] = x
+        self.ele_idxs[name] += 1
 
     def finalize(self):
         """Finalizes the calculations (e.g. averaging the total term, output
         files creations ...).
         """
         if self.group_molecules:
-            for grp in self.trajectory.group_lookup:
-                eles = self.trajectory.group_elements(grp)
-                idxs = []
-                for ele in eles:
-                    idxs += self.ele_idxs[f"<{grp}>/{ele}"]
-                idxs = sorted(idxs)
-                self._outputData.add(
-                    f"rmsf/axes/indices/<{grp}>/all",
-                    "LineOutputVariable",
-                    idxs,
-                )
-                self._outputData.add(
-                    f"rmsf/<{grp}>/all",
-                    "LineOutputVariable",
-                    (len(idxs),),
-                    axis=f"rmsf/axes/indices/<{grp}>/all",
-                    units="nm",
-                )
-                for i, idx in enumerate(idxs):
-                    self._outputData[f"rmsf/<{grp}>/all"][i] = self._outputData[
+            for grp, index_dict in self.group_indices.items():
+                for result_in, job_in in enumerate(index_dict.keys()):
+                    self._outputData[f"rmsf/<{grp}>/all"][result_in] = self._outputData[
                         "rmsf/all"
-                    ][idx]
+                    ][job_in]
 
         # Write the output variables.
         self._outputData.write(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -15,6 +15,8 @@
 #
 from __future__ import annotations
 
+from itertools import groupby
+
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.MolecularDynamics.Analysis import mean_square_fluctuation
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -70,9 +70,8 @@ class RootMeanSquareFluctuation(IJob):
         self.group_molecules = self.configuration["grouping_level"]["value"] != "atom"
         self.ele_idxs = {}
 
-        self._names = [
-            self.trajectory.atom_names[index] for index in self.trajectory.atom_indices
-        ]
+        all_names = self.trajectory.atom_names
+        self._names = [all_names[index] for index in self.trajectory.atom_indices]
 
         self._outputData.add(
             "rmsf/axes/indices/all",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -97,9 +97,9 @@ class RootMeanSquareFluctuation(IJob):
                     if f"<{grp}>" in self._names[job_i]
                 }
                 for grp in self.trajectory.group_lookup
-             }
-         else:
-             self.group_indices = {}
+            }
+        else:
+            self.group_indices = {}
 
         for name in self.trajectory.unique_names:
             idxs = [

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -69,15 +69,10 @@ class Temperature(IJob):
         """
         super().initialize()
 
-        real_atoms = {
-            at_symbol
-            for at_symbol in self.trajectory.unique_elements
-            if not self.trajectory.get_atom_property(at_symbol, "dummy")
-        }
         self.indices = [
             index
             for index, symbol in enumerate(self.trajectory.atom_types)
-            if symbol in real_atoms
+            if symbol in self.trajectory.non_dummy_elements
         ]
 
         self.numberOfSteps = len(self.indices)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -69,9 +69,18 @@ class Temperature(IJob):
         """
         super().initialize()
 
-        self.numberOfSteps = self.configuration["trajectory"][
-            "instance"
-        ].chemical_system.number_of_atoms
+        real_atoms = {
+            at_symbol
+            for at_symbol in self.trajectory.unique_elements
+            if not self.trajectory.get_atom_property(at_symbol, "dummy")
+        }
+        self.indices = [
+            index
+            for index, symbol in enumerate(self.trajectory.atom_types)
+            if symbol in real_atoms
+        ]
+
+        self.numberOfSteps = len(self.indices)
 
         self._nFrames = self.configuration["frames"]["number"]
 
@@ -124,7 +133,8 @@ class Temperature(IJob):
             #. kineticEnergy (np.array): The calculated kinetic energy
         """
 
-        symbol = self._atoms[index]
+        real_index = self.indices[index]
+        symbol = self._atoms[real_index]
 
         mass = self.trajectory.get_atom_property(symbol, "atomic_weight")
 
@@ -132,7 +142,7 @@ class Temperature(IJob):
 
         if self.configuration["interpolation_order"]["value"] == 0:
             series = trajectory.read_configuration_trajectory(
-                index,
+                real_index,
                 first=self.configuration["frames"]["first"],
                 last=self.configuration["frames"]["last"] + 1,
                 step=self.configuration["frames"]["step"],
@@ -140,7 +150,7 @@ class Temperature(IJob):
             )
         else:
             series = trajectory.read_atomic_trajectory(
-                index,
+                real_index,
                 first=self.configuration["frames"]["first"],
                 last=self.configuration["frames"]["last"] + 1,
                 step=self.configuration["frames"]["step"],
@@ -173,7 +183,7 @@ class Temperature(IJob):
         Finalizes the calculations (e.g. averaging the total term, output files creations ...).
         """
 
-        nAtoms = len(self._atoms)
+        nAtoms = len(self.indices)
         self._outputData["temp/kinetic_energy"] /= nAtoms - 1
 
         norm = np.arange(1, self._outputData["temp/kinetic_energy"].shape[0] + 1)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Connectivity.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Connectivity.py
@@ -178,7 +178,8 @@ class Connectivity:
                 if value > maxbonds_sq[element_pair]:
                     continue
                 bonds.append(key)
-        self._unique_bonds = np.unique(np.sort(bonds, axis=1), axis=0)
+        if bonds:
+            self._unique_bonds = np.unique(np.sort(bonds, axis=1), axis=0)
 
     def add_bond_information(self, new_chemical_system: ChemicalSystem):
         new_chemical_system.add_bonds(self._unique_bonds)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -246,6 +246,15 @@ class Trajectory:
         if self._selection:
             return set(always_iterable(self.selection_getter(self.atom_types)))
         return set(always_iterable(self.atom_types))
+    
+    @property
+    def non_dummy_elements(self) -> set[str]:
+        """Set of chemical elements which are not dummy atoms."""
+        return {
+            at_symbol
+            for at_symbol in self.unique_elements
+            if not self.get_atom_property(at_symbol, "dummy")
+        }
 
     @property
     def unique_names(self) -> set[str]:

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -681,6 +681,8 @@ class MolecularViewer(QtWidgets.QWidget):
         """
         # determine and set bonds without PBC applied
         bonds = vtk.vtkCellArray()
+        if not len(covs):
+            return bonds
 
         dist, js, ks, _ = distance_calculation(rs, 2 * np.max(covs) + tolerance)
         sum_radii = (covs[js] + covs[ks] + tolerance) ** 2

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -619,6 +619,9 @@ class MolecularViewer(QtWidgets.QWidget):
 
     def change_atm_polydata_lines(self):
         """Calculate and/or updates the atom polydata bonds."""
+        if not len(self.not_du):
+            self._atm_polydata.SetLines(vtk.vtkCellArray())
+            return
         match self.bond_calc:
             case BondCalc.EVERY:
                 rs = self._current_coords[self.not_du]


### PR DESCRIPTION
**Description of work**
This PR should remove several inconsistencies caused the the presence of dummy atoms in the input trajectory.

closes #1124 
closes #1125 
closes #1126

**Fixes**
1. RootMeanSquareFluctuation now works also with an incomplete atom selection.
2. Temperature and Density do not count dummy atoms when counting all the atoms in the system.
3. MolecularViewer does not calculate distances if it is given an empty list of covalent radii.

**To test**
Load the DL_POLY water into the GUI. Try to invert the selection in atom selection dialog.
Remove dummy atoms from DL_POLY water. Run Temperature and Density on the trajectory with and without dummy atoms. The results should be the same.
Run RootMeanSquareFluctuation on DL_POLY water with both atom and molecule grouping. Both should run successfully.
