### PR TITLE
Use "core" driver for trajectories on data analysis workspaces

### DIFF
--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -157,14 +157,16 @@ class Trajectory:
     such as the atom selection, atom transmutation and grouping.
     """
 
-    def __init__(self, filename, trajectory_format: ValidFormats | None = None):
+    def __init__(self, filename, trajectory_format: ValidFormats | None = None,
+                 hdf5_driver: str | None = None):
         self._filename = filename
+        self._hdf5_driver = hdf5_driver
         self._format = (
             trajectory_format if trajectory_format else self.guess_correct_format()
         )
 
         if self._format not in {"mock"}:
-            self._trajectory = self.open_trajectory(self._format)
+            self._trajectory = self.open_trajectory(self._format, self._hdf5_driver)
         self._min_span = None
         self._max_span = None
         self._grouping_level = GroupingLevels.ATOM
@@ -424,9 +426,9 @@ class Trajectory:
 
         return "MDANSE"
 
-    def open_trajectory(self, trajectory_format):
+    def open_trajectory(self, trajectory_format, hdf5_driver):
         trajectory_class = available_formats[trajectory_format]
-        trajectory = trajectory_class(self._filename)
+        trajectory = trajectory_class(self._filename, hdf5_driver=hdf5_driver)
         return trajectory
 
     def close(self):
@@ -455,7 +457,7 @@ class Trajectory:
 
     def __setstate__(self, state):
         self.__dict__ = state
-        self._trajectory = self.open_trajectory(self._format)
+        self._trajectory = self.open_trajectory(self._format, self._hdf5_driver)
 
     def __len__(self):
         return len(self._trajectory)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import copy
 import html
 import math
+import os
 from collections import Counter, defaultdict
 from enum import auto
 from operator import itemgetter
@@ -52,6 +53,27 @@ available_formats = {
 }
 ValidFormats = Literal["MDANSE", "H5MD"]
 SLICE_ALL = np.s_[:]
+
+
+def check_hdf5_driver() -> bool:
+    """Return True if 'core' driver should be used for HDF5 files.
+
+    Checks if MDANSE_FILE_IN_MEMORY environment is set to a non-zero int value.
+
+    Returns
+    -------
+    bool
+        True if MDANSE_FILE_IN_MEMORY is set to a non-zero number, False otherwise.
+    """
+    try:
+        env_var = os.environ["MDANSE_FILE_IN_MEMORY"]
+    except KeyError:
+        return False
+    try:
+        flag_value = int(env_var)
+    except (ValueError, TypeError):
+        return False
+    return flag_value > 0
 
 
 class GroupingLevels(UCEnum):

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -65,15 +65,8 @@ def check_hdf5_driver() -> bool:
     bool
         True if MDANSE_FILE_IN_MEMORY is set to a non-zero number, False otherwise.
     """
-    try:
-        env_var = os.environ["MDANSE_FILE_IN_MEMORY"]
-    except KeyError:
-        return False
-    try:
-        flag_value = int(env_var)
-    except (ValueError, TypeError):
-        return False
-    return flag_value > 0
+    env_var = os.environ.get("MDANSE_FILE_IN_MEMORY", "0")
+    return env_var.isdigit() and int(env_var)
 
 
 class GroupingLevels(UCEnum):

--- a/MDANSE/Src/MDANSE/Scripts/mdanse.py
+++ b/MDANSE/Src/MDANSE/Scripts/mdanse.py
@@ -15,7 +15,6 @@
 #
 from __future__ import annotations
 
-import os
 import textwrap
 from argparse import (
     ArgumentParser,

--- a/MDANSE/Src/MDANSE/Scripts/mdanse.py
+++ b/MDANSE/Src/MDANSE/Scripts/mdanse.py
@@ -36,6 +36,7 @@ from MDANSE.IO.AtomInfo import atom_info
 from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.Trajectory import (
     Trajectory,
+    check_hdf5_driver,
     chemical_system_summary,
     trajectory_summary,
 )
@@ -68,7 +69,7 @@ def show_trajectory_contents(args: Namespace):
     trajectory_name = Path.cwd() / trajectory_path
     instance = (
         Trajectory(trajectory_name, hdf5_driver="core")
-        if int(os.environ["MDANSE_FILE_IN_MEMORY"])
+        if check_hdf5_driver()
         else Trajectory(trajectory_name)
     )
     result = trajectory_summary(instance)

--- a/MDANSE/Src/MDANSE/Scripts/mdanse.py
+++ b/MDANSE/Src/MDANSE/Scripts/mdanse.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+import os
 import textwrap
 from argparse import (
     ArgumentParser,
@@ -65,7 +66,11 @@ def show_trajectory_contents(args: Namespace):
     if not trajectory_path:
         return
     trajectory_name = Path.cwd() / trajectory_path
-    instance = Trajectory(trajectory_name)
+    instance = (
+        Trajectory(trajectory_name, hdf5_driver="core")
+        if int(os.environ["MDANSE_FILE_IN_MEMORY"])
+        else Trajectory(trajectory_name)
+    )
     result = trajectory_summary(instance)
     result += chemical_system_summary(instance.chemical_system)
     traj_arrays = get_hdf5_contents(instance.file)

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -129,7 +129,7 @@ class H5MDTrajectory(TrajectoryFile):
     def velocities(self) -> h5py.Dataset:
         return self._h5_file[self.vel_key]
 
-    def __init__(self, h5_filename: Path | str):
+    def __init__(self, h5_filename: Path | str, hdf5_driver: str | None = None):
         """Constructor.
 
         Parameters
@@ -141,7 +141,7 @@ class H5MDTrajectory(TrajectoryFile):
 
         self._h5_filename = Path(h5_filename)
 
-        self._h5_file = h5py.File(self._h5_filename, "r")
+        self._h5_file = h5py.File(self._h5_filename, "r", driver=hdf5_driver)
 
         particle_types = self._h5_file["/particles/all/species"]
         particle_lookup = h5py.check_enum_dtype(

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -55,7 +55,7 @@ class MdanseTrajectory(TrajectoryFile):
     is the specific implementation for the Mdanse HDF5 format.
     """
 
-    def __init__(self, h5_filename: Path | str):
+    def __init__(self, h5_filename: Path | str, hdf5_driver: str | None = None):
         """Open the file and build a trajectory.
 
         Parameters
@@ -73,7 +73,7 @@ class MdanseTrajectory(TrajectoryFile):
         self.unit_cell_warning = ""
         self._h5_filename = Path(h5_filename)
 
-        self._h5_file = h5py.File(self._h5_filename, "r")
+        self._h5_file = h5py.File(self._h5_filename, "r", driver=hdf5_driver)
         self._has_database = "atom_database" in self._h5_file
         self._has_atoms = []
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
@@ -34,7 +34,7 @@ from qtpy.QtGui import QStandardItem, QStandardItemModel
 
 from MDANSE.Core.Platform import PLATFORM
 from MDANSE.MLogging import LOG
-from MDANSE.MolecularDynamics.Trajectory import Trajectory
+from MDANSE.MolecularDynamics.Trajectory import Trajectory, check_hdf5_driver
 from MDANSE_GUI.Session.RecentFiles import RecentFiles
 
 
@@ -68,7 +68,7 @@ class LoaderThread(QThread):
         try:
             trajectory = (
                 Trajectory(self._filename, hdf5_driver="core")
-                if int(os.environ["MDANSE_FILE_IN_MEMORY"])
+                if check_hdf5_driver
                 else Trajectory(self._filename)
             )
         except Exception as e:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import itertools
+import os
 import traceback
 from enum import Enum, auto
 
@@ -65,7 +66,11 @@ class LoaderThread(QThread):
 
     def run(self):
         try:
-            trajectory = Trajectory(self._filename)
+            trajectory = (
+                Trajectory(self._filename, hdf5_driver="core")
+                if int(os.environ["MDANSE_FILE_IN_MEMORY"])
+                else Trajectory(self._filename)
+            )
         except Exception as e:
             LOG.error(
                 "Failed loading file %s, exception %s traceback %s",

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
@@ -68,7 +68,7 @@ class LoaderThread(QThread):
         try:
             trajectory = (
                 Trajectory(self._filename, hdf5_driver="core")
-                if check_hdf5_driver
+                if check_hdf5_driver()
                 else Trajectory(self._filename)
             )
         except Exception as e:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/TrajectoryModel.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import itertools
-import os
 import traceback
 from enum import Enum, auto
 


### PR DESCRIPTION
**Description of work**
These changes are meant to speed up trajectory file access on data analysis platforms without changing anything on ordinary computers.

Since the filesystems we are looking at are likely to cache the file after it has been loaded initially, it may be that the load operation in the GUI will place the trajectory file in the cache and speed up the subsequent analysis as well.

**Fixes**
1. The changes are only applied if an environment variable MDANSE_FILE_IN_MEMORY is set to a non-zero value.
2. The GUI and the CLI will use `h5py.File(..., driver='core')` when loading the trajectory to read information.
3. The analysis jobs will still use the default driver, not to risk loading large files into memory completely for every subprocess.

**To test**
Set MDANSE_FILE_IN_MEMORY to 1.
Run the GUI and load some trajectories. There should be no change to the results. The memory requirements of running the GUI may increase with the number and size of trajectories.
