### PR TITLE
Clear the property viewer on trajectory delete

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
@@ -423,8 +423,8 @@ class PropertyWidget(QWidget):
         """Clears the property viewer."""
         self._prop_selection.clear()
         self._prop_model.clear()
-        self._atom_props = {}
-        self._raw_props = {}
-        self._frame_props = {}
-        self._trajectory_props = {}
-        self.curr_selection = {}
+        self._atom_props.clear()
+        self._raw_props.clear()
+        self._frame_props.clear()
+        self._trajectory_props.clear()
+        self.curr_selection.clear()

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
@@ -50,6 +50,8 @@ class PropertyWidget(QWidget):
         self._index = index
         self.active = False
         self.viewer.frame_changed.connect(self.update_table)
+        self._atom_props = {}
+        self._trajectory_props = {}
 
     @Slot(int)
     def _active(self, index: int):
@@ -416,3 +418,13 @@ class PropertyWidget(QWidget):
             self._update_prop_table(prop_name)
 
         self._last_prop = prop_name
+
+    def clear_viewer(self):
+        """Clears the property viewer."""
+        self._prop_selection.clear()
+        self._prop_model.clear()
+        self._atom_props = {}
+        self._raw_props = {}
+        self._frame_props = {}
+        self._trajectory_props = {}
+        self.curr_selection = {}

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/View3D.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/View3D.py
@@ -49,6 +49,7 @@ class View3D(QWidget):
     def update_panel(self, data: tuple[str, Trajectory] | None):
         if data is None or data[0] == "":
             self._viewer.clear_panel()
+            self._controls._property_widget.clear_viewer()
             return
         fullpath, incoming = data
         try:
@@ -57,3 +58,4 @@ class View3D(QWidget):
         except AttributeError:
             self.error.emit(f"3D View could not visualise {fullpath}")
             self._viewer.clear_panel()
+            self._controls._property_widget.clear_viewer()


### PR DESCRIPTION
**Description of work**
The property viewer now clears when the trajectory is deleted in the trajectory tab.

**Fixes**
Fixes #1134
Error message no longer seen when atoms or trajectory is selected in the first drop-down menu in the property viewer when no trajectory is loaded.

**To test**
Load a trajectory and check that the property viewer work as usual. Delete the trajectory from the trajectory tab and check that the property viewer is cleared.

