### PR TITLE
Make filter fail early for invalid input parameters

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import json
 from traceback import format_exc
 
+import numpy as np
+
 from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
 from MDANSE.Mathematics.Signal import (
     DEFAULT_FILTER,
@@ -94,9 +96,17 @@ class TrajectoryFilterConfigurator(IConfigurator):
         )
 
         try:
-            FILTER_MAP[dict_value["filter"]](**dict_value["attributes"])
+            filter_instance = FILTER_MAP[dict_value["filter"]](
+                **dict_value["attributes"]
+            )
         except Exception as e:
             self.error_status = f"Could not create the filter. {e}: {format_exc()}"
+            return
+
+        try:
+            filter_instance.apply(np.empty((frames_configurator["number"],)))
+        except Exception as e:
+            self.error_status = f"Could not apply the filter. {e}: {format_exc()}"
             return
 
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
@@ -77,8 +77,10 @@ class TrajectoryFilterConfigurator(IConfigurator):
         try:
             dict_value = json.loads(value)
 
-            if not self._expected_keys <= dict_value.keys():
-                self.error_status = f"The input dictionary does not contain the expected keys {self._expected_keys}."
+            if missing := self._expected_keys - dict_value.keys():
+                self.error_status = (
+                    f"The input dictionary does is missing the expected keys {missing}."
+                )
                 return
 
         except (TypeError, ValueError):
@@ -90,7 +92,9 @@ class TrajectoryFilterConfigurator(IConfigurator):
         frames_configurator = self.configurable[self.dependencies["frames"]]
 
         dict_value["attributes"].setdefault("n_steps", frames_configurator["number"])
-        dict_value["attributes"].setdefault("time_step_ps", frames_configurator["time_step"])
+        dict_value["attributes"].setdefault(
+            "time_step_ps", frames_configurator["time_step"]
+        )
 
         try:
             FILTER_MAP[dict_value["filter"]](**dict_value["attributes"])

--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
@@ -73,6 +73,7 @@ class TrajectoryFilterConfigurator(IConfigurator):
         """
         if not self.update_needed(value):
             return
+        self.warning_status = ""
 
         self._settings = value
 
@@ -108,6 +109,15 @@ class TrajectoryFilterConfigurator(IConfigurator):
         except Exception as e:
             self.error_status = f"Could not apply the filter. {e}: {format_exc()}"
             return
+
+        expected_attributes = set(filter_instance.default_settings) | {
+            "n_steps",
+            "time_step_ps",
+        }
+        if unknown_attributes := dict_value["attributes"].keys() - expected_attributes:
+            self.warning_status = (
+                f"Unexpected filter attributes: {','.join(unknown_attributes)}"
+            )
 
         self.error_status = "OK"
         self["value"] = self._settings

--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
@@ -110,13 +110,23 @@ class TrajectoryFilterConfigurator(IConfigurator):
             self.error_status = f"Could not apply the filter. {e}: {format_exc()}"
             return
 
-        expected_attributes = set(filter_instance.default_settings) | {
+        expected_attributes = filter_instance.default_settings.keys() | {
             "n_steps",
             "time_step_ps",
         }
         if unknown_attributes := dict_value["attributes"].keys() - expected_attributes:
             self.warning_status = (
                 f"Unexpected filter attributes: {','.join(unknown_attributes)}"
+            )
+        if (
+            missing_attributes := filter_instance.default_settings.keys()
+            - dict_value["attributes"].keys()
+        ):
+            self.warning_status = "\n".join(
+                [
+                    self.warning_status,
+                    f"No values were given to expected filter attributes: {','.join(missing_attributes)}",
+                ]
             )
 
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
@@ -87,6 +87,13 @@ class TrajectoryFilterConfigurator(IConfigurator):
             )
             return
 
+        frames_configurator = self.configurable[self.dependencies["frames"]]
+
+        if "n_steps" not in dict_value["attributes"]:
+            dict_value["attributes"]["n_steps"] = frames_configurator["number"]
+        if "time_step_ps" not in dict_value["attributes"]:
+            dict_value["attributes"]["time_step_ps"] = frames_configurator["time_step"]
+
         try:
             _ = FILTER_MAP[dict_value["filter"]](**dict_value["attributes"])
         except Exception as e:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
@@ -89,13 +89,11 @@ class TrajectoryFilterConfigurator(IConfigurator):
 
         frames_configurator = self.configurable[self.dependencies["frames"]]
 
-        if "n_steps" not in dict_value["attributes"]:
-            dict_value["attributes"]["n_steps"] = frames_configurator["number"]
-        if "time_step_ps" not in dict_value["attributes"]:
-            dict_value["attributes"]["time_step_ps"] = frames_configurator["time_step"]
+        dict_value["attributes"].setdefault("n_steps", frames_configurator["number"])
+        dict_value["attributes"].setdefault("time_step_ps", frames_configurator["time_step"])
 
         try:
-            _ = FILTER_MAP[dict_value["filter"]](**dict_value["attributes"])
+            FILTER_MAP[dict_value["filter"]](**dict_value["attributes"])
         except Exception as e:
             self.error_status = f"Could not create the filter. {e}: {format_exc()}"
             return

--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
@@ -76,17 +76,14 @@ class TrajectoryFilterConfigurator(IConfigurator):
 
         try:
             dict_value = json.loads(value)
-
-            if missing := self._expected_keys - dict_value.keys():
-                self.error_status = (
-                    f"The input dictionary does is missing the expected keys {missing}."
-                )
-                return
-
-        except (TypeError, ValueError):
+        except (TypeError, json.JSONDecodeError):
             self.error_status = (
                 f"Input {value} is not of correct format (expected JSON string)."
             )
+            return
+
+        if missing := self._expected_keys - dict_value.keys():
+            self.error_status = f"The input dictionary is missing the expected keys: {', '.join(missing)}."
             return
 
         frames_configurator = self.configurable[self.dependencies["frames"]]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/TrajectoryFilterConfigurator.py
@@ -16,10 +16,12 @@
 from __future__ import annotations
 
 import json
+from traceback import format_exc
 
 from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
 from MDANSE.Mathematics.Signal import (
     DEFAULT_FILTER,
+    FILTER_MAP,
     filter_default_attributes,
     filter_description_string,
 )
@@ -76,10 +78,20 @@ class TrajectoryFilterConfigurator(IConfigurator):
             dict_value = json.loads(value)
 
             if not self._expected_keys <= dict_value.keys():
-                self.error_status = f"The dictionary \n{dict_value}\n does not contain the expected keys {self._expected_keys}."
+                self.error_status = f"The input dictionary does not contain the expected keys {self._expected_keys}."
+                return
 
         except (TypeError, ValueError):
-            self.error_status = f"Value \n{value}\n in {self} is not of correct format (expected JSON string)."
+            self.error_status = (
+                f"Input {value} is not of correct format (expected JSON string)."
+            )
+            return
+
+        try:
+            _ = FILTER_MAP[dict_value["filter"]](**dict_value["attributes"])
+        except Exception as e:
+            self.error_status = f"Could not create the filter. {e}: {format_exc()}"
+            return
 
         self.error_status = "OK"
         self["value"] = self._settings

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -126,6 +126,20 @@ class TrajectoryFilter(IJob):
             (len(self._selected_atoms), 3, len(self.configuration["frames"]["value"]))
         )
 
+        filter_config = json.loads(self.configuration["trajectory_filter"]["value"])
+
+        filter_class, filter_attributes = (
+            FILTER_MAP[filter_config["filter"]],
+            filter_config["attributes"],
+        )
+
+        filter_attributes.setdefault("n_steps", self.configuration["frames"]["number"])
+        filter_attributes.setdefault(
+            "time_step_ps", self.configuration["frames"]["time_step"]
+        )
+
+        self.filter = filter_class(**filter_attributes)
+
     def run_step(self, index):
         """Run the filter for a single atom.
 
@@ -170,30 +184,15 @@ class TrajectoryFilter(IJob):
     def finalize(self):
         """Write out the new trajectory."""
         # Get filter class and instantiate filter object
-        filter_config = json.loads(self.configuration["trajectory_filter"]["value"])
-
-        filter_class, filter_attributes = (
-            FILTER_MAP[filter_config["filter"]],
-            filter_config["attributes"],
-        )
-
-        filter_attributes.setdefault(
-            "n_steps", self.configuration["trajectory"]["length"]
-        )
-        filter_attributes.setdefault(
-            "time_step_ps", self.configuration["trajectory"]["md_time_step"]
-        )
-
-        filter = filter_class(**filter_attributes)
 
         trajectories = copy.deepcopy(self.atomic_trajectory_array)
 
         # Magnitude of zero frequency in filter response (equivalent to the average atomic positions)
-        zero_magnitude = np.abs(filter.freq_response.magnitudes[0])
+        zero_magnitude = np.abs(self.filter.freq_response.magnitudes[0])
 
         # Apply filter (only apply initial position offset to atoms if filter response f(0) != 1)
         filtered_coords = apply(
-            filter,
+            self.filter,
             trajectories,
             apply_offsets=not np.isclose(zero_magnitude, 1),
         )
@@ -252,7 +251,7 @@ class TrajectoryFilter(IJob):
         outputFile.create_group("metadata/filter").create_dataset(
             "trajectory_filter",
             (1,),
-            data=str(filter),
+            data=str(self.filter),
             dtype=h5py.string_dtype(),
         )
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -74,7 +74,7 @@ class TrajectoryFilter(IJob):
     )
     settings["trajectory_filter"] = (
         "TrajectoryFilterConfigurator",
-        {"dependencies": {"trajectory": "trajectory"}},
+        {"dependencies": {"trajectory": "trajectory", "frames": "frames"}},
     )
     settings["atom_selection"] = (
         "AtomSelectionConfigurator",

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -61,6 +61,7 @@ from MDANSE.Mathematics.Signal import (
 )
 from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
 from MDANSE_GUI.PlotUtils import MDANSEMatPlotLibNavBar
+from MDANSE_GUI.Utils import block_signals
 
 # Default maximum value for a float spinbox
 DEFAULT_SPINBOX_MAX_FLOAT = 1000.0
@@ -218,7 +219,7 @@ class ConstrainedDoubleSpinBox(QDoubleSpinBox):
 
         # New value is the closest value evenly dividing the constraint
         new_value = np.round(value / self.constraint) * self.constraint
-        self.setValue(np.round(new_value, FLOAT_SPINBOX_DECIMALS))
+        self.setValue(new_value)
 
     def search_by_function(self, value: Any) -> None:
         """Apply the constraint formalised in the lambda.
@@ -595,11 +596,8 @@ class FilterSettingGroup(QObject):
             The widget value.
 
         """
-        if isinstance(widget, QSpinBox):
+        if isinstance(widget, (QSpinBox, QDoubleSpinBox)):
             return widget.value()
-
-        if isinstance(widget, QDoubleSpinBox):
-            return np.round(widget.value(), FLOAT_SPINBOX_DECIMALS)
 
         if isinstance(widget, QComboBox):
             return widget.currentText()
@@ -645,6 +643,21 @@ class FilterSettingGroup(QObject):
 
         return self.grid
 
+    def update_widget_step(self, n_steps: int, time_step: float):
+        bin_width = Filter.frequency_resolution(n_steps, time_step, units=self.units)
+        vmax = Filter.nyquist(time_step, units=self.units) - bin_width
+        with block_signals(self):
+            for key in ("cutoff_freq", "fundamental_freq"):
+                if key in self.widgets:
+                    widget_instance: ConstrainedDoubleSpinBox = self.widgets[key]
+                    temp_value = widget_instance.value()
+                    widget_instance.setSingleStep(bin_width)
+                    widget_instance.set_snap(snap_to=bin_width)
+                    widget_instance.setMaximum(vmax)
+                    widget_instance.setMinimum(bin_width)
+                    new_value = bin_width * (min(temp_value, vmax) // bin_width)
+                    widget_instance.setValue(new_value)
+
     def setting_to_widget(self, setting_key: str, val_group: dict) -> QWidget:
         """Convert the setting dictionary to the corresponding setting widget and sets up connections.
 
@@ -681,35 +694,20 @@ class FilterSettingGroup(QObject):
                     "time_step_ps", DEFAULT_TIME_STEP
                 )
 
-                bin_width = np.round(
-                    Filter.frequency_resolution(n_steps, time_step, units=self.units),
-                    FLOAT_SPINBOX_DECIMALS,
+                bin_width = Filter.frequency_resolution(
+                    n_steps, time_step, units=self.units
                 )
 
-                vmax = np.round(
-                    Filter.nyquist(time_step, units=self.units) - bin_width,
-                    FLOAT_SPINBOX_DECIMALS,
-                )
+                vmax = Filter.nyquist(time_step, units=self.units) - bin_width
 
                 # Configure constrained spinbox based on filter type
-                if Filter.Flags.FUNDAMENTAL_EVENLY_DIVIDES_FS in self.flags:
-                    widget = ConstrainedDoubleSpinBox(
-                        minimum=bin_width,
-                        maximum=vmax,
-                        step=bin_width,
-                        value=bin_width,
-                    )
-                    widget.set_search(
-                        constraint_func=lambda x: ((1 / time_step) % x) == 0
-                    )
-                else:
-                    widget = ConstrainedDoubleSpinBox(
-                        minimum=bin_width,
-                        maximum=vmax,
-                        step=bin_width,
-                        value=bin_width,
-                    )
-                    widget.set_snap(snap_to=bin_width)
+                widget = ConstrainedDoubleSpinBox(
+                    minimum=bin_width,
+                    maximum=vmax,
+                    step=bin_width,
+                    value=bin_width,
+                )
+                widget.set_snap(snap_to=bin_width)
             else:
                 # Other data spinbox
                 widget = QDoubleSpinBox()
@@ -983,6 +981,9 @@ class FilterDesigner(QDialog):
         self.time_step_ps = time_step_ps
         self.settings["attributes"]["n_steps"] = n_steps
         self.settings["attributes"]["time_step_ps"] = time_step_ps
+        for settings_group in self.settings_group.values():
+            settings_group.update_widget_step(n_steps, time_step_ps)
+        self.settings_group[self.settings["filter"]].collect_inputs()
 
     def find_configuration(self) -> dict[str, str]:
         """Find the configuration of the main filter job.
@@ -1554,7 +1555,6 @@ class FilterDesigner(QDialog):
             self.combine_attributes(filter_class, self.settings["attributes"]),
         )
         self.field.setText(field)
-        self.close()
 
     def create_buttons(self) -> list[QPushButton]:
         """Create button widgets needed by the filter interface.
@@ -1566,17 +1566,17 @@ class FilterDesigner(QDialog):
             create_layouts.
 
         """
-        apply = QPushButton("Use Setting")
         close = QPushButton("Close")
 
-        apply.setAutoDefault(False)
-        apply.setDefault(False)
         close.setAutoDefault(False)
         close.setDefault(False)
 
-        apply.clicked.connect(self.apply)
         close.clicked.connect(self.close)
-        return [apply, close]
+        return [close]
+
+    def closeEvent(self, a0):
+        self.apply()
+        return super().closeEvent(a0)
 
 
 class TrajectoryFilterWidget(WidgetBase):
@@ -1612,12 +1612,14 @@ class TrajectoryFilterWidget(WidgetBase):
         self.update_labels()
         self.updateValue()
         self._field.setToolTip(self._tooltip_text)
+        self.filter_designer.apply()
 
     def update_time_steps(self):
         frames_configurator = self._frames_widget._configurator
         time_step_ps = frames_configurator["time_step"]
         n_steps = frames_configurator["number"]
         self.filter_designer.accept_time_steps(n_steps, time_step_ps)
+        self.filter_designer.apply()
 
     def create_helper(self) -> FilterDesigner:
         """

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -958,6 +958,9 @@ class FilterDesigner(QDialog):
         self.field = field
         self.configurator = configurator
 
+        self.n_steps = DEFAULT_N_STEPS
+        self.time_step_ps = DEFAULT_TIME_STEP
+
         self.graph_ready = False
 
         self.setting_stack_layout = QStackedLayout()
@@ -974,6 +977,12 @@ class FilterDesigner(QDialog):
         self.set_filter(self.configurator._default_filter.__name__)
         self.create_designer()
         self.preferences_group.pps_checkbox.checkStateChanged.connect(self.update_pps)
+
+    def accept_time_steps(self, n_steps: int, time_step_ps: float):
+        self.n_steps = n_steps
+        self.time_step_ps = time_step_ps
+        self.settings["attributes"]["n_steps"] = n_steps
+        self.settings["attributes"]["time_step_ps"] = time_step_ps
 
     def find_configuration(self) -> dict[str, str]:
         """Find the configuration of the main filter job.
@@ -1017,13 +1026,9 @@ class FilterDesigner(QDialog):
             "filter": filter_type,
             "attributes": {
                 # Number of simulation steps
-                "n_steps": self.configurator.configurable.settings["trajectory"][1][
-                    "configurator"
-                ]["length"],
+                "n_steps": self.n_steps,
                 # Simulation time step in picoseconds
-                "time_step_ps": self.configurator.configurable.settings["trajectory"][
-                    1
-                ]["configurator"]["md_time_step"],
+                "time_step_ps": self.time_step_ps,
             },
         }
 
@@ -1588,7 +1593,18 @@ class TrajectoryFilterWidget(WidgetBase):
         self._field.setPlaceholderText(self._default_value)
         self._field.setMaxLength(2147483647)  # set to the largest possible
         self._field.textChanged.connect(self.updateValue)
+        for widget in self.parent()._widgets:
+            if (
+                widget._configurator
+                is self._configurator.configurable[
+                    self._configurator.dependencies["frames"]
+                ]
+            ):
+                self._frames_widget = widget
+                break
+        self._frames_widget.value_changed.connect(self.update_time_steps)
         self.filter_designer = self.create_helper()
+        self.update_time_steps()
         helper_button = QPushButton(self._push_button_text, self._base)
         helper_button.clicked.connect(self.helper_dialog)
         self._layout.addWidget(self._field)
@@ -1596,6 +1612,12 @@ class TrajectoryFilterWidget(WidgetBase):
         self.update_labels()
         self.updateValue()
         self._field.setToolTip(self._tooltip_text)
+
+    def update_time_steps(self):
+        frames_configurator = self._frames_widget._configurator
+        time_step_ps = frames_configurator["time_step"]
+        n_steps = frames_configurator["number"]
+        self.filter_designer.accept_time_steps(n_steps, time_step_ps)
 
     def create_helper(self) -> FilterDesigner:
         """

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -644,6 +644,15 @@ class FilterSettingGroup(QObject):
         return self.grid
 
     def update_widget_step(self, n_steps: int, time_step: float):
+        """Update the spin box settings based on frames settings.
+
+        Parameters
+        ----------
+        n_steps : int
+            Number of trajectory steps currently selected by frames widget.
+        time_step : float
+            Time step between consecutive trajectory frames.
+        """
         bin_width = Filter.frequency_resolution(n_steps, time_step, units=self.units)
         vmax = Filter.nyquist(time_step, units=self.units) - bin_width
         with block_signals(self):
@@ -977,6 +986,15 @@ class FilterDesigner(QDialog):
         self.preferences_group.pps_checkbox.checkStateChanged.connect(self.update_pps)
 
     def accept_time_steps(self, n_steps: int, time_step_ps: float):
+        """Save the new time parameters given by the frames settings.
+
+        Parameters
+        ----------
+        n_steps : int
+            Number of trajectory steps currently selected.
+        time_step_ps : float
+            Time interval between consecutive trajectory frames.
+        """
         self.n_steps = n_steps
         self.time_step_ps = time_step_ps
         self.settings["attributes"]["n_steps"] = n_steps
@@ -1545,8 +1563,6 @@ class FilterDesigner(QDialog):
 
     def apply(self) -> None:
         """Pass the filter parameters to the main widget."""
-        self.configurator.configure(self.settings)
-
         filter_class = FILTER_MAP[self.settings["filter"]]
 
         # update widget field text to reflect filter designer
@@ -1615,6 +1631,7 @@ class TrajectoryFilterWidget(WidgetBase):
         self.filter_designer.apply()
 
     def update_time_steps(self):
+        """Configure filters using the new frames settings."""
         frames_configurator = self._frames_widget._configurator
         time_step_ps = frames_configurator["time_step"]
         n_steps = frames_configurator["number"]

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/TrajectoryFilterWidget.py
@@ -596,14 +596,13 @@ class FilterSettingGroup(QObject):
             The widget value.
 
         """
-        if isinstance(widget, (QSpinBox, QDoubleSpinBox)):
-            return widget.value()
-
-        if isinstance(widget, QComboBox):
-            return widget.currentText()
-
-        if isinstance(widget, QCheckBox):
-            return widget.isChecked()
+        match widget:
+            case QComboBox():
+                return widget.currentText()
+            case QCheckBox():
+                return widget.isChecked()
+            case _:
+                return widget.value()
 
     @Slot()
     def collect_inputs(self) -> None:
@@ -656,16 +655,15 @@ class FilterSettingGroup(QObject):
         bin_width = Filter.frequency_resolution(n_steps, time_step, units=self.units)
         vmax = Filter.nyquist(time_step, units=self.units) - bin_width
         with block_signals(self):
-            for key in ("cutoff_freq", "fundamental_freq"):
-                if key in self.widgets:
-                    widget_instance: ConstrainedDoubleSpinBox = self.widgets[key]
-                    temp_value = widget_instance.value()
-                    widget_instance.setSingleStep(bin_width)
-                    widget_instance.set_snap(snap_to=bin_width)
-                    widget_instance.setMaximum(vmax)
-                    widget_instance.setMinimum(bin_width)
-                    new_value = bin_width * (min(temp_value, vmax) // bin_width)
-                    widget_instance.setValue(new_value)
+            for key in {"cutoff_freq", "fundamental_freq"} & self.widgets.keys():
+                widget_instance: ConstrainedDoubleSpinBox = self.widgets[key]
+                temp_value = widget_instance.value()
+                widget_instance.setSingleStep(bin_width)
+                widget_instance.set_snap(snap_to=bin_width)
+                widget_instance.setMaximum(vmax)
+                widget_instance.setMinimum(bin_width)
+                new_value = bin_width * (min(temp_value, vmax) // bin_width)
+                widget_instance.setValue(new_value)
 
     def setting_to_widget(self, setting_key: str, val_group: dict) -> QWidget:
         """Convert the setting dictionary to the corresponding setting widget and sets up connections.


### PR DESCRIPTION
**Description of work**
At the moment it is possible to run the TrajectoryFilter with wrong input parameters and have it run all the way to 100% progress before it first attempts to create the filter (and fails). To save the user's time, we should prefer the filter to fail early.

This PR connects the frames widget with filter widget, but does not solve all the problems such as plot scaling. (Should it?)

**Fixes**
1. Create the filter in the `TrajectoryFilter.initialize` method to avoid processing the trajectory if the filter can't be used anyway.
2. Test the filter parameters in `TrajectoryFilterConfigurator` to catch invalid filter parameters in the GUI and prevent the run.
3. Take the time step information from frames configurator to prevent the GUI tests from failing.

**To test**
Try introducing deliberately wrong filter parameters in the input. Ideally, the configurator will pick it up and block the execution in the GUI. If it does not, the job should fail immediately and not only after processing the trajectory.
