### PR TITLE
Improve vector statistics output

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/QVectors/IQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/IQVectors.py
@@ -81,6 +81,35 @@ def truncated_normal_distribution(
     )
 
 
+def calculate_average_q_per_shell(vector_config: IQVectors) -> npt.NDArray[float]:
+    r"""Calculates the average :math:`\mathbf{q}` per shell.
+
+    The averaging uses the weights determined by sampling the reciprocal space.
+
+    Parameters
+    ----------
+    vector_config : IQVectors
+        An instance of a q-vector generator. A subclass of IQVectors.
+
+    Returns
+    -------
+    npt.NDArray[float]
+        Array of average q per shell.
+    """
+    results = np.empty(len(vector_config._configuration["q_vectors"]))
+    for shell_index, shell_dict in enumerate(
+        vector_config._configuration["q_vectors"].values()
+    ):
+        if shell_dict is None or len(shell_dict["q_vectors"]) == 0:
+            results[shell_index] = np.nan
+            continue
+        results[shell_index] = np.average(
+            np.linalg.norm(shell_dict["q_vectors"], axis=0),
+            weights=shell_dict["weights"],
+        )
+    return results
+
+
 class IQVectors(Configurable, metaclass=SubclassFactory):
     """Parent class of all Q vector generators."""
 
@@ -228,6 +257,12 @@ class IQVectors(Configurable, metaclass=SubclassFactory):
             "vector_generator/q",
             "LineOutputVariable",
             q_values,
+            units="1/nm",
+        )
+        output_data.add(
+            "vector_generator/average_q",
+            "LineOutputVariable",
+            calculate_average_q_per_shell(self),
             units="1/nm",
         )
         output_data.add(

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -41,6 +41,8 @@ MAX_BINS_PER_SHELL = 20
 MIN_BINS_PER_SHELL = 1
 MAX_BINS_PER_PLOT = 180
 
+WEIGHTS_MULTIPLIER = 100
+
 
 def qvector_binning_from_dict(
     qvector_params: dict[str, Any],
@@ -452,7 +454,7 @@ def vector_q_statistics_datasets(
         data=[
             np.concatenate(
                 [
-                    int(vec_weights[shellindex][vecindex])
+                    int(vec_weights[shellindex][vecindex] * WEIGHTS_MULTIPLIER)
                     * list(always_iterable(veclen))
                     for vecindex, veclen in enumerate(
                         modq_per_shell[shellindex] - qvals[shell],


### PR DESCRIPTION
**Description of work**
Improvements to the way the vector distribution is presented.
New vector generation mechanism made it necessary to adjust the violin plot parameters.
Average |q| is written into the output files and can be compared to the nominal |q|.

**Fixes**
1. Weights used for generating multiple copies of vectors for the violin plot are now scaled by a constant before converting to `int`, reducing the fraction of weights that would otherwise be rounded to 0.
2. `average_q` is a new dataset written into .mda files, containing the weighted average of |q| of all the vectors in the shell.

**To test**
Run DCSF or DISF analysis. Check that the new dataset (`average_q`) is written into the output files and can be plotted.
