### PR TITLE
Improve QVectorsWidget warning highlighting

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/QVectorsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/QVectorsConfigurator.py
@@ -69,7 +69,8 @@ class QVectorsConfigurator(IConfigurator):
         self._original_input = value
 
         trajConfig = self.configurable[self.dependencies["trajectory"]]
-        self.error_status = "NONE"
+        self.error_status = "OK"
+        self.warning_status = ""
         try:
             if not isinstance(value, tuple):
                 raise Exception(f"Q vectors setting must be a tuple {value}")

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
@@ -455,6 +455,7 @@ class QVectorsWidget(WidgetBase):
         """Update the widget appearance based on the input validation results."""
         if all_are_correct:
             self.clear_error()
+            self.mark_warning(self._configurator.warning_status)
         else:
             self.mark_error("Some entries in the parameter table are invalid.")
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
@@ -440,7 +440,6 @@ class QVectorsWidget(WidgetBase):
         self._selector.setToolTip(
             "The q vectors will be generated using the method chosen here.",
         )
-        self._model.input_is_valid.connect(self.validate_model_parameters)
         policy = self._view.sizePolicy()
         policy.setVerticalPolicy(QSizePolicy.Policy.Minimum)
         self._view.setSizePolicy(policy)
@@ -449,15 +448,6 @@ class QVectorsWidget(WidgetBase):
             QAbstractScrollArea.SizeAdjustPolicy.AdjustToContents,
         )
         self.value_changed.connect(self.preview_vectors)
-
-    @Slot(bool)
-    def validate_model_parameters(self, all_are_correct: bool):
-        """Update the widget appearance based on the input validation results."""
-        if all_are_correct:
-            self.clear_error()
-            self.mark_warning(self._configurator.warning_status)
-        else:
-            self.mark_error("Some entries in the parameter table are invalid.")
 
     @Slot()
     def fail_early(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -443,11 +443,11 @@ class Action(QWidget):
         has_warning = False
         for widget in self._widgets:
             widget.clear_error()
+            widget.mark_warning(widget._configurator.warning_status)
+            has_warning = has_warning or widget.has_warning
             if not widget._configurator.valid:
                 allow = False
                 widget.mark_error(widget._configurator.error_status, silent=True)
-            widget.mark_warning(widget._configurator.warning_status)
-            has_warning = has_warning or widget.has_warning
         if self.execute_button is not None:
             self.execute_button.setEnabled(allow)
             self.save_button.setEnabled(allow)


### PR DESCRIPTION
**Description of work**
`QVectorsWidget` has an extra feature of setting and clearing errors if the inputs in the vector parameter table are invalid. This needed to be updated to account for the possibility of a warning being set in the underlying configurator.

closes #1201

**Fixes**
1. Reset the warning after clearing the input errors in the widget.

**To test**
Try to reproduce the problem from the issue. The warning should stay marked in the GUI.

