### PR TITLE
Add dynamic (git) versioning

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
@@ -16,12 +16,12 @@
 from __future__ import annotations
 
 import json
-from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import h5py
 
+import MDANSE
 from MDANSE import PLATFORM
 from MDANSE.Framework.Formats.IFormat import IFormat
 from MDANSE.MLogging import LOG
@@ -113,7 +113,7 @@ def write_metadata(job: IJob, output_file: h5py.File):
     meta.create_dataset(
         "MDANSE_version",
         (1,),
-        data=str(metadata.version("MDANSE")),
+        data=MDANSE.__version__,
         dtype=string_dt,
     )
 
@@ -210,7 +210,7 @@ class HDFFormat(IFormat):
             meta.create_dataset(
                 "MDANSE_version",
                 (1,),
-                data=str(metadata.version("MDANSE")),
+                data=MDANSE.__version__,
                 dtype=string_dt,
             )
 

--- a/MDANSE/Src/MDANSE/Framework/Formats/TextFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/TextFormat.py
@@ -19,12 +19,12 @@ import codecs
 import io
 import tarfile
 import time
-from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
 
+import MDANSE
 from MDANSE import PLATFORM
 from MDANSE.Framework.Formats.IFormat import IFormat
 
@@ -90,7 +90,7 @@ class TextFormat(IFormat):
                 real_buffer = io.BytesIO()
                 tempStr = codecs.getwriter("utf-8")(real_buffer)
                 tempStr.write(f"run type: {run_instance.__class__.__name__}\n")
-                tempStr.write(f"MDANSE version: {metadata.version('MDANSE')}\n")
+                tempStr.write(f"MDANSE version: {MDANSE.__version__}\n")
                 for key, value in inputs.items():
                     tempStr.write(f"parameters[{key}] = {value}\n")
                 tempStr.write("\n\n")

--- a/MDANSE/Src/MDANSE/__init__.py
+++ b/MDANSE/Src/MDANSE/__init__.py
@@ -15,12 +15,13 @@
 #
 from __future__ import annotations
 
-import importlib.metadata
 import os
 import warnings
 
 import MDANSE.Framework
 from MDANSE.Core.Platform import PLATFORM
+
+from ._version import get_version
 
 # Limit underlying math libraries (OpenMP, BLAS, MKL, etc.) to use only 1 thread
 # to prevent them from creating many worker threads and overloading the CPU.
@@ -34,6 +35,6 @@ os.environ.update(
     }
 )
 
-__version__ = importlib.metadata.version("MDANSE")
+__version__ = str(get_version())
 
 warnings.filterwarnings("ignore")

--- a/MDANSE/Src/MDANSE/_version.py
+++ b/MDANSE/Src/MDANSE/_version.py
@@ -1,6 +1,6 @@
-#    This file is part of MDANSE_GUI.
+#    This file is part of MDANSE.
 #
-#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    MDANSE is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
@@ -17,24 +17,20 @@ from __future__ import annotations
 
 import os
 
-os.environ.update(
-    {
-        "OMP_NUM_THREADS": "1",
-        "OPENBLAS_NUM_THREADS": "1",
-        "MKL_NUM_THREADS": "1",
-        "VECLIB_MAXIMUM_THREADS": "1",
-        "NUMEXPR_NUM_THREADS": "1",
-    }
-)
 
-from ._version import get_version
+def get_version():
+    """Get MDANSE version.
 
-__version__ = get_version()
+    If not in git, return static version.
+    """
+    if version := os.getenv("MDANSE_VERSION"):
+        return version
 
-import warnings
+    try:
+        from setuptools_git_versioning import version_from_git
 
-warnings.filterwarnings("ignore")
+        return version_from_git()
+    except Exception:
+        from importlib.metadata import version
 
-import vtk
-
-vtk.vtkObject.GlobalWarningDisplayOff()
+        return version("MDANSE")

--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools", "numpy", "wheel"]
+requires = ["setuptools", "numpy", "wheel", "setuptools-git-versioning>=3.0,<4"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "MDANSE"
-version = "2.0.1"
 description = 'MDANSE Core package - Molecular Dynamics trajectory handling and analysis code'
+dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.10"
 license = {file = "LICENSE"}
@@ -42,6 +42,7 @@ dependencies = [
     "networkx",
     "more-itertools",
     "typing_extensions",
+    "setuptools-git-versioning>=3.0,<4",
 ]
 
 [dependency-groups]
@@ -68,6 +69,10 @@ include-package-data = true
 MDANSE = ["Chemistry/*.json",
           "Chemistry/*.csv",
           "Framework/*.json"]
+
+[tool.setuptools-git-versioning]
+enabled = true
+starting_version = "2.0.1"
 
 [project.scripts]
 mdanse = "MDANSE.Scripts.mdanse:main"

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import json
 import os
 from collections import defaultdict
-from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -34,6 +33,8 @@ from qtpy.QtWidgets import (
     QToolBar,
 )
 
+import MDANSE
+import MDANSE_GUI
 from MDANSE.MLogging import LOG
 from MDANSE_GUI.ElementsDatabaseEditor import ElementsDatabaseEditor
 from MDANSE_GUI.PeriodicTableViewer import PeriodicTableViewer
@@ -354,8 +355,8 @@ class TabbedWindow(QMainWindow):
 
     def version_information(self):
         version = ""
-        version += f"MDANSE version: {metadata.version('MDANSE')}\n"
-        version += f"MDANSE_GUI version: {metadata.version('MDANSE_GUI')}\n"
+        version += f"MDANSE version: {MDANSE.__version__}\n"
+        version += f"MDANSE_GUI version: {MDANSE_GUI.__version__}\n"
         _popup = QMessageBox.about(self, "MDANSE Version Information", version)
 
     def show_website_code(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/_version.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/_version.py
@@ -1,6 +1,6 @@
-#    This file is part of MDANSE_GUI.
+#    This file is part of MDANSE.
 #
-#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    MDANSE is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
@@ -17,24 +17,20 @@ from __future__ import annotations
 
 import os
 
-os.environ.update(
-    {
-        "OMP_NUM_THREADS": "1",
-        "OPENBLAS_NUM_THREADS": "1",
-        "MKL_NUM_THREADS": "1",
-        "VECLIB_MAXIMUM_THREADS": "1",
-        "NUMEXPR_NUM_THREADS": "1",
-    }
-)
 
-from ._version import get_version
+def get_version():
+    """Get MDANSE version.
 
-__version__ = get_version()
+    If not in git, return static version.
+    """
+    if version := os.getenv("MDANSE_GUI_VERSION"):
+        return version
 
-import warnings
+    try:
+        from setuptools_git_versioning import version_from_git
 
-warnings.filterwarnings("ignore")
+        return version_from_git()
+    except Exception:
+        from importlib.metadata import version
 
-import vtk
-
-vtk.vtkObject.GlobalWarningDisplayOff()
+        return version("MDANSE_GUI")

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools", "numpy", "wheel"]
+requires = ["setuptools", "numpy", "wheel", "setuptools-git-versioning>=3.0,<4"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "MDANSE_GUI"
-version = "2.0.1"
 description = 'MDANSE GUI package - the graphical interface for MDANSE'
+dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.10"
 license = {file = "LICENSE"}
@@ -39,7 +39,8 @@ dependencies = [
     "vtk>=9.4.0",
     "PyQt6",
     "PyYAML",
-    "tomlkit"
+    "tomlkit",
+    "setuptools-git-versioning>=3.0,<4",
 ]
 
 [dependency-groups]
@@ -62,6 +63,10 @@ include-package-data = true
 [tool.setuptools.package-data]
 MDANSE_GUI = ["Icons/*.png", "Icons/*.ico", "Icons/*.stl",
               "Resources/*.toml", "Resources/*.png"]
+
+[tool.setuptools-git-versioning]
+enabled = true
+starting_version = "2.0.1"
 
 [project.gui-scripts]
 mdanse_elements_database = "MDANSE_GUI.Scripts.mdanse_elements_database:main"


### PR DESCRIPTION
**Description of work**
- Add dynamic versioning through [`setuptools-git-versioning`](https://setuptools-git-versioning.readthedocs.io/en/stable/index.html)
- Add override with environment variables (`MDANSE_VERSION`, `MDANSE_GUI_VERSION`) to ignore settings
- Use `MDANSE.__version__` globally for internal versioning
- Synchronise MDANSE and MDANSE_GUI versions to 2.0.0rc2

**Fixes**
- Fixes #1141

**To test**
Ensure installs from:
- `pip install git+...`
- `pip install .`
- `pip install -e .`
- `pip install --upgrade .`

-- `git commit --allow-empty -m 'Dummy'`

- `export MDANSE[_GUI]_VERSION`
- `unset MDANSE[_GUI]_VERSION`

All give sensible answers in both `pip`, `uv` and `MDANSE.__version__`

