### PR TITLE
Add switch for setting vector weights to 1

### DIFF
--- a/Doc/pages/analysis_jobs.rst
+++ b/Doc/pages/analysis_jobs.rst
@@ -69,9 +69,8 @@ Inputs:
 
 - trajectory: :ref:`configurator-analysis-HDFTrajectoryConfigurator` default=N/A
 - frames: :ref:`configurator-analysis-FramesConfigurator` default=(0, 1, 1)
-- atom_selection: :ref:`configurator-analysis-AtomSelectionConfigurator` default=N/A
+- atom_selection: :ref:`configurator-analysis-AtomSelectionConfigurator` default={"0": {"function_name": "select_all", "operation_type": "union"}}
 - fold: :ref:`configurator-analysis-BooleanConfigurator` default=False
-- grouping_level: :ref:`configurator-analysis-GroupingLevelConfigurator` default=molecule
 - output_files: :ref:`configurator-analysis-OutputTrajectoryConfigurator` default=N/A
 
 
@@ -160,7 +159,7 @@ Calculate the vibrational density of states of the trajectory.
 
 The Density Of States describes the number of vibrations per unit frequency.
 In MDANSE the DOS calculation returns the Fourier transform (FT) of the weighted
-Velocity AutoCorrelation Function (VACF). With an atomic mass weighting scheme
+Velocity Correlation Function (vcf). With an atomic mass weighting scheme
 the MDANSE DOS result is proportional to the actual vibrational DOS.
 The partial DOS corresponds to selected sets of atoms or molecules.
 
@@ -404,7 +403,6 @@ Inputs:
 - grouping_level: :ref:`configurator-analysis-GroupingLevelConfigurator` default=N/A
 - atom_selection: :ref:`configurator-analysis-AtomSelectionConfigurator` default=N/A
 - atom_transmutation: :ref:`configurator-analysis-AtomTransmutationConfigurator` default=N/A
-- weights: :ref:`configurator-analysis-WeightsConfigurator` default=N/A
 - output_files: :ref:`configurator-analysis-OutputFilesConfigurator` default=N/A
 - running_mode: :ref:`configurator-analysis-RunningModeConfigurator` default=N/A
 
@@ -498,14 +496,14 @@ Inputs:
 - running_mode: :ref:`configurator-analysis-RunningModeConfigurator` default=N/A
 
 
-.. _analysis-reference-PositionAutoCorrelationFunction:
+.. _analysis-reference-PositionCorrelationFunction:
 
-PositionAutoCorrelationFunction
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PositionCorrelationFunction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Calculates the position autocorrelation function.
+Calculates the position correlation function.
 
-Like the velocity autocorrelation function, but using positions instead of
+Like the velocity correlation function, but using positions instead of
 velocities.
 
 Inputs:
@@ -529,9 +527,9 @@ PositionPowerSpectrum
 Calculates the position power spectrum.
 
 Power spectrum (using Fast Fourier Transform) of atomic trajectories calculated
-from the Positional Autocorrelation Function (PACF). The calculation result
+from the Positional correlation Function (PCF). The calculation result
 is similar to the density of states, which is calculated from the velocity
-autocorrelation function. In fact, PPS and DOS may show the same features
+correlation function. In fact, PPS and DOS may show the same features
 in systems where position and velocity are strongly correlated (i.e. solids).
 
 This calculation is used by TrajectoryFilter to create a preview of the spectrum,
@@ -836,7 +834,7 @@ Inputs:
 - trajectory: :ref:`configurator-analysis-HDFTrajectoryConfigurator` default=N/A
 - frames: :ref:`configurator-analysis-FramesConfigurator` default=(0, 1, 1)
 - unit_cell: :ref:`configurator-analysis-UnitCellConfigurator` default=([[1, 0, 0], [0, 1, 0], [0, 0, 1]], False)
-- atom_selection: :ref:`configurator-analysis-AtomSelectionConfigurator` default=N/A
+- atom_selection: :ref:`configurator-analysis-AtomSelectionConfigurator` default={"0": {"function_name": "select_all", "operation_type": "union"}}
 - atom_transmutation: :ref:`configurator-analysis-AtomTransmutationConfigurator` default=N/A
 - atom_charges: :ref:`configurator-analysis-PartialChargeConfigurator` default={}
 - molecule_tolerance: :ref:`configurator-analysis-OptionalFloatConfigurator` default=[False, 0.04]
@@ -863,15 +861,12 @@ and the modified spectrum is Fourier-transformed back into positions.
 Inputs:
 
 - trajectory: :ref:`configurator-analysis-HDFTrajectoryConfigurator` default=N/A
-- frames: :ref:`configurator-analysis-CorrelationFramesConfigurator` default=N/A
-- instrument_resolution: :ref:`configurator-analysis-InstrumentResolutionConfigurator` default=N/A
-- projection: :ref:`configurator-analysis-ProjectionConfigurator` default=N/A
+- frames: :ref:`configurator-analysis-FramesConfigurator` default=N/A
+- pps_input_file: :ref:`configurator-analysis-HDFInputFileConfigurator` default=
 - trajectory_filter: :ref:`configurator-analysis-TrajectoryFilterConfigurator` default=N/A
 - atom_selection: :ref:`configurator-analysis-AtomSelectionConfigurator` default=N/A
 - atom_transmutation: :ref:`configurator-analysis-AtomTransmutationConfigurator` default=N/A
-- weights: :ref:`configurator-analysis-WeightsConfigurator` default=atomic_weight
 - output_files: :ref:`configurator-analysis-OutputTrajectoryConfigurator` default=N/A
-- running_mode: :ref:`configurator-analysis-RunningModeConfigurator` default=N/A
 
 
 .. _analysis-reference-VanHoveFunctionDistinct:
@@ -936,14 +931,14 @@ Inputs:
 - running_mode: :ref:`configurator-analysis-RunningModeConfigurator` default=N/A
 
 
-.. _analysis-reference-VelocityAutoCorrelationFunction:
+.. _analysis-reference-VelocityCorrelationFunction:
 
-VelocityAutoCorrelationFunction
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+VelocityCorrelationFunction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Calculates the velocity autocorrelation function of the selected atoms.
+Calculates the velocity correlation function of the selected atoms.
 
-The Velocity AutoCorrelation Function (VACF) is a property describing the dynamics
+The Velocity Correlation Function (VCF) is a property describing the dynamics
 of a molecular system. It reveals the underlying nature of the forces acting on
 the system. Its Fourier Transform gives the cartesian density of states for a set
 of atoms.

--- a/Doc/pages/parameters.rst
+++ b/Doc/pages/parameters.rst
@@ -202,7 +202,10 @@ Analysis Inputs
 AtomSelectionConfigurator
 -------------------------
 
-default={}
+default={
+        "0": {"function_name": "select_all", "operation_type": "union"},
+        "1": {"function_name": "select_dummy", "operation_type": "difference"}
+    }
 
 Selects atoms in trajectory based on the input string.
 
@@ -345,6 +348,28 @@ GridStepConfigurator
 
 default=0
 
+Configurator to manage a finite element grid within the unit cell.
+
+This configurator provides extra information about a grid in a
+trajectory's unit cell.
+
+It can also read a primary cell-vector along which the spacing is defined
+which is specified in the optional `axis` dependency
+(an :class:`AxisSelectionConfigurator` instance).
+
+If any frame does not have a unit cell, the maximum span of the atoms is
+used, otherwise the average unit cell is used.
+
+The input value specifies the grid spacing in `nm`.
+
+If `axis` is present, information about the prediction is stored in `grid`
+and is a single range along the primary axis.
+
+If `axis` is not present, information about the prediction is stored in the keys:
+
+- `a-direction grid`
+- `b-direction grid`
+- `c-direction grid`
 
 
 .. _configurator-analysis-GroupingLevelConfigurator:
@@ -593,7 +618,7 @@ Q vectors on Q-shells, each shell containing a set of Q vectors whose
 norm match the Q shell value within a given tolerance.
 
 Depending on the generator selected, Q vectors can be generated
-isotropically or anistropically, on a lattice or randomly.
+isotropically or anisotropically, on a lattice or randomly.
 
 
 
@@ -637,7 +662,7 @@ Selects a single item from multiple choices.
 TrajectoryFilterConfigurator
 ----------------------------
 
-default={"filter": "Butterworth", "attributes": {"order": 1, "attenuation_type": "lowpass", "cutoff_freq": 25.0}}
+default={"filter": "Butterworth", "attributes": {"order": 1, "attenuation_type": "lowpass", "cutoff_freq": 0.0001}}
 
 Defines the filter that will be applied to atom positions.
 

--- a/Doc/pages/qvectors.rst
+++ b/Doc/pages/qvectors.rst
@@ -52,3 +52,28 @@ handling jumps in particle trajectories. Here :math:`h`, :math:`k`, and :math:`l
 are integers, jumps in the particle trajectories
 produce phase changes of multiples of :math:`2\pi` in the Fourier transformed
 particle density, i.e. leave it unchanged.
+
+
+Random sampling of reciprocal space
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The current implementation of the lattice vector generators 
+:ref:`qvectors-reference-SphericalLatticeQVectors`,
+:ref:`qvectors-reference-CircularLatticeQVectors` and
+:ref:`qvectors-reference-LinearLatticeQVectors` assumes
+that different vectors can have different weights. This
+is meant to approximate a spherical distribution of vectors
+in low-symmetry systems where lattice vectors are not uniformly
+spaced, and also to give preference to vectors with :math:`|Q|`
+close to the nominal value for a specific shell. This behaviour
+is different from MDANSE 1.5, where the shell population was
+deterministic for shells containing less lattice vectors than
+the requested number, and stochastic with binary (0 or 1) weights
+for other shells.
+
+If you prefer to revert to the original weights scheme of MDANSE 1.5,
+you can set the variable :code:`force_equal_weights=True` for these
+vector generators. You can also save the value of this variable in your
+instrument profiles, so it is set to :code:`True` every time you set
+the vector parameters using these profiles.
+

--- a/Doc/pages/vector_generators.rst
+++ b/Doc/pages/vector_generators.rst
@@ -28,6 +28,7 @@ Inputs:
 - shells: :ref:`configurator-analysis-RangeConfigurator` default=(0.0, 5.0, 0.5)
 - n_vectors: :ref:`configurator-analysis-IntegerConfigurator` default=50
 - width: :ref:`configurator-analysis-FloatConfigurator` default=1.0
+- force_equal_weights: :ref:`configurator-analysis-BooleanConfigurator` default=False
 - axis: :ref:`configurator-analysis-VectorConfigurator` default=[0, 0, 1]
 
 
@@ -110,7 +111,7 @@ Inputs:
 - hrange: :ref:`configurator-analysis-RangeConfigurator` default=(0, 8, 1)
 - krange: :ref:`configurator-analysis-RangeConfigurator` default=(0, 8, 1)
 - lrange: :ref:`configurator-analysis-RangeConfigurator` default=(0, 8, 1)
-- qstep: :ref:`configurator-analysis-FloatConfigurator` default=0.01
+- q_step: :ref:`configurator-analysis-FloatConfigurator` default=0.2
 
 
 .. _qvectors-reference-LinearLatticeQVectors:
@@ -136,6 +137,7 @@ Inputs:
 - shells: :ref:`configurator-analysis-RangeConfigurator` default=(0, 5.0, 0.5)
 - n_vectors: :ref:`configurator-analysis-IntegerConfigurator` default=50
 - width: :ref:`configurator-analysis-FloatConfigurator` default=1.0
+- force_equal_weights: :ref:`configurator-analysis-BooleanConfigurator` default=False
 - axis: :ref:`configurator-analysis-VectorConfigurator` default=[1, 0, 0]
 
 
@@ -205,6 +207,7 @@ Inputs:
 - seed: :ref:`configurator-analysis-IntegerConfigurator` default=0
 - shells: :ref:`configurator-analysis-RangeConfigurator` default=(0, 5.0, 0.5)
 - n_vectors: :ref:`configurator-analysis-IntegerConfigurator` default=50
+- force_equal_weights: :ref:`configurator-analysis-BooleanConfigurator` default=False
 - width: :ref:`configurator-analysis-FloatConfigurator` default=1.0
 
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/CircularLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/CircularLatticeQVectors.py
@@ -54,6 +54,7 @@ class CircularLatticeQVectors(LatticeQVectors):
     )
     settings["n_vectors"] = ("IntegerConfigurator", {"mini": 1, "default": 50})
     settings["width"] = ("FloatConfigurator", {"mini": 1.0e-6, "default": 1.0})
+    settings["force_equal_weights"] = ("BooleanConfigurator", {"default": False})
     settings["axis"] = (
         "VectorConfigurator",
         {"normalize": False, "notNull": True, "valueType": float, "default": [0, 0, 1]},
@@ -93,6 +94,8 @@ class CircularLatticeQVectors(LatticeQVectors):
             if not len(weights):
                 self._configuration["q_vectors"][q] = None
                 continue
+            if self._configuration["force_equal_weights"]["value"]:
+                weights[:] = 1.0
 
             self._configuration["q_vectors"][q] = {
                 "q_vectors": self.hkl_to_qvectors(lattice_hkl_vectors, self._unit_cell),

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LinearLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LinearLatticeQVectors.py
@@ -50,6 +50,7 @@ class LinearLatticeQVectors(LatticeQVectors):
     )
     settings["n_vectors"] = ("IntegerConfigurator", {"mini": 1, "default": 50})
     settings["width"] = ("FloatConfigurator", {"mini": 1.0e-6, "default": 1.0})
+    settings["force_equal_weights"] = ("BooleanConfigurator", {"default": False})
     settings["axis"] = (
         "VectorConfigurator",
         {"normalize": True, "notNull": True, "valueType": float, "default": [1, 0, 0]},
@@ -86,6 +87,8 @@ class LinearLatticeQVectors(LatticeQVectors):
             if not len(weights):
                 self._configuration["q_vectors"][q] = None
                 continue
+            if self._configuration["force_equal_weights"]["value"]:
+                weights[:] = 1.0
 
             self._configuration["q_vectors"][q] = {
                 "q_vectors": self.hkl_to_qvectors(lattice_hkl_vectors, self._unit_cell),

--- a/MDANSE/Src/MDANSE/Framework/QVectors/SphericalLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/SphericalLatticeQVectors.py
@@ -47,6 +47,7 @@ class SphericalLatticeQVectors(LatticeQVectors):
         },
     )
     settings["n_vectors"] = ("IntegerConfigurator", {"mini": 1, "default": 50})
+    settings["force_equal_weights"] = ("BooleanConfigurator", {"default": False})
     settings["width"] = ("FloatConfigurator", {"mini": 1.0e-6, "default": 1.0})
 
     def _generate(self):
@@ -78,6 +79,8 @@ class SphericalLatticeQVectors(LatticeQVectors):
             if not len(weights):
                 self._configuration["q_vectors"][q] = None
                 continue
+            if self._configuration["force_equal_weights"]["value"]:
+                weights[:] = 1.0
 
             self._configuration["q_vectors"][q] = {
                 "q_vectors": self.hkl_to_qvectors(lattice_hkl_vectors, self._unit_cell),

--- a/MDANSE/Tests/UnitTests/Analysis/test_qvectors.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_qvectors.py
@@ -223,8 +223,7 @@ def test_disf(tmp_path, trajectory, qvector_generator):
  'SphericalLatticeQVectors',
  'CircularLatticeQVectors',
  'LinearLatticeQVectors'])
-@pytest.mark.parametrize("weights_flag", [True, False])
-def test_weights_flag_resets_weights(qvector_generator: str, weights_flag: bool):
+def test_weights_flag_resets_weights(qvector_generator: str, weights_flag: bool = True):
     """Check if the weights override flag resets vector weights to 1."""
     vec_par = copy.deepcopy(VEC_PARAMS)
     cell = UnitCell([[45, 45, 0], [45, 0, 45], [0, 45, 45]])
@@ -236,8 +235,6 @@ def test_weights_flag_resets_weights(qvector_generator: str, weights_flag: bool)
     qvg.generate()
     for key1 in qvg["q_vectors"]:
         weights = qvg["q_vectors"][key1]["weights"]
-        if weights_flag:
-            np.testing.assert_allclose(weights, 1)
-            assert np.isclose(0, np.std(weights))
-        else:
-            assert any(x != 1 for x in weights)
+        np.testing.assert_allclose(weights, 1)
+        assert np.isclose(0, np.std(weights))
+

--- a/MDANSE/Tests/UnitTests/Analysis/test_qvectors.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_qvectors.py
@@ -231,6 +231,7 @@ def test_weights_flag_resets_weights(qvector_generator: str, weights_flag: bool)
     qvg = IQVectors.create(qvector_generator, cell)
     vec_par["force_equal_weights"] = weights_flag
     vec_par["n_vectors"] = 1000
+    vec_par["shells"] =  (6.0, 7.0, 2.0)
     qvg.setup(vec_par)
     qvg.generate()
     for key1 in qvg["q_vectors"]:
@@ -239,5 +240,4 @@ def test_weights_flag_resets_weights(qvector_generator: str, weights_flag: bool)
             np.testing.assert_allclose(weights, 1)
             assert np.isclose(0, np.std(weights))
         else:
-            print(weights)
             assert any(x != 1 for x in weights)

--- a/MDANSE/Tests/UnitTests/Analysis/test_qvectors.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_qvectors.py
@@ -218,3 +218,26 @@ def test_disf(tmp_path, trajectory, qvector_generator):
 
     assert out_file.is_file()
     assert log_file.is_file()
+
+@pytest.mark.parametrize("qvector_generator", [
+ 'SphericalLatticeQVectors',
+ 'CircularLatticeQVectors',
+ 'LinearLatticeQVectors'])
+@pytest.mark.parametrize("weights_flag", [True, False])
+def test_weights_flag_resets_weights(qvector_generator: str, weights_flag: bool):
+    """Check if the weights override flag resets vector weights to 1."""
+    vec_par = copy.deepcopy(VEC_PARAMS)
+    cell = UnitCell([[45, 45, 0], [45, 0, 45], [0, 45, 45]])
+    qvg = IQVectors.create(qvector_generator, cell)
+    vec_par["force_equal_weights"] = weights_flag
+    vec_par["n_vectors"] = 1000
+    qvg.setup(vec_par)
+    qvg.generate()
+    for key1 in qvg["q_vectors"]:
+        weights = qvg["q_vectors"][key1]["weights"]
+        if weights_flag:
+            np.testing.assert_allclose(weights, 1)
+            assert np.isclose(0, np.std(weights))
+        else:
+            print(weights)
+            assert any(x != 1 for x in weights)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
@@ -171,6 +171,8 @@ class VectorModel(QStandardItemModel):
             return float(value)
         elif vtype == "IntegerConfigurator":
             return int(value)
+        elif vtype == "BooleanConfigurator":
+            return bool(value)
         else:
             return value
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentDetails.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtGui import QDoubleValidator, QIntValidator, QValidator
 from qtpy.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QGridLayout,
     QLabel,
@@ -166,6 +167,10 @@ class InstrumentDetails(QWidget):
             instance = VectorWidget(self)
             instance.set_value([0, 0, 0])
             instance.value_changed.connect(self.update_values)
+        elif widget == "QCheckBox":
+            instance = QCheckBox("", self)
+            instance.setChecked(False)
+            instance.checkStateChanged.connect(self.update_values)
         qlabel = QLabel(label, self)
         layout.addWidget(qlabel, next_row, 0)
         layout.addWidget(instance, next_row, 1)
@@ -192,6 +197,10 @@ class InstrumentDetails(QWidget):
     @Slot()
     def update_values(self):
         for key, value in self._widgets.items():
+            if hasattr(value, "isChecked"):
+                new_val = value.isChecked()
+                self._values[key] = new_val
+                continue
             try:
                 new_val = value.text()
             except AttributeError:
@@ -256,6 +265,9 @@ class InstrumentDetails(QWidget):
         self._current_instrument = None
         for key, widget in self._widgets.items():
             new_value = getattr(instrument_instance, key, "Nothing!")
+            if hasattr(widget, "setChecked"):
+                widget.setChecked(new_value)
+                continue
             try:
                 widget.setText(str(new_value))
             except AttributeError:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
@@ -88,6 +88,7 @@ class SimpleInstrument:
         self._axis_1 = [1, 0, 0]
         self._axis_2 = [0, 1, 0]
         self._vectors_per_shell = 100
+        self._force_equal_weights = False
         self._configured = False
         self._model_index = -1
 
@@ -107,6 +108,7 @@ class SimpleInstrument:
             ["_q_step", "QLineEdit", "float"],
             ["_q_width", "QLineEdit", "float"],
             ["_vectors_per_shell", "QLineEdit", "int"],
+            ["_force_equal_weights", "QCheckBox", "bool"],
             ["_axis_1", "VectorWidget", "float"],
             ["_axis_2", "VectorWidget", "float"],
         ]
@@ -191,6 +193,8 @@ class SimpleInstrument:
         if "axis_2" in qvec_generator._configuration:
             ax_vector = [float(x) for x in self._axis_2.split(",")]
             param_dictionary["axis_2"] = ax_vector
+        if "force_equal_weights" in qvec_generator._configuration:
+            param_dictionary["force_equal_weights"] = bool(self._force_equal_weights)
         mdanse_tuple = (
             cov_type,
             param_dictionary,


### PR DESCRIPTION
**Description of work**
For users who want to override the reciprocal space sampling, we add an additional configuration flag.

**Fixes**
1. Added new vector variable `force_equal_weights`,
2. Updated instrument profiles to store the new value.

**To test**
Try running the same DCSF analysis with and without weights override.
