### PR TITLE
Apply common formatting to input widget error messages

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/AseInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AseInputFileConfigurator.py
@@ -68,7 +68,7 @@ class AseInputFileConfigurator(InputFileConfigurator):
             if self.optional:
                 return
             LOG.error(f"FILE MISSING in {self.name}")
-            self.error_status = f"The file {value} does not exist"
+            self.error_status = f"The file {value} does not exist."
             return
 
         if file_format == "guess":
@@ -76,7 +76,7 @@ class AseInputFileConfigurator(InputFileConfigurator):
 
         if file_format is not None and file_format not in self._allowed_formats:
             LOG.error(f"WRONG FORMAT in {self.name}")
-            self.error_status = f"The ASE file format {file_format} is not supported"
+            self.error_status = f"The ASE file format {file_format} is not supported."
             return
 
         self["value"] = value

--- a/MDANSE/Src/MDANSE/Framework/Configurators/AtomTransmutationConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/AtomTransmutationConfigurator.py
@@ -149,7 +149,7 @@ class AtomTransmutationConfigurator(IConfigurator):
         try:
             value = {int(idx): element for idx, element in value.items()}
         except ValueError:
-            self.error_status = "Key of transmutation map should be castable to int"
+            self.error_status = "Key of transmutation map should be castable to int."
             return
 
         keys = set(value.keys())
@@ -165,7 +165,7 @@ class AtomTransmutationConfigurator(IConfigurator):
                 element not in ATOMS_DATABASE.atoms
             ):
                 self.error_status = (
-                    f"the element {element} is not registered in the database"
+                    f"The element {element} is not registered in the database."
                 )
                 return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/BooleanConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/BooleanConfigurator.py
@@ -58,7 +58,7 @@ class BooleanConfigurator(IConfigurator):
         self._original_input = value
 
         if value not in self._shortCuts:
-            self.error_status = "Input is not recognised as a true/false value"
+            self.error_status = "Input is not recognised as a true/false value."
         else:
             self.error_status = "OK"
             self["value"] = self._shortCuts[value]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/CorrelationFramesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/CorrelationFramesConfigurator.py
@@ -60,15 +60,14 @@ class CorrelationFramesConfigurator(FramesConfigurator):
 
         if c_frames > self["n_frames"]:
             self.error_status = (
-                "Number of frames used for the correlation "
-                "greater than the total number of frames of "
-                "the trajectory."
+                "Number of frames used for the correlation should not be "
+                "greater than the number of frames in the current frame range."
             )
             return
 
         if c_frames < 2:
             self.error_status = (
-                "Number of frames used for the correlation should be greater then zero."
+                "Number of frames used for the correlation should be greater than one."
             )
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DerivativeOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DerivativeOrderConfigurator.py
@@ -60,15 +60,15 @@ class DerivativeOrderConfigurator(IntegerConfigurator):
 
         if value <= 0 or value > 5:
             self.error_status = (
-                "Use an interpolation order less than or equal to zero or "
-                "greater than 5 is not implemented."
+                "Interpolation orders less than or equal to zero or "
+                "greater than 5 are not implemented."
             )
             return
 
         number = frames_configurator["number"]
         if number < value + 1:
             self.error_status = (
-                f"Not enough MD frames to apply derivatives of order {value}"
+                f"Not enough MD frames to apply derivatives of order {value}."
             )
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FileWithAtomDataConfigurator.py
@@ -75,11 +75,11 @@ class FileWithAtomDataConfigurator(InputFileConfigurator):
         try:
             self.instance = self.parser(filepath)
         except Exception as e:
-            self.error_status = f"File parsing error {e}: {traceback.format_exc()}"
+            self.error_status = f"File parsing error {e}: {traceback.format_exc()}."
             return
 
         if not self.labels:
-            self.error_status = "Unable to generate atom labels"
+            self.error_status = "Unable to generate atom labels."
             return
 
     @property

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FloatConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FloatConfigurator.py
@@ -62,19 +62,25 @@ class FloatConfigurator(IConfigurator):
         try:
             value = float(value)
         except (TypeError, ValueError):
-            self.error_status = f"Wrong value {value} in {self}"
+            self.error_status = f"Wrong value {value} in {self}."
             return
 
         if self.choices and value not in self.choices:
-            self.error_status = "the input value is not a valid choice."
+            self.error_status = (
+                f"The input value is not one of the valid choices: {self.choices}."
+            )
             return
 
         if self.mini is not None and value < self.mini:
-            self.error_status = f"the input value is lower than {self.mini}"
+            self.error_status = (
+                f"The input value is lower than the minimum value {self.mini}."
+            )
             return
 
         if self.maxi is not None and value > self.maxi:
-            self.error_status = f"the input value is higher than {self.maxi}"
+            self.error_status = (
+                f"The input value is higher than the maximum value {self.maxi}."
+            )
             return
 
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/FramesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FramesConfigurator.py
@@ -63,7 +63,7 @@ class FramesConfigurator(RangeConfigurator):
         try:
             num_values = [int(x) for x in value[0:3]]
         except (ValueError, TypeError):
-            self.error_status = "Input values must castable to int"
+            self.error_status = "Input values must castable to int."
             return
 
         # special case for negative last step option
@@ -74,17 +74,17 @@ class FramesConfigurator(RangeConfigurator):
 
         # check first setting
         if first < 0 or first > n_steps - 1:
-            self.error_status = f"First frame needs to be between 0 and {n_steps - 1}"
+            self.error_status = f"First frame needs to be between 0 and {n_steps - 1}."
             return
 
         # check last setting
         if last <= 0 or last > n_steps or last <= first:
-            self.error_status = f"Last frame needs to be between 1 and {n_steps} and greater than the first frame"
+            self.error_status = f"Last frame needs to be between 1 and {n_steps} and greater than the first frame."
             return
 
         # check step setting
         if step < 1:
-            self.error_status = f"Cannot create a range with a step: {step}"
+            self.error_status = f"Cannot create a range with a step: {step}."
             return
 
         self._mini = 0

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFInputFileConfigurator.py
@@ -70,7 +70,7 @@ class HDFInputFileConfigurator(InputFileConfigurator):
             self["instance"] = h5py.File(self["value"], "r")
 
         except OSError:
-            self.error_status = f"can not open {value} HDF file for reading"
+            self.error_status = f"Cannot open HDF file {value} for reading."
             return
 
         for v in self.variables:
@@ -82,7 +82,7 @@ class HDFInputFileConfigurator(InputFileConfigurator):
                     self._units[v] = "unitless"
             else:
                 self.error_status = (
-                    f"the variable {v} was not  found in {value} HDF file"
+                    f"The variable {v} was not found in HDF file {value}."
                 )
                 return
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -62,7 +62,7 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
         try:
             trajectory_instance = Trajectory(self["value"])
         except KeyError:
-            self.error_status = f"Could not use {value} as input trajectory"
+            self.error_status = f"Could not use {value} as input trajectory."
             return
         self.extract_information(trajectory_instance)
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InputFileConfigurator.py
@@ -64,7 +64,7 @@ class InputFileConfigurator(IConfigurator):
         value = PLATFORM.get_path(value)
 
         if not value.exists():
-            self.error_status = f"The file {value} does not exist"
+            self.error_status = f"The file {value} does not exist."
             return
 
         self["value"] = value

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IntegerConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IntegerConfigurator.py
@@ -72,20 +72,26 @@ class IntegerConfigurator(IConfigurator):
             return
 
         if self.choices and value not in self.choices:
-            self.error_status = "the input value is not a valid choice."
+            self.error_status = (
+                f"The input value is not one of the valid choices: {self.choices}."
+            )
             return
 
         if self.mini is not None and value < self.mini:
-            self.error_status = f"the input value is lower than {self.mini}"
+            self.error_status = (
+                f"The input value is lower than the minimum value {self.mini}."
+            )
             return
 
         if self.maxi is not None and value > self.maxi:
-            self.error_status = f"the input value is higher than {self.maxi}"
+            self.error_status = (
+                f"The input value is higher than the maximum value {self.maxi}."
+            )
             return
 
         if self._exclude and value in self._exclude:
             self.error_status = (
-                f"the input value is forbidden; forbidden values are {self._exclude}"
+                f"The input value is forbidden; forbidden values are {self._exclude}."
             )
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/InterpolationOrderConfigurator.py
@@ -73,19 +73,22 @@ class InterpolationOrderConfigurator(IntegerConfigurator):
 
         if value == 0:
             if not traj_has_velocities:
-                self.error_status = "the trajectory does not contain any velocities. Use an interpolation order higher than 0"
+                self.error_status = (
+                    "The trajectory does not contain any velocities. "
+                    "Use an interpolation order higher than 0."
+                )
                 return
             self["variable"] = "velocities"
         elif value > 5:
             self.error_status = (
-                "Use an interpolation order greater than 5 is not implemented."
+                "Interpolation orders greater than 5 are not implemented."
             )
             return
         else:
             number = frames_configurator["number"]
             if number < value + 1:
                 self.error_status = (
-                    f"Not enough MD frames to apply derivatives of order {value}"
+                    f"Not enough MD frames to apply derivatives of order {value}."
                 )
                 return
             self["variable"] = "coordinates"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisCoordinateFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisCoordinateFileConfigurator.py
@@ -57,7 +57,7 @@ class MDAnalysisCoordinateFileConfigurator(MultiInputFileConfigurator):
 
         topology_configurator = self.configurable[self.dependencies["input_file"]]
         if not topology_configurator.valid:
-            self.error_status = "Requires valid topology file."
+            self.error_status = "Requires a valid topology file."
             return
 
         try:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTimeStepConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDAnalysisTimeStepConfigurator.py
@@ -70,7 +70,7 @@ class MDAnalysisTimeStepConfigurator(FloatConfigurator):
                     )
                     return
             else:
-                self.error_status = "Unable to determine a time step from MDAnalysis"
+                self.error_status = "Unable to determine a time step from MDAnalysis."
                 return
 
         super().configure(value)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTimeStepConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTimeStepConfigurator.py
@@ -58,7 +58,7 @@ class MDTrajTimeStepConfigurator(FloatConfigurator):
                     )
                     return
             else:
-                self.error_status = "Unable to determine a time step from MDTraj"
+                self.error_status = "Unable to determine a time step from MDTraj."
                 return
 
         super().configure(value)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -60,7 +60,7 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
             if extension not in supported:
                 self.error_status = (
                     f"Trajectory file does not contain topology information. "
-                    f"File '{extension}' is not supported; should be one of the following: {supported}."
+                    f"File '{extension}' is not supported. Should be one of the following: {supported}."
                 )
                 return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MDTrajTopologyFileConfigurator.py
@@ -45,7 +45,7 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
             return
 
         if not self.configurable[self.dependencies["coordinate_files"]].valid:
-            self.error_status = "Trajectory file not valid"
+            self.error_status = "Trajectory file not valid."
             return
 
         if not value:
@@ -60,7 +60,7 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
             if extension not in supported:
                 self.error_status = (
                     f"Trajectory file does not contain topology information. "
-                    f"File '{extension}' not support should be one of the following: {supported}"
+                    f"File '{extension}' is not supported; should be one of the following: {supported}."
                 )
                 return
 
@@ -71,13 +71,13 @@ class MDTrajTopologyFileConfigurator(FileWithAtomDataConfigurator):
                 return
 
             if len(self.labels) == 0:
-                self.error_status = "Unable to generate atom labels"
+                self.error_status = "Unable to generate atom labels."
 
         else:
             extension = "".join(Path(value).suffixes)[1:]
             supported = [i[1:] for i in _TOPOLOGY_EXTS]
             if extension not in supported:
-                self.error_status = f"File '{extension}' not supported. Should be one of the following: {supported}"
+                self.error_status = f"File '{extension}' is not supported. Should be one of the following: {supported}"
                 return
             super().configure(value)
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MultiInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MultiInputFileConfigurator.py
@@ -67,9 +67,7 @@ class MultiInputFileConfigurator(IConfigurator):
                 self.error_status = "Input values should be a list of str."
                 return
         else:
-            self.error_status = (
-                "Not possible to evaluate input values as a list.."
-            )
+            self.error_status = "Not possible to evaluate input values as a list.."
             return
 
         values = [PLATFORM.get_path(value) for value in values]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MultiInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MultiInputFileConfigurator.py
@@ -56,7 +56,7 @@ class MultiInputFileConfigurator(IConfigurator):
                     return
                 if type(values) is not list:
                     self.error_status = (
-                        "Input values should be able to be evaluated as a list"
+                        "Input values should be possible to be evaluated as a list."
                     )
                     return
             else:
@@ -64,10 +64,12 @@ class MultiInputFileConfigurator(IConfigurator):
 
         if isinstance(values, list):
             if not all(isinstance(value, str) for value in values):
-                self.error_status = "Input values should be a list of str"
+                self.error_status = "Input values should be a list of str."
                 return
         else:
-            self.error_status = "Input values should be able to be evaluated as a list"
+            self.error_status = (
+                "Input values should be possible to be evaluated as a list."
+            )
             return
 
         values = [PLATFORM.get_path(value) for value in values]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MultiInputFileConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MultiInputFileConfigurator.py
@@ -56,7 +56,7 @@ class MultiInputFileConfigurator(IConfigurator):
                     return
                 if type(values) is not list:
                     self.error_status = (
-                        "Input values should be possible to be evaluated as a list."
+                        "Not possible to evaluate input values as a list.."
                     )
                     return
             else:
@@ -68,7 +68,7 @@ class MultiInputFileConfigurator(IConfigurator):
                 return
         else:
             self.error_status = (
-                "Input values should be possible to be evaluated as a list."
+                "Not possible to evaluate input values as a list.."
             )
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MultipleChoicesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MultipleChoicesConfigurator.py
@@ -59,7 +59,7 @@ class MultipleChoicesConfigurator(IConfigurator):
         self._original_input = value
 
         if self.nChoices is not None and len(value) != self.nChoices:
-            self.error_status = "invalid number of choices."
+            self.error_status = "Invalid number of choices."
             return
 
         indices = []
@@ -67,7 +67,7 @@ class MultipleChoicesConfigurator(IConfigurator):
             indices = [self.choices.index(v) for v in value]
         except ValueError:
             self.error_status = (
-                f"{', '.join(set(value) - set(self.choices))} are not valid choices"
+                f"{', '.join(set(value) - set(self.choices))} are not valid choices."
             )
             return
 

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OptionalFloatConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OptionalFloatConfigurator.py
@@ -68,19 +68,25 @@ class OptionalFloatConfigurator(IConfigurator):
         try:
             value[1] = float(value[1])
         except (TypeError, ValueError):
-            self.error_status = f"Wrong value {value[1]} in {self}"
+            self.error_status = f"Wrong value {value[1]} in {self}."
             return
 
         if self.choices and value[1] not in self.choices:
-            self.error_status = "the input value is not a valid choice."
+            self.error_status = (
+                f"The input value is not one of the valid choices: {self.choices}."
+            )
             return
 
         if self.mini is not None and value[1] < self.mini:
-            self.error_status = f"the input value is lower than {self.mini}"
+            self.error_status = (
+                f"The input value is lower than the minimum value {self.mini}."
+            )
             return
 
         if self.maxi is not None and value[1] > self.maxi:
-            self.error_status = f"the input value is higher than {self.maxi}"
+            self.error_status = (
+                f"The input value is higher than the maximum value {self.maxi}."
+            )
             return
 
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputStructureConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputStructureConfigurator.py
@@ -68,19 +68,19 @@ class OutputStructureConfigurator(IConfigurator):
         root = Path(root)
 
         if logs not in self.log_options:
-            self.error_status = "log level option not recognised"
+            self.error_status = f"Log level option {logs} not recognised."
             return
 
         if not root:
-            self.error_status = "empty root name for the output file."
+            self.error_status = "Empty root name for the output file."
             return
 
         if not PLATFORM.is_file_writable(root):
-            self.error_status = f"the file {root} is not writable"
+            self.error_status = f"The file {root} is not writable."
             return
 
         if format not in self.formats:
-            self.error_status = "Output format is not supported"
+            self.error_status = f"Output format {format} is not supported."
             return
 
         self["root"] = root

--- a/MDANSE/Src/MDANSE/Framework/Configurators/PartialChargeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/PartialChargeConfigurator.py
@@ -168,7 +168,7 @@ class PartialChargeConfigurator(IConfigurator):
                 try:
                     charge = float(k)
                 except (TypeError, ValueError):
-                    self.error_status = f"Wrong charge {k} in the charge dictionary"
+                    self.error_status = f"Wrong charge {k} in the charge dictionary."
                     return
                 else:
                     for index in v:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/RangeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/RangeConfigurator.py
@@ -87,7 +87,7 @@ class RangeConfigurator(IConfigurator):
         first, last, step = value
 
         if step == 0:
-            self.error_status = "Step of a range cannot be 0"
+            self.error_status = "Step of a range cannot be 0."
             return
 
         if self.includeLast:
@@ -110,7 +110,7 @@ class RangeConfigurator(IConfigurator):
             value = value[value < self.maxi]
 
         if value.size == 0:
-            self.error_status = "the input range is empty."
+            self.error_status = "The input range is empty."
             return
 
         if self.sort:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
@@ -61,7 +61,7 @@ class RunningModeConfigurator(IConfigurator):
             if slots < 0:
                 slots = min(abs(slots), maxSlots)
             elif slots == 0 or slots > maxSlots:
-                self.error_status = "invalid number of allocated slots."
+                self.error_status = f"Invalid number of allocated slots: {slots}."
                 return
 
         self["mode"] = mode

--- a/MDANSE/Src/MDANSE/Framework/Configurators/SingleChoiceConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/SingleChoiceConfigurator.py
@@ -54,7 +54,9 @@ class SingleChoiceConfigurator(IConfigurator):
         try:
             self["index"] = self.choices.index(value)
         except ValueError:
-            self.error_status = f"{value} item is not a valid choice"
+            self.error_status = (
+                f"{value} item is not one of the valid choices: {self.choices}."
+            )
             return
         else:
             self["value"] = value

--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
@@ -40,6 +40,7 @@ class TrajectoryFilterConfigurator(IConfigurator):
     _default_filter = DEFAULT_FILTER
 
     _settings = filter_default_attributes()
+    _expected_keys = {"filter", "attributes"}
 
     @classmethod
     def get_default(cls) -> str:
@@ -72,11 +73,11 @@ class TrajectoryFilterConfigurator(IConfigurator):
         try:
             dict_value = json.loads(value)
 
-            if not {"filter", "attributes"} <= dict_value.keys():
-                self.error_status = f"The dictionary \n{dict_value}\n does not contain the expected keys"
+            if not self._expected_keys <= dict_value.keys():
+                self.error_status = f"The dictionary \n{dict_value}\n does not contain the expected keys {self._expected_keys}."
 
         except (TypeError, ValueError):
-            self.error_status = f"Value \n{value}\n in {self} is not of correct format (expected JSON string)"
+            self.error_status = f"Value \n{value}\n in {self} is not of correct format (expected JSON string)."
 
         self.error_status = "OK"
         self["value"] = self._settings

--- a/MDANSE/Src/MDANSE/Framework/Configurators/UnitCellConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/UnitCellConfigurator.py
@@ -106,12 +106,12 @@ class UnitCellConfigurator(IConfigurator):
                 input_array = np.array(value[0], dtype=float)
             except Exception:
                 self.error_status = (
-                    "Could not convert the inputs into a floating point array"
+                    "Could not convert the inputs into a floating point array."
                 )
                 return
             else:
                 if input_array.shape != (3, 3):
-                    self.error_status = "Input shape must be 3x3"
+                    self.error_status = "Input shape must be 3x3."
                     return
 
             self["value"] = value[0]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/VectorConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/VectorConfigurator.py
@@ -68,11 +68,11 @@ class VectorConfigurator(IConfigurator):
         self._original_input = value
 
         if not isinstance(value, list | tuple):
-            self.error_status = "Invalid input type"
+            self.error_status = "Invalid input type."
             return
 
         if len(value) != self.dimension:
-            self.error_status = "Invalid dimension"
+            self.error_status = f"This vector should have {self.dimension} components."
             return
 
         vector = Vector(np.array(value, dtype=self.valueType))
@@ -81,7 +81,7 @@ class VectorConfigurator(IConfigurator):
             vector = vector.normal()
 
         if self.notNull and vector.length() == 0.0:
-            self.error_status = "The vector is null"
+            self.error_status = "The vector is null."
             return
 
         self["vector"] = vector

--- a/MDANSE/Src/MDANSE/Framework/Configurators/WeightsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/WeightsConfigurator.py
@@ -115,7 +115,7 @@ class WeightsConfigurator(SingleChoiceConfigurator):
             return
 
         if self.test_values_for_nan(value):
-            self.error_status = f"Property {value} is NaN for at leas one atom type."
+            self.error_status = f"Property {value} is NaN for at least one atom type."
             return
 
         self["property"] = value


### PR DESCRIPTION
**Description of work**
A minor improvement to the error message strings shown by the `Configurator` objects.

closes #1132

**Fixes**
1. Changed the error message for correlation frames to "greater than one".
2. Capitalised the first word of each error message and added a full stop at the end, except where external input is added at the end of the string.
3. Increased the verbosity of error messages dealing with min/max values and finite lists of valid input values.

**To test**
Try putting different wrong values into the input fields and check if the error messages are relevant.
