### PR TITLE
Fix input parsing in QVectorsWidget

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/BooleanConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/BooleanConfigurator.py
@@ -17,6 +17,19 @@ from __future__ import annotations
 
 from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
 
+BOOL_MAPPING = {
+    True: True,
+    "true": True,
+    "yes": True,
+    "y": True,
+    "1": True,
+    False: False,
+    "false": False,
+    "no": False,
+    "n": False,
+    "0": False,
+}
+
 
 class BooleanConfigurator(IConfigurator):
     """Sets a value to a logical True or False.
@@ -27,19 +40,6 @@ class BooleanConfigurator(IConfigurator):
     """
 
     _default = False
-
-    _shortCuts = {
-        True: True,
-        "true": True,
-        "yes": True,
-        "y": True,
-        "1": True,
-        False: False,
-        "false": False,
-        "no": False,
-        "n": False,
-        "0": False,
-    }
 
     def configure(self, value):
         """
@@ -57,8 +57,9 @@ class BooleanConfigurator(IConfigurator):
 
         self._original_input = value
 
-        if value not in self._shortCuts:
+        value = value.lower() if isinstance(value, str) else value
+        if value not in BOOL_MAPPING:
             self.error_status = "Input is not recognised as a true/false value."
         else:
             self.error_status = "OK"
-            self["value"] = self._shortCuts[value]
+            self["value"] = BOOL_MAPPING[value]

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
@@ -36,6 +36,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from MDANSE.Framework.Configurators.BooleanConfigurator import BOOL_MAPPING
 from MDANSE.Framework.Configurators.QVectorsConfigurator import QVectorsConfigurator
 from MDANSE.Framework.QVectors.IQVectors import IQVectors
 from MDANSE.MLogging import LOG
@@ -172,7 +173,12 @@ class VectorModel(QStandardItemModel):
         elif vtype == "IntegerConfigurator":
             return int(value)
         elif vtype == "BooleanConfigurator":
-            return bool(value)
+            try:
+                value = BOOL_MAPPING[value.lower() if isinstance(value, str) else value]
+            except (KeyError, ValueError):
+                LOG.warning("Could not parse %s as logical true/false value", value)
+            else:
+                return value
         else:
             return value
 


### PR DESCRIPTION
**Description of work**
A few fixes to make "False" evaluate as `False`.

**Fixes**
1. Modified BooleanConfigurator,
2. Added checks to QVectorsWidget.

**To test**
Try running DCSF or DISF. Change the true/false values of `force_equal_weights`. The value should be parsed correctly. Invalid input should trigger a widget error.
