### PR TITLE
Only apply origin offset once in LAMMPS converter

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Converters/LAMMPS.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/LAMMPS.py
@@ -15,7 +15,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
 from MDANSE.Framework.Converters.Converter import Converter
@@ -26,11 +26,6 @@ from MDANSE.Framework.Parsers import (
     LAMMPSxyz,
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
-
-if TYPE_CHECKING:
-    from MDANSE.Framework.Configurators.ConfigFileConfigurator import (
-        ConfigFileConfigurator,
-    )
 
 
 class LAMMPS(Converter):

--- a/MDANSE/Src/MDANSE/Framework/Parsers/LAMMPS.py
+++ b/MDANSE/Src/MDANSE/Framework/Parsers/LAMMPS.py
@@ -349,6 +349,7 @@ class LAMMPScustom(LAMMPSReader):
         """
         self._file = open(filename, encoding="utf-8")  # noqa: SIM115
         self._start = 0
+        self._first_origin = None
 
     def parse_first_step(
         self, aliases: dict[str, dict[str, str]], config: dict[str, Any]
@@ -516,6 +517,9 @@ class LAMMPScustom(LAMMPSReader):
 
         cell = np.fromstring(" ".join(take(3, file)), dtype=np.float64, sep=" ")
         unit_cell, origin = self._style.to_cell(cell, bounds=True)
+        self._first_origin = (
+            origin if self._first_origin is None else self._first_origin
+        )
 
         len_conv = measure(1.0, self.units["length"]).toval("nm")
 
@@ -579,7 +583,7 @@ class LAMMPScustom(LAMMPSReader):
 
         if self._fractionalCoordinates:
             # MDANSE origin is always 0,0,0
-            origin *= len_conv
+            origin = self._first_origin * len_conv
             origin_recip = np.matmul(origin, unit_cell.inverse)
 
             coords -= origin_recip
@@ -592,7 +596,7 @@ class LAMMPScustom(LAMMPSReader):
 
         else:
             # MDANSE origin is always 0,0,0
-            coords -= origin
+            coords -= self._first_origin
             coords *= len_conv
 
             real_conf = PeriodicRealConfiguration(


### PR DESCRIPTION
**Description of work**
The results of the 1st tutorial in MDANSE-Examples have changed since we created the tutorial.

<img width="1302" height="378" alt="Screenshot 2026-03-18 at 14 25 57" src="https://github.com/user-attachments/assets/af31b6a2-1f19-4221-9840-d8b5fc7aa7fa" />

The additional spikes in the temperature were not there before.

This PR is a compromise, since the spikes in temperature are removed, but the animation of the trajectory slowly loses the synchronisation between the unit cell and atom positions.

Last frame of Mo trajectory:

<img width="446" height="520" alt="Screenshot 2026-03-18 at 17 33 03" src="https://github.com/user-attachments/assets/7eef625a-fa9d-49db-8f53-6ee1114acde6" />

**Fixes**
1. Instead of updating the value of `origin` every step, we always shift the coordinates by the `first_origin` value from initial frame.

**To test**
Go through the tutorial 1 in MDANSE-Examples. The temperature results should be the same as in the tutorial description.

