### PR TITLE
Update plot limits when changing axes

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/Controls.py
@@ -181,7 +181,7 @@ class ViewerControls(QWidget):
             layout.addWidget(temp)
             self._buttons[button_name] = temp
         self._buttons["stop"].clicked.connect(self.stop_animation)
-        self._buttons["play"].clicked.connect(lambda: self.animate())
+        self._buttons["play"].clicked.connect(lambda: self.animate(step_size=1))
         self._buttons["fwd"].clicked.connect(lambda: self.animate(step_size=10))
         self._buttons["back"].clicked.connect(lambda: self.animate(step_size=-10))
         self._buttons["start"].clicked.connect(lambda: self.go_to_end(last_frame=False))

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlotDataModel.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from pathlib import Path
+from traceback import format_exc
 from typing import TypeVar
 
 import h5py
@@ -198,7 +199,7 @@ class PlotDataModel(QStandardItemModel):
         try:
             new_datafile = MDADataStructure(filename)
         except Exception as e:
-            LOG.error("Invalid: %s", e)
+            LOG.error("Invalid: %s, error message: %s", e, format_exc())
         else:
             self._nodes[self._next_number] = new_datafile
             new_item = DataFileItem()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -103,6 +103,7 @@ class SingleDataset:
         self._imaginary_data = None
         self._valid = True
         self._scaling_factor = 1.0
+        self._main_axis = None
         self._axes = {}
         self._axes_units = {}
         self._current_units = {}
@@ -405,7 +406,7 @@ class SingleDataset:
 
         return (int(token),)
 
-    def set_data_limits(self, limit_string: str):
+    def set_data_limits(self, limit_string: str, main_axis: str = ""):
         """Parse the string used for selecting a subset of data.
 
         Parameters
@@ -420,6 +421,7 @@ class SingleDataset:
 
         complete_subset = {}
 
+        self._main_axis = main_axis
         axes = map(len, self.dep_axes.values())
 
         max_len = prod(axes)
@@ -473,7 +475,7 @@ class SingleDataset:
     @property
     def dep_axes(self) -> dict[str, npt.NDArray]:
         """Axes which are likely to be dependent."""
-        _, la = self.longest_axis()
+        la = self.longest_axis()[1] if not self._main_axis else self._main_axis
         return {aname: axis for aname, axis in self._axes.items() if aname != la}
 
     @property
@@ -850,17 +852,18 @@ class PlottingContext(QStandardItemModel):
                 continue
 
             data_number_string = row_data["Use it?"].text()
+            main_axis = row_data["Main axis"].text()
 
             plot_args = {
                 "colour": row_data["Colour"].text(),
                 "line_style": row_data["Line style"].text(),
                 "marker": row_data["Marker"].text(),
                 "row": row,
-                "main_axis": row_data["Main axis"].text(),
+                "main_axis": main_axis,
                 "legend_label": row_data["Legend label"].text(),
             }
 
-            self._datasets[key].set_data_limits(data_number_string)
+            self._datasets[key].set_data_limits(data_number_string, main_axis=main_axis)
             self._datasets[key].set_current_units(self._unit_lookup)
             result[key] = PlotArgs(self._datasets[key], **plot_args)
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotSettings.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotSettings.py
@@ -167,7 +167,7 @@ class PlotSettings(QWidget):
         style_list_mpl = mpl.style.available
         style_list_filtered = [x for x in style_list_mpl if x[0] != "_"]
         style_list_filtered = [x for x in style_list_filtered if "lorbli" not in x]
-        style_list_filtered = [x for x in style_list_filtered if x not in ["fast"]]
+        style_list_filtered = [x for x in style_list_filtered if x != "fast"]
         style_selector.addItems(style_list_filtered)
         try:
             style_string = self._settings.group("matplotlib").get("style")


### PR DESCRIPTION
**Description of work**
Limits of data slices in the plotter now depend on the choice of the main axis.

closes #1193

**Fixes**
1. SingleDataset uses the main axis information when checking slice limits.
2. Extra error output from the plotter when loading files.
3. Minor changes based on `ruff check` output.

**To test**
Plot a 2D data set.
Change the main axis. The limits in the "use it?" field should be applied correctly.
