### PR TITLE
Animate MolecularViewer only when TrajectoryTab is active

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -95,6 +95,8 @@ class MolecularViewer(QtWidgets.QWidget):
         self._line_scale_factor = 0.4
 
         self._element_database = None
+        self._viewer_is_visible = False
+        self.tab_index = -1
 
         self._iren = QVTKRenderWindowInteractor(self)
         self._iren.keyPressEvent = lambda *args, **kwargs: None
@@ -305,6 +307,10 @@ class MolecularViewer(QtWidgets.QWidget):
         self.axes_type = axes_option
         self.create_axes()
         self.update_renderer()
+
+    @Slot(int)
+    def change_visibility(self, current_tab_index: int):
+        self._viewer_is_visible = current_tab_index == self.tab_index
 
     def clear_atom_labels(self):
         """Clears the atom label actors and removes it from the renderer."""

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewerExtended.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewerExtended.py
@@ -160,7 +160,7 @@ class MolecularViewerExtended(MolecularViewer):
 
     def animate_rotation(self):
         """Continuously rotate the 3D model."""
-        if self._animation_timer.isActive():
+        if self._animation_timer.isActive() and self._viewer_is_visible:
             for i, actor in enumerate(self.placeholder_actors):
                 if i == 0:  # center sphere
                     actor.RotateZ(self.rotation_speed)

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -452,8 +452,12 @@ class TabbedWindow(QMainWindow):
             self._logger,
             model=self._trajectory_model,
         )
-        self.tabs.addTab(trajectory_tab._core, name)
+        traj_tab_index = self.tabs.addTab(trajectory_tab._core, name)
+        trajectory_tab._visualiser._viewer.tab_index = traj_tab_index
         self._tabs[name] = trajectory_tab
+        self.tabs.currentChanged.connect(
+            trajectory_tab._visualiser._viewer.change_visibility
+        )
         self._job_holder.trajectory_for_loading.connect(trajectory_tab.load_trajectory)
         self._job_holder.trajectory_for_loading.connect(trajectory_tab.tab_notification)
 


### PR DESCRIPTION
**Description of work**
My system monitor shows that MDANSE_GUI uses the CPU from the moment it starts until a trajectory has been selected. I expect that the placeholder animation is causing it.

This PR makes the animation run only when the trajectory tab is the active tab.

**Fixes**
1. Stores the trajectory tab index in the MolecularViewer instance.
2. Animates the placeholder only when the current tab index is the trajectory tab index.

**To test**
Run any kind of CPU activity monitor you normally use on your system.
Start MDANSE_GUI and compare the CPU use of MDANE_GUI depending on if Trajectory Tab is selected.
Do the same for the main branch and compare the results. The CPU use in this PR should be the same as in main when Trajectory Tab is active, and lower than in main for other tabs.
