### PR TITLE
Attach the 'use it?' field to Text output

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -496,7 +496,8 @@ class SingleDataset:
         self,
         index_tuple: list[int],
         axis_lookup: list[str],
-    ) -> str:
+        skip_text: bool = False,
+    ) -> str | float:
         """Get a meaningful label for a subset of data.
 
         Used when plotting 1D arrays out of a multidimensional array.
@@ -504,14 +505,16 @@ class SingleDataset:
         Parameters
         ----------
         index_tuple : list[int]
-            indices of the 1D data array position in the ND array
+            indices of the 1D data array position in the ND array.
         axis_lookup : list[str]
-            Names of the axes to use
+            Names of the axes to use.
+        skip_text : bool, optional
+            If set to true, omits the text parts of the label. By default False.
 
         Returns
         -------
-        str
-            A string label for the plot legend.
+        str | float
+            A string label for the plot legend or a number for Text plotter.
 
         """
         if self._n_dim < 2:
@@ -540,13 +543,16 @@ class SingleDataset:
                 picked_value = round(picked_value, 1)
 
             label += f"{axis_label}={picked_value} {axis_unit}, "
+            if skip_text:
+                return float(picked_value)
         return label.rstrip(", ")
 
     def curves_vs_axis(
         self,
         x_axis_details: tuple[str, str],
         max_limit: int = 1,
-    ) -> list[np.ndarray]:
+        skip_label_text: bool = False,
+    ) -> dict[int, np.ndarray]:
         """Prepare a set of curves for plotting.
 
         Parameters
@@ -555,10 +561,12 @@ class SingleDataset:
             Name and original unit of the primary plotting axis
         max_limit : int, optional
             Maximum number of curves allowed by plotter, by default 1
+        skip_label_text: bool, optional
+            Whether to skip the axis name and unit in the curve label, by default False.
 
         Returns
         -------
-        list[np.ndarray]
+        dict[int, np.ndarray]
             List of data arrays ready for plotting
 
         """
@@ -610,6 +618,7 @@ class SingleDataset:
                 self._curve_labels[index_tuple] = self.generate_curve_label(
                     index_tuple,
                     label_lookup,
+                    skip_text=skip_label_text,
                 )
 
         return self._curves

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -496,6 +496,7 @@ class SingleDataset:
         self,
         index_tuple: list[int],
         axis_lookup: list[str],
+        *,
         skip_text: bool = False,
     ) -> str | float:
         """Get a meaningful label for a subset of data.
@@ -551,6 +552,7 @@ class SingleDataset:
         self,
         x_axis_details: tuple[str, str],
         max_limit: int = 1,
+        *,
         skip_label_text: bool = False,
     ) -> dict[int, np.ndarray]:
         """Prepare a set of curves for plotting.

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
@@ -304,7 +304,7 @@ class DatasetFormatter:
             )
         )
         # Add corner nil
-        xaxis = prepend(0.0, new_axes[axis_numbers[1 if flip_array else 0]].flat)
+        xaxis = prepend(0.0, new_axes[axis_numbers[flip_array]].flat)
 
         # Add axes to data
         data_lines = zip(

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
@@ -30,7 +30,11 @@ from MDANSE_GUI.Tabs.Plotters.Plotter import Plotter
 if TYPE_CHECKING:
     from qtpy.QtWidgets import QTextBrowser
 
-    from MDANSE_GUI.Tabs.Models.PlottingContext import PlottingContext, SingleDataset
+    from MDANSE_GUI.Tabs.Models.PlottingContext import (
+        PlotArgs,
+        PlottingContext,
+        SingleDataset,
+    )
 
 
 class DatasetFormatter:
@@ -82,7 +86,7 @@ class DatasetFormatter:
 
         for databundle in self._plotting_context.datasets().values():
             header, data = self.process_data(
-                databundle.dataset,
+                databundle,
                 main_axis=databundle.main_axis,
             )
             self._new_text.append(
@@ -97,7 +101,7 @@ class DatasetFormatter:
             return ["No data selected"]
 
         for databundle in self._plotting_context.datasets().values():
-            yield self.process_data(databundle.dataset, main_axis=databundle.main_axis)
+            yield self.process_data(databundle, main_axis=databundle.main_axis)
 
     def make_dataset_header(self, dataset: SingleDataset, comment_character="#"):
         """Return the dataset informartion as text.
@@ -154,21 +158,22 @@ class DatasetFormatter:
 
     def process_data(
         self,
-        dataset: SingleDataset,
+        databundle: PlotArgs,
         main_axis: str | None = None,
     ):
-        """Wrapper for approriately handling ND data."""
+        """Wrapper for appropriately handling ND data."""
+        dataset = databundle.dataset
 
         if dataset._n_dim == 1:
-            return self.process_1D_data(dataset)
+            return self.process_1D_data(databundle)
         if dataset._n_dim == 2:
-            return self.process_2D_data(dataset, main_axis=main_axis)
+            return self.process_2D_data(databundle, main_axis=main_axis)
 
-        return self.process_ND_data(dataset)
+        return self.process_ND_data(databundle)
 
     def process_1D_data(
         self,
-        dataset: SingleDataset,
+        databundle: PlotArgs,
     ) -> tuple[list[str], Iterator[Iterator[float]]]:
         """Turn a 1D array into text.
 
@@ -178,8 +183,8 @@ class DatasetFormatter:
 
         Parameters
         ----------
-        dataset : SingleDataset
-            A SingleDataset read from an .MDA file (HDF5).
+        dataset : PlotArgs
+            A SingleDataset with the GUI parameters.
 
         Returns
         -------
@@ -189,6 +194,7 @@ class DatasetFormatter:
             A data table with 2 columns.
 
         """
+        dataset = databundle.dataset
         header_lines, _ = self.make_dataset_header(
             dataset, comment_character=self._comment
         )
@@ -214,7 +220,7 @@ class DatasetFormatter:
 
     def process_2D_data(
         self,
-        dataset: SingleDataset,
+        databundle: PlotArgs,
         *,
         main_axis: str | None = None,
     ) -> tuple[list[str], Iterator[Iterator[float]]]:
@@ -222,8 +228,8 @@ class DatasetFormatter:
 
         Parameters
         ----------
-        dataset : SingleDataset
-            A SingleDataset read from an .MDA file (HDF5).
+        dataset : PlotArgs
+            A SingleDataset with the GUI parameters.
         main_axis : str or None
             Main axis to plot.
 
@@ -243,6 +249,8 @@ class DatasetFormatter:
             v
 
         """
+        dataset = databundle.dataset
+
         header_lines, comment_char = self.make_dataset_header(
             dataset, comment_character=self._comment
         )
@@ -267,18 +275,43 @@ class DatasetFormatter:
 
             LOG.debug(f"process_2D_data: axis {ax_key} has length {len(axis)}")
 
-            rc = "column" if n == flip_array else "row"
+            rc = "column" if n else "row"
             header_lines.append(
                 f"{comment_char} first {rc} is {ax_key} in units {new_unit}"
             )
 
         LOG.debug(f"Data shape: {dataset._data.shape}")
+        try:
+            best_unit, best_axis = (
+                dataset._axes_units[databundle.main_axis],
+                databundle.main_axis,
+            )
+        except KeyError:
+            best_unit, best_axis = dataset.longest_axis()
 
+        if self._is_preview:
+            curves_limit = self._preview_columns if flip_array else self._preview_lines
+        else:
+            curves_limit = (
+                dataset._data.shape[0] if flip_array else dataset._data.shape[1]
+            )
+
+        multi_curves = np.vstack(
+            list(
+                dataset.curves_vs_axis(
+                    (best_unit, best_axis), max_limit=curves_limit, skip_label_text=True
+                ).values()
+            )
+        )
         # Add corner nil
-        xaxis = prepend(0.0, new_axes[axis_numbers[1]].flat)
+        xaxis = prepend(0.0, new_axes[axis_numbers[1 if flip_array else 0]].flat)
 
         # Add axes to data
-        data_lines = zip(new_axes[axis_numbers[0]].flat, dataset.data, strict=True)
+        data_lines = zip(
+            dataset._curve_labels.values(),
+            multi_curves,
+            strict=True,
+        )
 
         # Put xaxis in
         temp = prepend(xaxis, data_lines)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Text.py
@@ -145,7 +145,12 @@ class DatasetFormatter:
             data = data_array
 
         text_data = "\n".join(
-            separator.join(str(round(x, self._rounding_prec)) for x in line)
+            separator.join(
+                str(round(x, self._rounding_prec))
+                if hasattr(x, "__round__")
+                else str(x)
+                for x in line
+            )
             for line in data
         )
 
@@ -304,7 +309,7 @@ class DatasetFormatter:
             )
         )
         # Add corner nil
-        xaxis = prepend(0.0, new_axes[axis_numbers[flip_array]].flat)
+        xaxis = prepend("_", new_axes[axis_numbers[flip_array]].flat)
 
         # Add axes to data
         data_lines = zip(


### PR DESCRIPTION
**Description of work**
In the MDANSE plotter, we are able to select specific rows or columns in a 2D array. However, the same input field is ignored in the `Text` "plotter". This PR makes it possible to pick a subset of data in the `Text` viewer and save it to a CSV file instead of saving all the rows and columns.

**Fixes**
1. Modify `Text` plotter to use the `curves_vs_axis` method.
2. Minor type hint corrections.

**To test**
Load a 2D dataset and plot it. Select two specific rows  or columns using the `Use it?` field.
Send the same dataset to the `Text` plotter. Try to show the same rows/columns in the text. (Disable/enable preview to check if that still works correctly.)

