### PR TITLE
Add copyright checking to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,46 +10,27 @@ concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ruff_version: 0.13.0
+
 jobs:
-  lint-mdanse:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
-        with:
-          src: "./MDANSE/Src"
-          args: "format --check"
-          version: "0.13.0"
 
-  lint_check_ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
-        with:
-          src: "./MDANSE/Src"
-          args: "check"
-          version: "0.13.0"
+  lint:
+    name: ${{ matrix.mdanse }} -- (${{ matrix.type }})
+    strategy:
+      fail-fast: false
+      matrix:
+        mdanse: ["MDANSE", "MDANSE_GUI"]
+        type: ["check", "format --check"]
 
-  lint_format_ruff_gui:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
-          src: "./MDANSE_GUI/Src"
-          args: "format --check"
-          version: "0.13.0"
-
-  lint_check_ruff_gui:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
-        with:
-          src: "./MDANSE_GUI/Src"
-          args: "check"
-          version: "0.13.0"
+          src: ./${{ matrix.mdanse }}/Src
+          args: ${{ matrix.type }}
+          version: ${{ env.ruff_version }}
 
   lint_copyright:
     runs-on: ubuntu-latest
@@ -57,9 +38,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
-          src: "./MDANSE_GUI/Src"
-          args: "check --preview --select 'CPY'"
-          version: "0.13.0"
+          args: check --preview --select CPY
+          version: ${{ env.ruff_version }}
 
   lint_vermin:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,16 @@ jobs:
           args: "check"
           version: "0.13.0"
 
+  lint_copyright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          src: "./MDANSE_GUI/Src"
+          args: "check --preview --select 'CPY'"
+          version: "0.13.0"
+
   lint_vermin:
     runs-on: ubuntu-latest
     steps:

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
@@ -1,3 +1,18 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 from __future__ import annotations
 
 from math import floor

--- a/MDANSE/Src/MDANSE/Framework/Configurators/GridStepConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/GridStepConfigurator.py
@@ -1,3 +1,7 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #

--- a/MDANSE/Src/MDANSE/Framework/Parsers/FortranUnformat.py
+++ b/MDANSE/Src/MDANSE/Framework/Parsers/FortranUnformat.py
@@ -1,3 +1,18 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 """General parser for the Fortran Unformatted file format."""
 
 from __future__ import annotations

--- a/MDANSE/Src/MDANSE/MLogging/__init__.py
+++ b/MDANSE/Src/MDANSE/MLogging/__init__.py
@@ -1,3 +1,18 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 from __future__ import annotations
 
 import logging

--- a/MDANSE/Src/MDANSE/Trajectory/__init__.py
+++ b/MDANSE/Src/MDANSE/Trajectory/__init__.py
@@ -1,0 +1,15 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
@@ -1,3 +1,18 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 from __future__ import annotations
 
 from collections import ChainMap

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,6 +36,7 @@ select = [
     # "D",   # Pydocstyle
     "UP",  # Pyupgrade
     "T20",   # Print
+    "CPY",  # Copyright check
 ]
 ignore = [
     "E501",     # Line too long
@@ -52,3 +53,6 @@ ignore = [
 [lint.isort]
 known-first-party = ["MDANSE", "MDANSE_GUI"]
 required-imports = ["from __future__ import annotations"]
+
+[lint.flake8-copyright]
+notice-rgx = "it under the terms of the GNU General Public License as published by"


### PR DESCRIPTION
**Description of work**
Add automatic checking for presence of copyright notice in files.

Since this is under the `--preview` block, it is in a separate workflow to avoid enabling features which may be problematic.

To run manually, run `ruff check --preview --select "CPY"`

**Fixes**
N/A

**To test**
N/A