### PR TITLE
Check for nan when saving plot limits

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Heatmap.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Heatmap.py
@@ -50,7 +50,6 @@ class Heatmap(Plotter):
         self._backup_limits = {}
         self._initial_values = [0.0, 100.0]
         self._slider_values = [0.0, 100.0]
-        self._last_minmax = [-1, -1]
         self._slice_axis = 2
         self._plot_limit = 1
 
@@ -210,7 +209,9 @@ class Heatmap(Plotter):
                 self._backup_scale_interpolators[databundle.row](51.2)
             except Exception:
                 percentiles = np.linspace(0, 100.0, 21)
-                results = [np.percentile(ds._data, perc) for perc in percentiles]
+                results = [
+                    np.percentile(np.nan_to_num(ds._data), perc) for perc in percentiles
+                ]
                 self._backup_scale_interpolators[databundle.row] = interp1d(
                     percentiles,
                     results,

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Single.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Single.py
@@ -104,10 +104,10 @@ class Single(Plotter):
             curve.set_ydata(new_ydata)
             xmin, xmax = np.nanmin(new_xdata), np.nanmax(new_xdata)
             ymin, ymax = np.nanmin(new_ydata), np.nanmax(new_ydata)
-            saved_xmin = min(xmin, saved_xmin)
-            saved_xmax = max(xmax, saved_xmax)
-            saved_ymin = min(ymin, saved_ymin)
-            saved_ymax = max(ymax, saved_ymax)
+            saved_xmin = np.nanmin([xmin, saved_xmin])
+            saved_xmax = np.nanmax([xmax, saved_xmax])
+            saved_ymin = np.nanmin([ymin, saved_ymin])
+            saved_ymax = np.nanmax([ymax, saved_ymax])
         self._backup_limits = [saved_xmin, saved_xmax, saved_ymin, saved_ymax]
         self._axes[0].relim()
         self._axes[0].autoscale()
@@ -204,8 +204,12 @@ class Single(Plotter):
                         temp.set_marker(int(databundle.marker))
                 self._active_curves.append(temp)
                 self._backup_curves.append([temp.get_xdata(), temp.get_ydata()])
-                self.height_max = max(self.height_max, np.nanmax(temp.get_ydata()))
-                self.length_max = max(self.length_max, np.nanmax(temp.get_xdata()))
+                self.height_max = np.nanmax(
+                    [self.height_max, np.nanmax(temp.get_ydata())]
+                )
+                self.length_max = np.nanmax(
+                    [self.length_max, np.nanmax(temp.get_xdata())]
+                )
             else:
                 multi_curves = dataset.curves_vs_axis(
                     (best_unit, best_axis), max_limit=self._curve_limit_per_dataset
@@ -232,11 +236,11 @@ class Single(Plotter):
                                 temp.set_marker(int(databundle.marker))
                         self._active_curves.append(temp)
                         self._backup_curves.append([temp.get_xdata(), temp.get_ydata()])
-                        self.height_max = max(
-                            self.height_max, np.nanmax(temp.get_ydata())
+                        self.height_max = np.nanmax(
+                            [self.height_max, np.nanmax(temp.get_ydata())]
                         )
-                        self.length_max = max(
-                            self.length_max, np.nanmax(temp.get_xdata())
+                        self.length_max = np.nanmax(
+                            [self.length_max, np.nanmax(temp.get_xdata())]
                         )
                     except ValueError:
                         LOG.error(f"Plotting failed for {plotlabel} using {best_axis}")


### PR DESCRIPTION
**Description of work**
This PR adds more checks for `nan` values, making improving the initial scaling of plots.

The crash experienced with python 3.14 could not be reproduced.

closes #1177

**Fixes**
1. Replaced `min` and `max` with `np.nanmin` and `np.nanmax` when saving the plot limits in `Single` and `Heatmap` plotters.

**To test**
Run a DCSF or DISF calculation. Make sure that the q vector widget warns you about some of the q shells being empty.
Try to plot the s(q,f) total result. The initial scaling of the `Single` plot and initial colorbar in `Heatmap` should both be correct (as opposed to their values in the main branch).
