### PR TITLE
Copy over charges in TrajectoryFilter

### DIFF
--- a/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
+++ b/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
@@ -69,7 +69,7 @@ def assign_molecules_after_atom_selection(
         for val in vals:
             new_cluster = set(val) & selected_idxs
             if new_cluster:
-                new_cluster = sorted([indx_map[i] for i in new_cluster])
+                new_cluster = sorted(indx_map[i] for i in new_cluster)
                 selected_clusters[key].append(new_cluster)
 
     new_cs._clusters = selected_clusters

--- a/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
+++ b/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import copy
 import itertools as it
+from collections import defaultdict
 from collections.abc import Iterable
 from functools import reduce
 from pathlib import Path
@@ -33,6 +34,45 @@ from rdkit.Geometry import Point3D
 from MDANSE.Chemistry import ATOMS_DATABASE
 from MDANSE.Framework.Units import measure
 from MDANSE.MLogging import LOG
+
+
+def assign_molecules_after_atom_selection(
+    selected_indices: Iterable[int], original_cs: ChemicalSystem, new_cs: ChemicalSystem
+):
+    """Create molecule definitions for the output trajectory based on selection.
+
+    Used by jobs which have both an input and an output trajectory.
+    Some molecules may not be completely selected in the input trajectory,
+    but they will keep the original molecule label in the output.
+
+    Parameters
+    ----------
+    selected_indices : Iterable[int]
+        The atom selection of the current analysis job.
+    original_cs : ChemicalSystem
+        The ChemicalSystem of the input trajectory.
+    new_cs : ChemicalSystem
+        The ChemicalSystem of the output trajectory.
+    """
+    selected_idxs = set(selected_indices)
+    indx_map = {j: i for i, j in enumerate(selected_indices)}
+
+    selected_bonds = [
+        (indx_map[i], indx_map[j])
+        for i, j in original_cs._bonds
+        if i in selected_idxs and j in selected_idxs
+    ]
+    new_cs.add_bonds(selected_bonds)
+
+    selected_clusters = defaultdict(list)
+    for key, vals in original_cs._clusters.items():
+        for val in vals:
+            new_cluster = set(val) & selected_idxs
+            if new_cluster:
+                new_cluster = sorted([indx_map[i] for i in new_cluster])
+                selected_clusters[key].append(new_cluster)
+
+    new_cs._clusters = selected_clusters
 
 
 class ChemicalSystem:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -19,7 +19,10 @@ from collections import defaultdict
 
 import numpy as np
 
-from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
+from MDANSE.Chemistry.ChemicalSystem import (
+    ChemicalSystem,
+    assign_molecules_after_atom_selection,
+)
 from MDANSE.Framework.Formats.HDFFormat import write_metadata
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.MolecularDynamics.Configuration import (
@@ -160,25 +163,9 @@ class TrajectoryEditor(IJob):
                 )
             coords = com_conf.contiguous_configuration().coordinates
         else:
-            selected_idxs = set(self._indices)
-            indx_map = {j: i for i, j in enumerate(self._indices)}
-
-            selected_bonds = [
-                (indx_map[i], indx_map[j])
-                for i, j in self._input_chemical_system._bonds
-                if i in selected_idxs and j in selected_idxs
-            ]
-            new_chemical_system.add_bonds(selected_bonds)
-
-            selected_clusters = defaultdict(list)
-            for key, vals in self._input_chemical_system._clusters.items():
-                for val in vals:
-                    new_cluster = set(val) & selected_idxs
-                    if new_cluster:
-                        new_cluster = sorted([indx_map[i] for i in new_cluster])
-                        selected_clusters[key].append(new_cluster)
-
-            new_chemical_system._clusters = selected_clusters
+            assign_molecules_after_atom_selection(
+                self._indices, self._input_chemical_system, new_chemical_system
+            )
 
         # The output trajectory is opened for writing.
         self._output_trajectory = TrajectoryWriter(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -22,7 +22,10 @@ import h5py
 import numpy as np
 from more_itertools import always_iterable
 
-from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
+from MDANSE.Chemistry.ChemicalSystem import (
+    ChemicalSystem,
+    assign_molecules_after_atom_selection,
+)
 from MDANSE.Framework.Formats.HDFFormat import write_metadata
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Signal import FILTER_MAP, Filter
@@ -201,6 +204,11 @@ class TrajectoryFilter(IJob):
             name = "filtered_traj_chemical_system"
         output_chemical_system = ChemicalSystem(name)
         output_chemical_system.initialise_atoms(self._selected_atoms)
+        assign_molecules_after_atom_selection(
+            self.trajectory.atom_indices,
+            self.trajectory.chemical_system,
+            output_chemical_system,
+        )
 
         # Create trajectory writer object
         self._output_trajectory = TrajectoryWriter(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -220,6 +220,18 @@ class TrajectoryFilter(IJob):
             output_trajectory=self._output_trajectory,
         )
 
+        for out_frame, in_frame in enumerate(
+            range(
+                self.configuration["frames"]["first"],
+                self.configuration["frames"]["last"] + 1,
+                self.configuration["frames"]["step"],
+            )
+        ):
+            self._output_trajectory.write_charges(
+                self.trajectory.charges(in_frame)[self.trajectory.atom_indices],
+                out_frame,
+            )
+
         # The input trajectory is closed.
         self.trajectory.close()
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -206,7 +206,7 @@ class TrajectoryFilter(IJob):
         self._output_trajectory = TrajectoryWriter(
             self.configuration["output_files"]["file"],
             output_chemical_system,
-            filter_attributes["n_steps"],
+            self.configuration["frames"]["number"],
             None,
             positions_dtype=self.configuration["output_files"]["dtype"],
             compression=self.configuration["output_files"]["compression"],
@@ -215,7 +215,7 @@ class TrajectoryFilter(IJob):
         # Write trajectory
         write_filtered_trajectory(
             parent_configuration=self.configuration,
-            nsteps=filter_attributes["n_steps"],
+            nsteps=self.configuration["frames"]["number"],
             filtered_coordinates=filtered_coords,
             output_trajectory=self._output_trajectory,
         )


### PR DESCRIPTION
**Description of work**
Adds code to `TrajectoryFilter` to make sure that the charge information included in the input trajectory is written to the output trajectory.

ADDED: 
1. The same functions handles molecule definitions in `TrajectoryEditor` and `TrajectoryFilter`. `TrajectoryFilter` will now copy the existing molecule definitions into the output trajectory.
2. `TrajectoryFilter` should run without errors when not all atoms/frames are selected.

closes #1151
closes #1168

**Fixes**
Add a loop over input frames that passes the charges of selected atoms to TrajectoryWriter.

**To test**
Run TrajectoryFilter on a trajectory containing charge information (DFTB water?). The output trajectory should contain the same charges.
Use atom selection in TrajectoryFilter to select an arbitrary subset of atoms and check if the charges were assigned correctly in the output trajectory.
