### PR TITLE
Reactivate output prediction

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
@@ -23,6 +23,7 @@ class DistHistCutoffConfigurator(RangeConfigurator):
         self.prediction = PredictionSettings(
             key="value",
             label="Interatomic distance",
+            unit="nm",
         )
 
     def configure(self, value):

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
@@ -72,10 +72,8 @@ class HDFTrajectoryWidget(WidgetBase):
         result = self.get_value()
         if not self._configurator.valid:
             self.mark_error(self._configurator.error_status)
+        elif self._configurator.warning_status:
+            self._label.setToolTip(self._configurator.warning_status)
         else:
-            if self._configurator.warning_status:
-                self._label.setToolTip(self._configurator.warning_status)
-            else:
-                self._label.setToolTip(self._tooltip)
-            self.value_updated.emit()
+            self._label.setToolTip(self._tooltip)
         return result

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
@@ -57,7 +57,6 @@ class WidgetBase(QObject):
         Layout to add.
     """
 
-    value_updated = Signal()
     value_changed = Signal()
 
     def __init__(

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -309,7 +309,7 @@ class Action(QWidget):
                     getattr(input_widget._configurator, "preview_output_axis", False)
                 )
                 if self._use_preview and has_preview:
-                    input_widget.value_updated.connect(self.show_output_prediction)
+                    input_widget.value_changed.connect(self.show_output_prediction)
                 LOG.info(f"Set up the right widget for {key}")
             # self.handlers[key] = data_handler
         self._has_been_initialised = True


### PR DESCRIPTION
**Description of work**
Reactivates the output prediction updates.

This PR has been tested on a trajectory with 40000 frames and 34000 atoms to check that the GUI is responsive for large trajectory files.

closes #1167

**Fixes**
1. Connected `WidgetBase.value_changed` to `Action.show_output_prediction` for all widgets.
2. Removed `value_updated` signal altogether.

**To test**
Load a trajectory and pick different Analysis jobs. Check that the output prediction updates when:
1. the input parameters are changed manually,
2. the user picks a different instrument in the combo box.
