### PR TITLE
Change trajectory filter to use sosfiltfilt, all filters to digital, and fix filter helper plots

### DIFF
--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -353,8 +353,7 @@ class Filter(ABC):
             Frequency response over a given range of angular frequencies.
 
         """
-
-        return signal.freqs(*transfer_function, worN=range)
+        return signal.freqz_sos(self.sos, worN=range, fs=self.sample_freq)
 
     def apply(self, input: np.array) -> np.ndarray:
         """Returns the convolution of the digital designed filter with an input signal.
@@ -375,12 +374,7 @@ class Filter(ABC):
             Output signal resulting from convolution with the filter.
 
         """
-        coeffs = (
-            self.to_digital_coeffs()
-            if Filter.Flags.DIGITAL_ONLY not in self.flags
-            else self.coeffs
-        )
-        return signal.filtfilt(coeffs.numerator, coeffs.denominator, input)
+        return signal.sosfiltfilt(self.sos, input)
 
     def to_digital_coeffs(self) -> TransferFunction:
         """Returns the filter instance digital coefficients converted from analog, by performing a bilinear transform.
@@ -397,9 +391,8 @@ class Filter(ABC):
 
         """
         return TransferFunction(
-            *signal.bilinear(
-                self.coeffs.numerator, self.coeffs.denominator, self.sample_freq
-            )
+            self.coeffs.numerator,
+            self.coeffs.denominator,
         )
 
     @property
@@ -768,7 +761,7 @@ class Butterworth(Filter):
 
     """
 
-    flags = {Filter.Flags.DIGITAL_AND_ANALOGUE}
+    flags = {Filter.Flags.DIGITAL_ONLY}
 
     default_settings = {
         "order": {"description": "The order of the filter", "value": 1},
@@ -786,15 +779,15 @@ class Butterworth(Filter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.coeffs = TransferFunction(
-            *signal.butter(
-                self.order,
-                self.cutoff_freq,
-                btype=self.attenuation_type,
-                analog=True,
-                output="ba",
-            )
+        self.sos = signal.butter(
+            self.order,
+            self.cutoff_freq,
+            btype=self.attenuation_type,
+            analog=False,
+            output="sos",
+            fs=self.sample_freq,
         )
+        self.coeffs = TransferFunction(*signal.sos2tf(self.sos))
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
 
 
@@ -808,7 +801,7 @@ class ChebyshevTypeI(Filter):
 
     """
 
-    flags = {Filter.Flags.DIGITAL_AND_ANALOGUE}
+    flags = {Filter.Flags.DIGITAL_ONLY}
 
     default_settings = {
         "order": {"description": "The order of the filter", "value": 1},
@@ -830,16 +823,16 @@ class ChebyshevTypeI(Filter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.coeffs = TransferFunction(
-            *signal.cheby1(
-                self.order,
-                self.max_ripple,
-                self.cutoff_freq,
-                btype=self.attenuation_type,
-                analog=True,
-                output="ba",
-            )
+        self.sos = signal.cheby1(
+            self.order,
+            self.max_ripple,
+            self.cutoff_freq,
+            btype=self.attenuation_type,
+            analog=False,
+            output="sos",
+            fs=self.sample_freq,
         )
+        self.coeffs = TransferFunction(*signal.sos2tf(self.sos))
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
 
 
@@ -853,7 +846,7 @@ class ChebyshevTypeII(Filter):
 
     """
 
-    flags = {Filter.Flags.DIGITAL_AND_ANALOGUE}
+    flags = {Filter.Flags.DIGITAL_ONLY}
 
     default_settings = {
         "order": {"description": "The order of the filter", "value": 1},
@@ -875,16 +868,16 @@ class ChebyshevTypeII(Filter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.coeffs = TransferFunction(
-            *signal.cheby2(
-                self.order,
-                self.min_attenuation,
-                self.cutoff_freq,
-                btype=self.attenuation_type,
-                analog=True,
-                output="ba",
-            )
+        self.sos = signal.cheby2(
+            self.order,
+            self.min_attenuation,
+            self.cutoff_freq,
+            btype=self.attenuation_type,
+            analog=False,
+            output="sos",
+            fs=self.sample_freq,
         )
+        self.coeffs = TransferFunction(*signal.sos2tf(self.sos))
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
 
 
@@ -898,7 +891,7 @@ class Elliptical(Filter):
 
     """
 
-    flags = {Filter.Flags.DIGITAL_AND_ANALOGUE}
+    flags = {Filter.Flags.DIGITAL_ONLY}
 
     default_settings = {
         "order": {"description": "The order of the filter", "value": 1},
@@ -924,17 +917,17 @@ class Elliptical(Filter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.coeffs = TransferFunction(
-            *signal.ellip(
-                self.order,
-                self.max_ripple,
-                self.min_attenuation,
-                self.cutoff_freq,
-                btype=self.attenuation_type,
-                analog=True,
-                output="ba",
-            )
+        self.sos = signal.ellip(
+            self.order,
+            self.max_ripple,
+            self.min_attenuation,
+            self.cutoff_freq,
+            btype=self.attenuation_type,
+            analog=False,
+            output="sos",
+            fs=self.sample_freq,
         )
+        self.coeffs = TransferFunction(*signal.sos2tf(self.sos))
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
 
 
@@ -948,7 +941,7 @@ class Bessel(Filter):
 
     """
 
-    flags = {Filter.Flags.DIGITAL_AND_ANALOGUE}
+    flags = {Filter.Flags.DIGITAL_ONLY}
 
     default_settings = {
         "order": {"description": "The order of the filter", "value": 1},
@@ -971,16 +964,16 @@ class Bessel(Filter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.coeffs = TransferFunction(
-            *signal.bessel(
-                self.order,
-                self.cutoff_freq,
-                btype=self.attenuation_type,
-                analog=True,
-                output="ba",
-                norm=self.norm,
-            )
+        self.sos = signal.bessel(
+            self.order,
+            self.cutoff_freq,
+            btype=self.attenuation_type,
+            norm=self.norm,
+            analog=False,
+            output="sos",
+            fs=self.sample_freq,
         )
+        self.coeffs = TransferFunction(*signal.sos2tf(self.sos))
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
 
 
@@ -1010,37 +1003,12 @@ class Notch(Filter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.coeffs = TransferFunction(
-            *signal.iirnotch(
-                self.fundamental_freq, self.quality_factor, fs=self.sample_freq
-            )
+        b, a = signal.iirnotch(
+            self.fundamental_freq, self.quality_factor, fs=self.sample_freq
         )
+        self.sos = signal.tf2sos(a, b, analog=False)
+        self.coeffs = TransferFunction(b, a)
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
-
-    def compute_frequencies(
-        self, transfer_function: TransferFunction, range: np.ndarray
-    ):
-        """Computes the frequency magnitudes over given cyclic frequency range, from the filter transfer function.
-
-        See Also
-        ________
-        scipy.signal.freqz :
-            https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.freqz.html
-
-        Parameters
-        ----------
-        transfer_function : TransferFunction
-            Numerator and denominator of the filter transfer function.
-        range : np.ndarray
-            Range of frequency values over which to compute.
-
-        Returns
-        -------
-        np.ndarray
-            Frequency response over a given range of cyclic frequencies.
-        """
-
-        return signal.freqz(*transfer_function, worN=range, fs=self.sample_freq)
 
 
 class Peak(Filter):
@@ -1069,38 +1037,12 @@ class Peak(Filter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.coeffs = TransferFunction(
-            *signal.iirpeak(
-                self.fundamental_freq, self.quality_factor, fs=self.sample_freq
-            )
+        b, a = signal.iirpeak(
+            self.fundamental_freq, self.quality_factor, fs=self.sample_freq
         )
+        self.sos = signal.tf2sos(a, b, analog=False)
+        self.coeffs = TransferFunction(b, a)
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
-
-    def compute_frequencies(
-        self, transfer_function: TransferFunction, range: np.ndarray
-    ):
-        """Computes the frequency magnitudes over given cyclic frequency range, from the filter transfer function.
-
-        See Also
-        ________
-        scipy.signal.freqz :
-            https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.freqz.html
-
-        Parameters
-        ----------
-        transfer_function : TransferFunction)
-            Numerator and denominator of the filter transfer function.
-        range : np.ndarray
-            Range of frequency values over which to compute.
-
-        Returns
-        -------
-        np.ndarray
-            Frequency response over a given range of cyclic frequencies.
-
-        """
-
-        return signal.freqz(*transfer_function, worN=range, fs=self.sample_freq)
 
 
 class Comb(Filter):
@@ -1139,42 +1081,16 @@ class Comb(Filter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.coeffs = TransferFunction(
-            *signal.iircomb(
-                self.fundamental_freq,
-                self.quality_factor,
-                ftype=self.comb_type,
-                pass_zero=self.pass_zero,
-                fs=self.sample_freq,
-            )
+        b, a = signal.iircomb(
+            self.fundamental_freq,
+            self.quality_factor,
+            ftype=self.comb_type,
+            pass_zero=self.pass_zero,
+            fs=self.sample_freq,
         )
+        self.sos = signal.tf2sos(a, b, analog=False)
+        self.coeffs = TransferFunction(b, a)
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
-
-    def compute_frequencies(
-        self, transfer_function: TransferFunction, range: np.ndarray
-    ):
-        """Computes the frequency magnitudes over given cyclic frequency range, from the filter transfer function.
-
-        See Also
-        ________
-        scipy.signal.freqz :
-            https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.freqz.html
-
-        Parameters
-        ----------
-        transfer_function : TransferFunction
-            Numerator and denominator of the filter transfer function.
-        range : np.ndarray
-            Range of frequency values over which to compute.
-
-        Returns
-        -------
-        np.ndarray
-            Frequency response over a given range of cyclic frequencies.
-
-        """
-
-        return signal.freqz(*transfer_function, worN=range, fs=self.sample_freq)
 
 
 FILTERS = (

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -258,8 +258,8 @@ def get_spectrum(signal, window=None, timeStep=1.0, axis=0, fft="fft"):
     return fftSignal.real
 
 
-# Default filter cutoff frequency
-DEFAULT_FILTER_CUTOFF = 25.0
+# Fraction of the sampling frequency
+DEFAULT_FREQ_RATIO = 0.25
 
 
 class TransferFunction(NamedTuple):
@@ -774,12 +774,15 @@ class Butterworth(Filter):
         },
         "cutoff_freq": {
             "description": "Cutoff frequency/vibrational energy (may be a 2-length array if bandpass/stop)",
-            "value": DEFAULT_FILTER_CUTOFF,
+            "value": None,
         },
     }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        if self.cutoff_freq is None:
+            self.cutoff_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         self.sos = signal.butter(
             self.order,
@@ -818,12 +821,15 @@ class ChebyshevTypeI(Filter):
         },
         "cutoff_freq": {
             "description": "Cutoff frequency/vibrational energy (may be a 2-length array if bandpass/stop)",
-            "value": DEFAULT_FILTER_CUTOFF,
+            "value": None,
         },
     }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        if self.cutoff_freq is None:
+            self.cutoff_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         self.sos = signal.cheby1(
             self.order,
@@ -863,12 +869,15 @@ class ChebyshevTypeII(Filter):
         },
         "cutoff_freq": {
             "description": "Cutoff frequency/vibrational energy (may be a 2-length array if bandpass/stop)",
-            "value": DEFAULT_FILTER_CUTOFF,
+            "value": None,
         },
     }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        if self.cutoff_freq is None:
+            self.cutoff_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         self.sos = signal.cheby2(
             self.order,
@@ -912,12 +921,15 @@ class Elliptical(Filter):
         },
         "cutoff_freq": {
             "description": "Cutoff frequency/vibrational energy (may be a 2-length array if bandpass/stop)",
-            "value": DEFAULT_FILTER_CUTOFF,
+            "value": None,
         },
     }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        if self.cutoff_freq is None:
+            self.cutoff_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         self.sos = signal.ellip(
             self.order,
@@ -959,12 +971,15 @@ class Bessel(Filter):
         },
         "cutoff_freq": {
             "description": "Cutoff frequency/vibrational energy (may be a 2-length array if bandpass/stop)",
-            "value": DEFAULT_FILTER_CUTOFF,
+            "value": None,
         },
     }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        if self.cutoff_freq is None:
+            self.cutoff_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         self.sos = signal.bessel(
             self.order,
@@ -994,7 +1009,7 @@ class Notch(Filter):
     default_settings = {
         "fundamental_freq": {
             "description": "Spacing between filter peaks (value must satisfy 0 < w0 < nyquist)",
-            "value": DEFAULT_FILTER_CUTOFF,
+            "value": None,
         },
         "quality_factor": {
             "description": "Specifies bandwidth, proportional to time taken for filter to decay by a factor of 1/e",
@@ -1004,6 +1019,9 @@ class Notch(Filter):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        if self.fundamental_freq is None:
+            self.fundamental_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         b, a = signal.iirnotch(
             self.fundamental_freq, self.quality_factor, fs=self.sample_freq
@@ -1028,7 +1046,7 @@ class Peak(Filter):
     default_settings = {
         "fundamental_freq": {
             "description": "Spacing between filter peaks (value must satisfy 0 < w0 < nyquist)",
-            "value": DEFAULT_FILTER_CUTOFF,
+            "value": None,
         },
         "quality_factor": {
             "description": "Specifies bandwidth, proportional to time taken for filter to decay by a factor of 1/e",
@@ -1038,6 +1056,9 @@ class Peak(Filter):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        if self.fundamental_freq is None:
+            self.fundamental_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         b, a = signal.iirpeak(
             self.fundamental_freq, self.quality_factor, fs=self.sample_freq
@@ -1062,7 +1083,7 @@ class Comb(Filter):
     default_settings = {
         "fundamental_freq": {
             "description": "Spacing between filter peaks (value must evenly divide sample frequency)",
-            "value": DEFAULT_FILTER_CUTOFF,
+            "value": None,
         },
         "quality_factor": {
             "description": "Specifies bandwidth, proportional to time taken for filter to decay by a factor of 1/e",
@@ -1082,6 +1103,9 @@ class Comb(Filter):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        if self.fundamental_freq is None:
+            self.fundamental_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         b, a = signal.iircomb(
             self.fundamental_freq,

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -1006,7 +1006,7 @@ class Notch(Filter):
         b, a = signal.iirnotch(
             self.fundamental_freq, self.quality_factor, fs=self.sample_freq
         )
-        self.sos = signal.tf2sos(a, b, analog=False)
+        self.sos = signal.tf2sos(b, a, analog=False)
         self.coeffs = TransferFunction(b, a)
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
 
@@ -1040,7 +1040,7 @@ class Peak(Filter):
         b, a = signal.iirpeak(
             self.fundamental_freq, self.quality_factor, fs=self.sample_freq
         )
-        self.sos = signal.tf2sos(a, b, analog=False)
+        self.sos = signal.tf2sos(b, a, analog=False)
         self.coeffs = TransferFunction(b, a)
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
 
@@ -1088,7 +1088,7 @@ class Comb(Filter):
             pass_zero=self.pass_zero,
             fs=self.sample_freq,
         )
-        self.sos = signal.tf2sos(a, b, analog=False)
+        self.sos = signal.tf2sos(b, a, analog=False)
         self.coeffs = TransferFunction(b, a)
         self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
 

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -258,8 +258,8 @@ def get_spectrum(signal, window=None, timeStep=1.0, axis=0, fft="fft"):
     return fftSignal.real
 
 
-# Fraction of the sampling frequency
-DEFAULT_FREQ_RATIO = 0.25
+# Default filter cutoff frequency
+DEFAULT_FILTER_CUTOFF = 0.0001
 
 
 class TransferFunction(NamedTuple):
@@ -774,15 +774,12 @@ class Butterworth(Filter):
         },
         "cutoff_freq": {
             "description": "Cutoff frequency/vibrational energy (may be a 2-length array if bandpass/stop)",
-            "value": None,
+            "value": DEFAULT_FILTER_CUTOFF,
         },
     }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.cutoff_freq is None:
-            self.cutoff_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         self.sos = signal.butter(
             self.order,
@@ -821,15 +818,12 @@ class ChebyshevTypeI(Filter):
         },
         "cutoff_freq": {
             "description": "Cutoff frequency/vibrational energy (may be a 2-length array if bandpass/stop)",
-            "value": None,
+            "value": DEFAULT_FILTER_CUTOFF,
         },
     }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.cutoff_freq is None:
-            self.cutoff_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         self.sos = signal.cheby1(
             self.order,
@@ -869,15 +863,12 @@ class ChebyshevTypeII(Filter):
         },
         "cutoff_freq": {
             "description": "Cutoff frequency/vibrational energy (may be a 2-length array if bandpass/stop)",
-            "value": None,
+            "value": DEFAULT_FILTER_CUTOFF,
         },
     }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.cutoff_freq is None:
-            self.cutoff_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         self.sos = signal.cheby2(
             self.order,
@@ -921,15 +912,12 @@ class Elliptical(Filter):
         },
         "cutoff_freq": {
             "description": "Cutoff frequency/vibrational energy (may be a 2-length array if bandpass/stop)",
-            "value": None,
+            "value": DEFAULT_FILTER_CUTOFF,
         },
     }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.cutoff_freq is None:
-            self.cutoff_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         self.sos = signal.ellip(
             self.order,
@@ -971,15 +959,12 @@ class Bessel(Filter):
         },
         "cutoff_freq": {
             "description": "Cutoff frequency/vibrational energy (may be a 2-length array if bandpass/stop)",
-            "value": None,
+            "value": DEFAULT_FILTER_CUTOFF,
         },
     }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.cutoff_freq is None:
-            self.cutoff_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         self.sos = signal.bessel(
             self.order,
@@ -1009,7 +994,7 @@ class Notch(Filter):
     default_settings = {
         "fundamental_freq": {
             "description": "Spacing between filter peaks (value must satisfy 0 < w0 < nyquist)",
-            "value": None,
+            "value": DEFAULT_FILTER_CUTOFF,
         },
         "quality_factor": {
             "description": "Specifies bandwidth, proportional to time taken for filter to decay by a factor of 1/e",
@@ -1019,9 +1004,6 @@ class Notch(Filter):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.fundamental_freq is None:
-            self.fundamental_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         b, a = signal.iirnotch(
             self.fundamental_freq, self.quality_factor, fs=self.sample_freq
@@ -1046,7 +1028,7 @@ class Peak(Filter):
     default_settings = {
         "fundamental_freq": {
             "description": "Spacing between filter peaks (value must satisfy 0 < w0 < nyquist)",
-            "value": None,
+            "value": DEFAULT_FILTER_CUTOFF,
         },
         "quality_factor": {
             "description": "Specifies bandwidth, proportional to time taken for filter to decay by a factor of 1/e",
@@ -1056,9 +1038,6 @@ class Peak(Filter):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.fundamental_freq is None:
-            self.fundamental_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         b, a = signal.iirpeak(
             self.fundamental_freq, self.quality_factor, fs=self.sample_freq
@@ -1083,7 +1062,7 @@ class Comb(Filter):
     default_settings = {
         "fundamental_freq": {
             "description": "Spacing between filter peaks (value must evenly divide sample frequency)",
-            "value": None,
+            "value": DEFAULT_FILTER_CUTOFF,
         },
         "quality_factor": {
             "description": "Specifies bandwidth, proportional to time taken for filter to decay by a factor of 1/e",
@@ -1103,9 +1082,6 @@ class Comb(Filter):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        if self.fundamental_freq is None:
-            self.fundamental_freq = DEFAULT_FREQ_RATIO * self.sample_freq
 
         b, a = signal.iircomb(
             self.fundamental_freq,

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -331,20 +331,16 @@ class Filter(ABC):
         self.sample_freq = 1 / kwargs.pop("time_step_ps")
         self.set_filter_attributes(kwargs)
 
-    def compute_frequencies(
-        self, transfer_function: TransferFunction, range: np.ndarray
-    ):
-        """Computes the frequency magnitudes over given angular frequency range, from the filter transfer function.
+    def compute_frequencies(self, range: np.ndarray):
+        """Computes the frequency magnitudes over given cyclic frequency range, from the filter transfer function.
 
         See Also
         ________
-        scipy.signal.freqs :
-            https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.freqs.html
+        scipy.signal.freqz_sos :
+            https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.freqz_sos.html
 
         Parameters
         ----------
-        transfer_function : TransferFunction
-            Numerator and denominator of the filter transfer function.
         range : np.ndarray
             Range of frequency values over which to compute.
 
@@ -361,8 +357,8 @@ class Filter(ABC):
 
         See Also
         ________
-        scipy.signal.filtfilt:
-            https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.filtfilt.html
+        scipy.signal.sosfiltfilt:
+            https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.sosfiltfilt.html
 
         Parameters
         ----------
@@ -409,23 +405,17 @@ class Filter(ABC):
         """
         return self._freq_response
 
-    @freq_response.setter
-    def freq_response(
-        self, params: tuple[TransferFunction, FrequencyRangeMethod]
-    ) -> None:
+    def set_freq_response(self, method: FrequencyRangeMethod) -> None:
         """Calculates the frequency response of the filter from the filter's transfer function numerator and denominator
         coefficients.
 
         Parameters
         ----------
-        params : tuple[TransferFunction, FrequencyRangeMethod]
-            Tuple contains the following elements:
-                - the rational polynomial expression for the filter transfer function, in terms of its numerator and
-                denominator coefficients.
-                - the method by which to compute the frequency range for displaying the filter.
+        method : FrequencyRangeMethod
+            The rational polynomial expression for the filter transfer function,
+            in terms of its numerator and denominator coefficients.
 
         """
-        expr, method = params
         units = (
             Filter.FrequencyUnits.CYCLIC
             if Filter.Flags.DIGITAL_ONLY in self.flags
@@ -453,9 +443,7 @@ class Filter(ABC):
             )
 
         # Compute filter response around frequencies given in range
-        response = self.compute_frequencies(
-            transfer_function=expr, range=np.abs(freq_range)
-        )
+        response = self.compute_frequencies(range=np.abs(freq_range))
         self._freq_response = FrequencyDomain(*response)
 
     @classmethod
@@ -790,7 +778,7 @@ class Butterworth(Filter):
             fs=self.sample_freq,
         )
         self.coeffs = TransferFunction(*signal.sos2tf(self.sos))
-        self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
+        self.set_freq_response(Filter.FrequencyRangeMethod.FFT)
 
 
 class ChebyshevTypeI(Filter):
@@ -835,7 +823,7 @@ class ChebyshevTypeI(Filter):
             fs=self.sample_freq,
         )
         self.coeffs = TransferFunction(*signal.sos2tf(self.sos))
-        self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
+        self.set_freq_response(Filter.FrequencyRangeMethod.FFT)
 
 
 class ChebyshevTypeII(Filter):
@@ -880,7 +868,7 @@ class ChebyshevTypeII(Filter):
             fs=self.sample_freq,
         )
         self.coeffs = TransferFunction(*signal.sos2tf(self.sos))
-        self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
+        self.set_freq_response(Filter.FrequencyRangeMethod.FFT)
 
 
 class Elliptical(Filter):
@@ -930,7 +918,7 @@ class Elliptical(Filter):
             fs=self.sample_freq,
         )
         self.coeffs = TransferFunction(*signal.sos2tf(self.sos))
-        self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
+        self.set_freq_response(Filter.FrequencyRangeMethod.FFT)
 
 
 class Bessel(Filter):
@@ -976,7 +964,7 @@ class Bessel(Filter):
             fs=self.sample_freq,
         )
         self.coeffs = TransferFunction(*signal.sos2tf(self.sos))
-        self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
+        self.set_freq_response(Filter.FrequencyRangeMethod.FFT)
 
 
 class Notch(Filter):
@@ -1010,7 +998,7 @@ class Notch(Filter):
         )
         self.sos = signal.tf2sos(b, a, analog=False)
         self.coeffs = TransferFunction(b, a)
-        self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
+        self.set_freq_response(Filter.FrequencyRangeMethod.FFT)
 
 
 class Peak(Filter):
@@ -1044,7 +1032,7 @@ class Peak(Filter):
         )
         self.sos = signal.tf2sos(b, a, analog=False)
         self.coeffs = TransferFunction(b, a)
-        self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
+        self.set_freq_response(Filter.FrequencyRangeMethod.FFT)
 
 
 class Comb(Filter):
@@ -1092,7 +1080,7 @@ class Comb(Filter):
         )
         self.sos = signal.tf2sos(b, a, analog=False)
         self.coeffs = TransferFunction(b, a)
-        self.freq_response = (self.coeffs, Filter.FrequencyRangeMethod.FFT)
+        self.set_freq_response(Filter.FrequencyRangeMethod.FFT)
 
 
 FILTERS = (

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -331,7 +331,7 @@ class Filter(ABC):
         self.sample_freq = 1 / kwargs.pop("time_step_ps")
         self.set_filter_attributes(kwargs)
 
-    def compute_frequencies(self, range: np.ndarray):
+    def compute_frequencies(self, filt_range: np.ndarray):
         """Computes the frequency magnitudes over given cyclic frequency range, from the filter transfer function.
 
         See Also
@@ -341,7 +341,7 @@ class Filter(ABC):
 
         Parameters
         ----------
-        range : np.ndarray
+        filt_range : np.ndarray
             Range of frequency values over which to compute.
 
         Returns
@@ -350,7 +350,7 @@ class Filter(ABC):
             Frequency response over a given range of angular frequencies.
 
         """
-        return signal.freqz_sos(self.sos, worN=range, fs=self.sample_freq)
+        return signal.freqz_sos(self.sos, worN=filt_range, fs=self.sample_freq)
 
     def apply(self, input: np.array) -> np.ndarray:
         """Returns the convolution of the digital designed filter with an input signal.
@@ -443,7 +443,7 @@ class Filter(ABC):
             )
 
         # Compute filter response around frequencies given in range
-        response = self.compute_frequencies(range=np.abs(freq_range))
+        response = self.compute_frequencies(filt_range=np.abs(freq_range))
         self._freq_response = FrequencyDomain(*response)
 
     @classmethod

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -319,6 +319,7 @@ class Filter(ABC):
         DIGITAL_ONLY: int = 0
         DIGITAL_AND_ANALOGUE: int = 1
         FUNDAMENTAL_EVENLY_DIVIDES_FS: int = 2
+        BOUNDED_FILTER: int = 3
 
     @abstractmethod
     def __init__(self, **kwargs):
@@ -391,8 +392,9 @@ class Filter(ABC):
 
         """
         return TransferFunction(
-            self.coeffs.numerator,
-            self.coeffs.denominator,
+            *signal.bilinear(
+                self.coeffs.numerator, self.coeffs.denominator, self.sample_freq
+            )
         )
 
     @property
@@ -761,7 +763,7 @@ class Butterworth(Filter):
 
     """
 
-    flags = {Filter.Flags.DIGITAL_ONLY}
+    flags = {Filter.Flags.DIGITAL_ONLY, Filter.Flags.BOUNDED_FILTER}
 
     default_settings = {
         "order": {"description": "The order of the filter", "value": 1},
@@ -801,7 +803,7 @@ class ChebyshevTypeI(Filter):
 
     """
 
-    flags = {Filter.Flags.DIGITAL_ONLY}
+    flags = {Filter.Flags.DIGITAL_ONLY, Filter.Flags.BOUNDED_FILTER}
 
     default_settings = {
         "order": {"description": "The order of the filter", "value": 1},
@@ -846,7 +848,7 @@ class ChebyshevTypeII(Filter):
 
     """
 
-    flags = {Filter.Flags.DIGITAL_ONLY}
+    flags = {Filter.Flags.DIGITAL_ONLY, Filter.Flags.BOUNDED_FILTER}
 
     default_settings = {
         "order": {"description": "The order of the filter", "value": 1},
@@ -891,7 +893,7 @@ class Elliptical(Filter):
 
     """
 
-    flags = {Filter.Flags.DIGITAL_ONLY}
+    flags = {Filter.Flags.DIGITAL_ONLY, Filter.Flags.BOUNDED_FILTER}
 
     default_settings = {
         "order": {"description": "The order of the filter", "value": 1},
@@ -941,7 +943,7 @@ class Bessel(Filter):
 
     """
 
-    flags = {Filter.Flags.DIGITAL_ONLY}
+    flags = {Filter.Flags.DIGITAL_ONLY, Filter.Flags.BOUNDED_FILTER}
 
     default_settings = {
         "order": {"description": "The order of the filter", "value": 1},

--- a/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
+++ b/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
@@ -477,10 +477,7 @@ def test_convolution(
 
     # Supply frequencies against which to calculate response H(w)
     filter_object.custom_freq_range = u_x_axis
-    filter_object.freq_response = (
-        filter_object.coeffs,
-        Filter.FrequencyRangeMethod.CUSTOM,
-    )
+    filter_object.set_freq_response(Filter.FrequencyRangeMethod.CUSTOM)
 
     # Resample H(w) to length of U(w)
     hw = np.abs(scipy.signal.resample(filter_object.freq_response.magnitudes, len(uw)))

--- a/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
+++ b/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
@@ -23,6 +23,9 @@ GLYCYL_L_ALANINE_TRAJ = "glycyl_l_alanine_charmm_unfiltered.mdt"
 SUFFIX = "_unfiltered_power_spectrum"
 
 
+TWOPI = 2 * np.pi
+
+
 def safe_mda(filename):
     ext = filename.suffix
     stripped = filename.with_suffix("").name
@@ -247,7 +250,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "time_step_ps": 0.005,
                 "order": 1,
                 "attenuation_type": "lowpass",
-                "cutoff_freq": 19.635 / (2 * np.pi),
+                "cutoff_freq": 19.635 / TWOPI,
             },
         },
         {
@@ -261,7 +264,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "time_step_ps": 0.005,
                 "order": 1,
                 "attenuation_type": "highpass",
-                "cutoff_freq": 31.416 / (2 * np.pi),
+                "cutoff_freq": 31.416 / TWOPI,
             },
         },
         {
@@ -276,7 +279,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 1,
                 "min_attenuation": 12.7,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [27.489000000000004 / (2 * np.pi), 376.992 / (2 * np.pi)],
+                "cutoff_freq": [27.489000000000004 / TWOPI, 376.992 / TWOPI],
             },
         },
         {
@@ -291,7 +294,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 1,
                 "norm": "phase",
                 "attenuation_type": "bandstop",
-                "cutoff_freq": [27.489000000000004 / (2 * np.pi), 70.686 / (2 * np.pi)],
+                "cutoff_freq": [27.489000000000004 / TWOPI, 70.686 / TWOPI],
             },
         },
         {
@@ -306,7 +309,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 2,
                 "min_attenuation": 20.0,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [15.708000000000002 / (2 * np.pi), 145.299 / (2 * np.pi)],
+                "cutoff_freq": [15.708000000000002 / TWOPI, 145.299 / TWOPI],
             },
         },
         {
@@ -321,7 +324,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 2,
                 "min_attenuation": 2.0,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [15.708000000000002 / (2 * np.pi), 145.299 / (2 * np.pi)],
+                "cutoff_freq": [15.708000000000002 / TWOPI, 145.299 / TWOPI],
             },
         },
         {
@@ -377,7 +380,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 1,
                 "min_attenuation": 10.0,
                 "attenuation_type": "bandstop",
-                "cutoff_freq": [0.00031415 / (2 * np.pi), 0.00043981 / (2 * np.pi)],
+                "cutoff_freq": [0.00031415 / TWOPI, 0.00043981 / TWOPI],
             },
         },
         {
@@ -393,7 +396,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "max_ripple": 1.0,
                 "min_attenuation": 20.0,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [0.00006283 / (2 * np.pi), 0.00018849 / (2 * np.pi)],
+                "cutoff_freq": [0.00006283 / TWOPI, 0.00018849 / TWOPI],
             },
         },
         {
@@ -408,7 +411,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 1,
                 "max_ripple": 5.0,
                 "attenuation_type": "bandstop",
-                "cutoff_freq": [0.00006283 / (2 * np.pi), 0.00012566 / (2 * np.pi)],
+                "cutoff_freq": [0.00006283 / TWOPI, 0.00012566 / TWOPI],
             },
         },
     ],
@@ -532,7 +535,7 @@ def test_convolution(
             "attributes": {
                 "n_steps": 25,
                 "time_step_ps": 4000.0,
-                "cutoff_freq": 0.000377 / (2 * np.pi),
+                "cutoff_freq": 0.000377 / TWOPI,
             },
         },
         {
@@ -542,7 +545,7 @@ def test_convolution(
             "attributes": {
                 "n_steps": 25,
                 "time_step_ps": 4000.0,
-                "cutoff_freq": 0.000377 / (2 * np.pi),
+                "cutoff_freq": 0.000377 / TWOPI,
             },
         },
         {
@@ -552,7 +555,7 @@ def test_convolution(
             "attributes": {
                 "n_steps": 25,
                 "time_step_ps": 4000.0,
-                "cutoff_freq": 0.000377 / (2 * np.pi),
+                "cutoff_freq": 0.000377 / TWOPI,
                 "min_attenuation": 10.0,
             },
         },
@@ -564,7 +567,7 @@ def test_convolution(
                 "n_steps": 25,
                 "time_step_ps": 4000.0,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [0.000377 / (2 * np.pi), 0.000577 / (2 * np.pi)],
+                "cutoff_freq": [0.000377 / TWOPI, 0.000577 / TWOPI],
             },
         },
         {
@@ -575,7 +578,7 @@ def test_convolution(
                 "n_steps": 25,
                 "time_step_ps": 4000.0,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [0.000377 / (2 * np.pi), 0.000577 / (2 * np.pi)],
+                "cutoff_freq": [0.000377 / TWOPI, 0.000577 / TWOPI],
             },
         },
         {
@@ -652,7 +655,7 @@ def test_default_settings(
                 "time_step_ps": 0.005,
                 "order": 1,
                 "attenuation_type": "highpass",
-                "cutoff_freq": 19.635 / (2 * np.pi),
+                "cutoff_freq": 19.635 / TWOPI,
             },
         },
         {
@@ -666,7 +669,7 @@ def test_default_settings(
                 "time_step_ps": 0.005,
                 "order": 2,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [19.635 / (2 * np.pi), 31.416 / (2 * np.pi)],
+                "cutoff_freq": [19.635 / TWOPI, 31.416 / TWOPI],
             },
         },
         {
@@ -681,7 +684,7 @@ def test_default_settings(
                 "order": 1,
                 "min_attenuation": 12.7,
                 "attenuation_type": "highpass",
-                "cutoff_freq": 376.992 / (2 * np.pi),
+                "cutoff_freq": 376.992 / TWOPI,
             },
         },
         {
@@ -766,7 +769,7 @@ def test_default_settings(
                 "order": 4,
                 "min_attenuation": 10.0,
                 "attenuation_type": "highpass",
-                "cutoff_freq": 0.00006283 / (2 * np.pi),
+                "cutoff_freq": 0.00006283 / TWOPI,
             },
         },
         {
@@ -781,7 +784,7 @@ def test_default_settings(
                 "order": 2,
                 "min_attenuation": 0.1,
                 "attenuation_type": "lowpass",
-                "cutoff_freq": 0.00006283 / (2 * np.pi),
+                "cutoff_freq": 0.00006283 / TWOPI,
             },
         },
         {
@@ -796,7 +799,7 @@ def test_default_settings(
                 "order": 1,
                 "max_ripple": 0.4,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [0.00018849 / (2 * np.pi), 0.00062830 / (2 * np.pi)],
+                "cutoff_freq": [0.00018849 / TWOPI, 0.00062830 / TWOPI],
             },
         },
     ],

--- a/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
+++ b/MDANSE/Tests/UnitTests/TrajectoryFilter/test_workflow.py
@@ -247,7 +247,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "time_step_ps": 0.005,
                 "order": 1,
                 "attenuation_type": "lowpass",
-                "cutoff_freq": 19.635,
+                "cutoff_freq": 19.635 / (2 * np.pi),
             },
         },
         {
@@ -261,7 +261,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "time_step_ps": 0.005,
                 "order": 1,
                 "attenuation_type": "highpass",
-                "cutoff_freq": 31.416,
+                "cutoff_freq": 31.416 / (2 * np.pi),
             },
         },
         {
@@ -276,7 +276,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 1,
                 "min_attenuation": 12.7,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [27.489000000000004, 376.992],
+                "cutoff_freq": [27.489000000000004 / (2 * np.pi), 376.992 / (2 * np.pi)],
             },
         },
         {
@@ -291,7 +291,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 1,
                 "norm": "phase",
                 "attenuation_type": "bandstop",
-                "cutoff_freq": [27.489000000000004, 70.686],
+                "cutoff_freq": [27.489000000000004 / (2 * np.pi), 70.686 / (2 * np.pi)],
             },
         },
         {
@@ -306,7 +306,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 2,
                 "min_attenuation": 20.0,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [15.708000000000002, 145.299],
+                "cutoff_freq": [15.708000000000002 / (2 * np.pi), 145.299 / (2 * np.pi)],
             },
         },
         {
@@ -321,7 +321,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 2,
                 "min_attenuation": 2.0,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [15.708000000000002, 145.299],
+                "cutoff_freq": [15.708000000000002 / (2 * np.pi), 145.299 / (2 * np.pi)],
             },
         },
         {
@@ -377,7 +377,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 1,
                 "min_attenuation": 10.0,
                 "attenuation_type": "bandstop",
-                "cutoff_freq": [0.00031415, 0.00043981],
+                "cutoff_freq": [0.00031415 / (2 * np.pi), 0.00043981 / (2 * np.pi)],
             },
         },
         {
@@ -393,7 +393,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "max_ripple": 1.0,
                 "min_attenuation": 20.0,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [0.00006283, 0.00018849],
+                "cutoff_freq": [0.00006283 / (2 * np.pi), 0.00018849 / (2 * np.pi)],
             },
         },
         {
@@ -408,7 +408,7 @@ def glycl_l_alanine_spectrum_clean(tmp_path_factory):
                 "order": 1,
                 "max_ripple": 5.0,
                 "attenuation_type": "bandstop",
-                "cutoff_freq": [0.00006283, 0.00012566],
+                "cutoff_freq": [0.00006283 / (2 * np.pi), 0.00012566 / (2 * np.pi)],
             },
         },
     ],
@@ -535,7 +535,7 @@ def test_convolution(
             "attributes": {
                 "n_steps": 25,
                 "time_step_ps": 4000.0,
-                "cutoff_freq": 0.000377,
+                "cutoff_freq": 0.000377 / (2 * np.pi),
             },
         },
         {
@@ -545,7 +545,7 @@ def test_convolution(
             "attributes": {
                 "n_steps": 25,
                 "time_step_ps": 4000.0,
-                "cutoff_freq": 0.000377,
+                "cutoff_freq": 0.000377 / (2 * np.pi),
             },
         },
         {
@@ -555,7 +555,7 @@ def test_convolution(
             "attributes": {
                 "n_steps": 25,
                 "time_step_ps": 4000.0,
-                "cutoff_freq": 0.000377,
+                "cutoff_freq": 0.000377 / (2 * np.pi),
                 "min_attenuation": 10.0,
             },
         },
@@ -567,7 +567,7 @@ def test_convolution(
                 "n_steps": 25,
                 "time_step_ps": 4000.0,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [0.000377, 0.000577],
+                "cutoff_freq": [0.000377 / (2 * np.pi), 0.000577 / (2 * np.pi)],
             },
         },
         {
@@ -578,7 +578,7 @@ def test_convolution(
                 "n_steps": 25,
                 "time_step_ps": 4000.0,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [0.000377, 0.000577],
+                "cutoff_freq": [0.000377 / (2 * np.pi), 0.000577 / (2 * np.pi)],
             },
         },
         {
@@ -655,7 +655,7 @@ def test_default_settings(
                 "time_step_ps": 0.005,
                 "order": 1,
                 "attenuation_type": "highpass",
-                "cutoff_freq": 19.635,
+                "cutoff_freq": 19.635 / (2 * np.pi),
             },
         },
         {
@@ -669,7 +669,7 @@ def test_default_settings(
                 "time_step_ps": 0.005,
                 "order": 2,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [19.635, 31.416],
+                "cutoff_freq": [19.635 / (2 * np.pi), 31.416 / (2 * np.pi)],
             },
         },
         {
@@ -684,7 +684,7 @@ def test_default_settings(
                 "order": 1,
                 "min_attenuation": 12.7,
                 "attenuation_type": "highpass",
-                "cutoff_freq": 376.992,
+                "cutoff_freq": 376.992 / (2 * np.pi),
             },
         },
         {
@@ -769,7 +769,7 @@ def test_default_settings(
                 "order": 4,
                 "min_attenuation": 10.0,
                 "attenuation_type": "highpass",
-                "cutoff_freq": 0.00006283,
+                "cutoff_freq": 0.00006283 / (2 * np.pi),
             },
         },
         {
@@ -784,7 +784,7 @@ def test_default_settings(
                 "order": 2,
                 "min_attenuation": 0.1,
                 "attenuation_type": "lowpass",
-                "cutoff_freq": 0.00006283,
+                "cutoff_freq": 0.00006283 / (2 * np.pi),
             },
         },
         {
@@ -799,7 +799,7 @@ def test_default_settings(
                 "order": 1,
                 "max_ripple": 0.4,
                 "attenuation_type": "bandpass",
-                "cutoff_freq": [0.00018849, 0.00062830],
+                "cutoff_freq": [0.00018849 / (2 * np.pi), 0.00062830 / (2 * np.pi)],
             },
         },
     ],

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -1192,7 +1192,7 @@ class FilterDesigner(QDialog):
         if self.current_filter_units() == Filter.FrequencyUnits.CYCLIC:
             freqs /= 2 * np.pi
 
-        return (freqs, normalised, normalised * attenuation(freqs))
+        return (freqs, normalised, normalised * abs(attenuation(freqs))**4)
 
     def create_settings_layout(self, widget_area: QVBoxLayout) -> None:
         """Create the filter settings vertical layout.
@@ -1317,7 +1317,7 @@ class FilterDesigner(QDialog):
         axes = self._figure.add_axes([0.1, 0.1, 0.8, 0.8])
         axes.plot(
             x,
-            20 * np.log10(abs(y)) if db_response else y,
+            20 * np.log10(abs(y)**4) if db_response else abs(y)**4,
             label="Filter response",
         )
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -1177,7 +1177,7 @@ class FilterDesigner(QDialog):
             freqs.max(),
             len(response.frequencies),
         )
-        tr_filter.freq_response = (tr_filter.coeffs, Filter.FrequencyRangeMethod.CUSTOM)
+        tr_filter.set_freq_response(Filter.FrequencyRangeMethod.CUSTOM)
 
         # Normalise trajectory power spectrum (y-axis)
         normalised = values / np.max(values)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -1326,13 +1326,13 @@ class FilterDesigner(QDialog):
             psx, ps, attenuated_ps = trajectory_power_spectrum
             axes.plot(
                 psx,
-                20 * np.log10(abs(ps)) if db_response else ps,
+                20 * np.log10(ps) if db_response else ps,
                 label="Trajectory response",
                 color="grey",
             )
             axes.plot(
                 psx,
-                20 * np.log10(abs(attenuated_ps)) if db_response else attenuated_ps,
+                20 * np.log10(attenuated_ps) if db_response else attenuated_ps,
                 label="Attenuation",
                 color="black",
             )

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -1192,7 +1192,7 @@ class FilterDesigner(QDialog):
         if self.current_filter_units() == Filter.FrequencyUnits.CYCLIC:
             freqs /= 2 * np.pi
 
-        return (freqs, normalised, normalised * abs(attenuation(freqs))**4)
+        return (freqs, normalised, normalised * abs(attenuation(freqs)) ** 4)
 
     def create_settings_layout(self, widget_area: QVBoxLayout) -> None:
         """Create the filter settings vertical layout.
@@ -1317,7 +1317,7 @@ class FilterDesigner(QDialog):
         axes = self._figure.add_axes([0.1, 0.1, 0.8, 0.8])
         axes.plot(
             x,
-            20 * np.log10(abs(y)**4) if db_response else abs(y)**4,
+            20 * np.log10(abs(y) ** 4) if db_response else abs(y) ** 4,
             label="Filter response",
         )
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -1230,9 +1230,9 @@ class FilterDesigner(QDialog):
 
         for name, filter_class in FILTER_MAP.items():
             template = (
-                FilterSettingGroup
-                if Filter.Flags.DIGITAL_ONLY in filter_class.flags
-                else BoundedFilterSettingsGroup
+                BoundedFilterSettingsGroup
+                if Filter.Flags.BOUNDED_FILTER in filter_class.flags
+                else FilterSettingGroup
             )
             group_obj = template(
                 parent_attributes=copy.deepcopy(self.settings["attributes"]),


### PR DESCRIPTION
**Description of work**
Minimum changes to resolve some issues with the trajectory filter.

- Change the trajectory filter so that it uses sosfiltfilt. Scipy recommends using sosfiltfilt over filtfilt.
- Change all filters so that they are digital filters. The approach avoids needing to call signal.bilinear, which can cause a “frequency warping” effect, which can mean that the resulting cutoff is different from what is seen in the trajectory filter helper.
- Fixes the trajectory filter helper so that it plots PPS(w), |F(w)|^4, and PPS(w)|F(w)|^4 where |F(w)| is the filter function. See https://github.com/ISISNeutronMuon/MDANSE/issues/1160#issuecomment-3855047785.


**Fixes**
Closes #1089
Closes #1171
Closes #1164
Closes #1161
Closes #1160

**To test**
- Run the trajectory filter with order setting set quite high >20. The trajectory filter should be more stable than protos.
- Use the trajectory filter with a high order to get a sharp cutoff.  Check that the resulting PPS of the new trajectory also has a sharp cutoff at the specific frequency the filter was set at.
- Check that the trajectory filter helper predicted PPS is close to the actual PPS after filtering the trajectory.
 
