### PR TITLE
Fix the vector dialog getting stuck

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/PlottingContext.py
@@ -538,7 +538,9 @@ class SingleDataset:
                 label += f"{axis_label} has no values, unit {axis_unit}"
                 continue
 
-            if significant_digit < 0:
+            if significant_digit < -20:
+                picked_value = 0
+            elif significant_digit < 0:
                 picked_value = round(picked_value, abs(significant_digit) + 2)
             else:
                 picked_value = round(picked_value, 1)


### PR DESCRIPTION
**Description of work**
Adds the smallest possible change needed to prevent the vector dialog from getting stuck in an invalid state.

closes #1204

**Fixes**
1. Added a check for the rounding order being calculated as a very small number.

**To test**
Use default vector shell settings (including 0). Lower the shell width until an error is triggered. Increase the width again. The vector dialog should show valid values again.
