### PR TITLE
Enable deleting entries from the second dict in ChainMap

### DIFF
--- a/MDANSE/Src/MDANSE/Chemistry/Databases.py
+++ b/MDANSE/Src/MDANSE/Chemistry/Databases.py
@@ -749,8 +749,11 @@ class AtomsDatabase(_Database):
         """
         try:
             del self._data[symbol]
-        except KeyError as err:
-            raise AtomsDatabaseError(f"Atom {symbol} does not exist.") from err
+        except KeyError:
+            try:
+                del self._data.parents[symbol]
+            except KeyError as err:
+                raise AtomsDatabaseError(f"Atom {symbol} does not exist.") from err
 
     def remove_property(self, label: str):
         """Remove an atom property from the database.
@@ -787,7 +790,10 @@ class AtomsDatabase(_Database):
                 f"Cannot rename atom from {old_key} to {new_key} as {new_key}"
                 " already exists.",
             )
-        self._data[new_key] = self._data.pop(old_key)
+        try:
+            self._data[new_key] = self._data.pop(old_key)
+        except KeyError:
+            self._data[new_key] = self._data.parents.pop(old_key)
 
     def rename_atom_property(self, old_key: str, new_key: str):
         """Rename the atom property in the atom database.

--- a/MDANSE/Tests/UnitTests/test_databases.py
+++ b/MDANSE/Tests/UnitTests/test_databases.py
@@ -13,6 +13,8 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+from collections import ChainMap
+
 import unittest
 from unittest.mock import patch, mock_open
 
@@ -73,7 +75,7 @@ class TestAtomsDatabase(unittest.TestCase):
         ATOMS_DATABASE._load()
 
     def overwrite_database(self):
-        ATOMS_DATABASE._data = self.data
+        ATOMS_DATABASE._data = ChainMap(self.data)
         ATOMS_DATABASE._properties = self.properties
         ATOMS_DATABASE._units = self.units
 
@@ -252,7 +254,7 @@ class TestAtomsDatabase(unittest.TestCase):
 
     def test__reset(self):
         ATOMS_DATABASE._reset()
-        self.assertDictEqual({}, ATOMS_DATABASE._data)
+        self.assertDictEqual({}, dict(ATOMS_DATABASE._data))
         self.assertDictEqual({}, ATOMS_DATABASE._properties)
 
     def test_save(self):


### PR DESCRIPTION
**Description of work**
Since `AtomsDatabase` uses a `ChainMap` now, the custom atoms are in the first dictionary when they are created, but in the second dictionary once the database has been reloaded. The code deleting and renaming the atoms has to account for this. 

closes #1216

**Fixes**
If the atom entry is not in the first dictionary in `AtomsDatabase`, allow access to the second one (but not the ones beyond).

**To test**
Create new atoms in the element editor. Rename and delete them.
Create new atoms, then restart the GUI. Rename and delete them.

