### PR TITLE
Add checks for uneven time steps in frames and LAMMPS

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/FramesConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/FramesConfigurator.py
@@ -97,12 +97,8 @@ class FramesConfigurator(RangeConfigurator):
 
         self["n_frames"] = self["number"]
 
-        self["time"] = trajConfig["md_time_step"] * self["value"]
+        self["time"] = trajConfig["time_axis"][self["value"]]
 
-        # case of single frame selected
-        try:
-            self["time_step"] = self["time"][1] - self["time"][0]
-        except IndexError:
-            self["time_step"] = 1.0
+        self["time_step"] = trajConfig["md_time_step"]
 
         self["duration"] = self["time"] - self["time"][0]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -15,9 +15,13 @@
 #
 from __future__ import annotations
 
+import numpy as np
+
 from MDANSE import PLATFORM
 from MDANSE.Framework.Configurators.InputFileConfigurator import InputFileConfigurator
 from MDANSE.MolecularDynamics.Trajectory import Trajectory
+
+TIME_STEP_TOL = 1e-8
 
 
 class HDFTrajectoryConfigurator(InputFileConfigurator):
@@ -57,6 +61,8 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
         if value == self._original_input:
             return
         self._original_input = value
+        self.error_status = "OK"
+        self.warning_status = ""
 
         InputFileConfigurator.configure(self, value)
         try:
@@ -65,9 +71,8 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
             self.error_status = f"Could not use {value} as input trajectory."
             return
         self.extract_information(trajectory_instance)
-        self.error_status = "OK"
         if not trajectory_instance.non_dummy_elements:
-            self.warning_status = (
+            self.warning_status += (
                 "This trajectory contains only dummy atoms. "
                 "Analysis runs will fail or produce meaningless results."
             )
@@ -82,6 +87,20 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
         self["length"] = len(self["instance"])
 
         time_axis = self["instance"].time()
+        if len(time_axis) == 0:
+            self.error_status = "The trajectory does not contain any time steps"
+            return
+        if len(time_axis) == 1:
+            self["md_time_step"] = 1.0
+        else:
+            time_steps = np.diff(time_axis)
+            self["md_time_step"] = np.mean(time_steps)
+            if not np.std(time_steps) < TIME_STEP_TOL:
+                self.warning_status += (
+                    f"Time step size changes between {np.min(time_steps)} and {np.max(time_steps)}."
+                    " Most analysis types will not work correctly unless the time step is constant."
+                )
+
         try:
             self["md_time_step"] = time_axis[1] - time_axis[0]
         except IndexError:
@@ -89,6 +108,8 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
         except ValueError:
             self["md_time_step"] = 1.0
 
+        self["time_axis"] = time_axis
+
         self["has_velocities"] = "velocities" in self["instance"].variables()
 
-        self.warning_status = trajectory_instance.unit_cell_warning()
+        self.warning_status += trajectory_instance.unit_cell_warning()

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MockTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MockTrajectoryConfigurator.py
@@ -70,5 +70,6 @@ class MockTrajectoryConfigurator(IConfigurator):
 
         temp = self["instance"].time()
         self["md_time_step"] = temp[1] - temp[0]
+        self["time_axis"] = temp
 
         self["has_velocities"] = self["instance"].has_variable("velocities")

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -15,8 +15,6 @@
 #
 from __future__ import annotations
 
-from collections import defaultdict
-
 import numpy as np
 
 from MDANSE.Chemistry.ChemicalSystem import (

--- a/MDANSE/Src/MDANSE/Framework/Parsers/LAMMPS.py
+++ b/MDANSE/Src/MDANSE/Framework/Parsers/LAMMPS.py
@@ -17,13 +17,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from contextlib import suppress
-from enum import Enum, auto
+from enum import auto
 from itertools import count
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
-import h5py
 import numpy as np
 from more_itertools import consume as drop
 from more_itertools import ilen, take
@@ -40,11 +38,6 @@ from MDANSE.MolecularDynamics.Configuration import (
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
-
-if TYPE_CHECKING:
-    from MDANSE.Framework.Configurators.ConfigFileConfigurator import (
-        ConfigFileConfigurator,
-    )
 
 ELECTRON_CHARGE = 1.6021765e-19
 DIMS = ("x", "y", "z")
@@ -220,6 +213,8 @@ class LAMMPSReader(ABC):
         self._timestep = timestep
         self._fold = fold_coordinates
         self._file = None
+        self._last_timestep = None
+        self._last_timestep_difference = None
 
     @staticmethod
     def _add_bonds(config, chemical_system):
@@ -247,6 +242,20 @@ class LAMMPSReader(ABC):
             Scheme to set.
         """
         self.units = LAMMPS_UNITS[units]
+
+    def check_timestep_change(self, new_timestep: int):
+        if self._last_timestep is not None:
+            new_timestep_difference = new_timestep - self._last_timestep
+            if (
+                self._last_timestep_difference is not None
+                and new_timestep_difference != self._last_timestep_difference
+            ):
+                LOG.error(
+                    "Time step in LAMMPS trajectory has changed at frame with timestep %s",
+                    new_timestep,
+                )
+            self._last_timestep_difference = new_timestep_difference
+        self._last_timestep = new_timestep
 
     @staticmethod
     @abstractmethod
@@ -517,6 +526,8 @@ class LAMMPScustom(LAMMPSReader):
 
         time = int(step) * self._timestep * measure(1.0, self.units["time"]).toval("ps")
 
+        self.check_timestep_change(int(step))
+
         drop(
             file,
             self._item_location["BOX BOUNDS"][0] - self._item_location["TIMESTEP"][1],
@@ -686,6 +697,8 @@ class LAMMPSxyz(LAMMPSReader):
         number_of_atoms = int(line)
         line = self._file.readline()
         timestep = int(line.rsplit(maxsplit=1)[-1])
+
+        self.check_timestep_change(timestep)
 
         positions = np.empty((number_of_atoms, 3), dtype=np.float64)
         atom_types = np.empty(number_of_atoms, dtype=int)


### PR DESCRIPTION
**Description of work**
Recently, it was reported that invalid trajectories can be passed through the LAMMPS converter, leading to analysis problems later. The trajectories in question contained frames corresponding to different time intervals, and the resulting .mdt files could not be easily fixed using `TrajectoryEditor`.

This PR is meant to address the issue. LAMMPS converter will log an error if the time step between consecutive frames changes in the input file. An .mdt file containing frames with different time steps will produce a warning in the GUI. The reason why the conversion does not fail immediately is that the changes in this PR make it possible to remove the invalid frames using `TrajectoryEditor` or to omit them by setting the initial frame index to a non-zero value.

closes #1217

**Fixes**
1. `HDFTrajectoryConfigurator` shows a warning if the time steps in the input trajectory are not equal,
2. `FramesConfigurator` takes the time values from the trajectory instead of calculating them assuming an even step,
3. LAMMPS converter logs an error (but does **not** fail) if the time step in the input trajectory changes between frames.

**To test**
Try re-running analysis on known, correct trajectories using different values of `start, stop, step` in the frames configurator. The results should not change.
Convert a LAMMPS trajectory with additional frames which do not match the normal writeout interval. An error should be logged.
Load the trajectory and select `TrajectoryEditor`. A warning should be shown in the GUI. Remove the invalid frames; the time step in the output trajectory should be correct. 
