### PR TITLE
Adjust fpsampling in q-vector generator

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/QVectors/CircularLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/CircularLatticeQVectors.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import random
+from functools import partial
 
 import numpy as np
 from scipy.spatial import KDTree
@@ -102,7 +103,11 @@ class CircularLatticeQVectors(LatticeQVectors):
             q_vectors = q_vectors.T[selection].T
             n_found = q_vectors.shape[1]
 
-            selection = fpsampling(q_vectors.T, nvecs_per_shell)
+            selection = fpsampling(
+                q_vectors.T,
+                nvecs_per_shell,
+                partial(circle_of_vectors, q=1, q_width=0, n_vecs=1, rot_mat=rot_mat),
+            )
             lattice_hkl_vectors = lattice_hkl_vectors.T[selection].T
             q_vectors = q_vectors.T[selection].T
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
@@ -52,14 +52,24 @@ def fpsampling(q_vectors: np.ndarray, n_vecs: int) -> np.ndarray:
     elif n_points <= 0:
         raise ValueError("n_vecs should be greater than zero.")
 
-    q_vectors = q_vectors / np.linalg.norm(q_vectors, axis=0)
+    mag_q = np.linalg.norm(q_vectors, axis=1)
+    q_vectors = q_vectors / mag_q[:,None]
 
     dists = np.full(n_points, np.inf)
-    selected = np.random.randint(n_points)
     selection = np.zeros(n_vecs, dtype=int)
-    selection[0] = selected
+    start = 0
 
-    for i in range(1, n_vecs):
+    if np.any(mag_q == 0):
+        # always select the q-vector at the origin since the angle
+        # between that and other vectors are undefined
+        zero_idx = np.where(mag_q == 0)[0]
+        dists[zero_idx] = 0
+        selection[start] = zero_idx
+        start = 1
+
+    selected = np.random.randint(n_points)
+    selection[start] = selected
+    for i in range(start + 1, n_vecs):
         theta = np.arccos(np.clip(np.dot(q_vectors, q_vectors[selected]), -1.0, 1.0))
         dists = np.minimum(dists, theta)
         selected = np.argmax(dists)

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
@@ -23,6 +23,9 @@ from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 def fpsampling(q_vectors: np.ndarray, n_vecs: int) -> np.ndarray:
     """Basic farthest point sampling function used to sample q-vectors.
+    Q-vectors are normalised to avoid sampling vectors from the ends of
+    the shell. Distances between vectors are calculated on the angle
+    between them.
 
     Parameters
     ----------
@@ -49,15 +52,16 @@ def fpsampling(q_vectors: np.ndarray, n_vecs: int) -> np.ndarray:
     elif n_points <= 0:
         raise ValueError("n_vecs should be greater than zero.")
 
+    q_vectors = q_vectors / np.linalg.norm(q_vectors, axis=0)
+
     dists = np.full(n_points, np.inf)
     selected = np.random.randint(n_points)
     selection = np.zeros(n_vecs, dtype=int)
     selection[0] = selected
 
     for i in range(1, n_vecs):
-        diff = q_vectors - q_vectors[selected]
-        dist_sq = np.sum(diff**2, axis=1)
-        dists = np.minimum(dists, dist_sq)
+        theta = np.arccos(np.clip(np.dot(q_vectors, q_vectors[selected]), -1.0, 1.0))
+        dists = np.minimum(dists, theta)
         selected = np.argmax(dists)
         selection[i] = selected
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import numpy as np
 
 from MDANSE.Framework.QVectors.IQVectors import IQVectors
+from MDANSE.Framework.QVectors.SphericalQVectors import spherical_vectors
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 
@@ -53,23 +54,21 @@ def fpsampling(q_vectors: np.ndarray, n_vecs: int) -> np.ndarray:
         raise ValueError("n_vecs should be greater than zero.")
 
     mag_q = np.linalg.norm(q_vectors, axis=1)
-    q_vectors = q_vectors / mag_q[:,None]
+    if np.any(mag_q == 0):
+        # deal with the vector at the origin by turning into some
+        # random unit vector
+        random_vector = spherical_vectors(1, 0, 1).T[0]
+        zero_idx = np.where(mag_q == 0)[0]
+        q_vectors[zero_idx] = random_vector
+        mag_q[zero_idx] = 1
+    q_vectors = q_vectors / mag_q[:, None]
 
     dists = np.full(n_points, np.inf)
-    selection = np.zeros(n_vecs, dtype=int)
-    start = 0
-
-    if np.any(mag_q == 0):
-        # always select the q-vector at the origin since the angle
-        # between that and other vectors are undefined
-        zero_idx = np.where(mag_q == 0)[0]
-        dists[zero_idx] = 0
-        selection[start] = zero_idx
-        start = 1
-
     selected = np.random.randint(n_points)
-    selection[start] = selected
-    for i in range(start + 1, n_vecs):
+    selection = np.zeros(n_vecs, dtype=int)
+    selection[0] = selected
+
+    for i in range(1, n_vecs):
         theta = np.arccos(np.clip(np.dot(q_vectors, q_vectors[selected]), -1.0, 1.0))
         dists = np.minimum(dists, theta)
         selected = np.argmax(dists)

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
@@ -15,6 +15,9 @@
 #
 from __future__ import annotations
 
+from functools import partial
+from typing import Callable
+
 import numpy as np
 
 from MDANSE.Framework.QVectors.IQVectors import IQVectors
@@ -22,7 +25,9 @@ from MDANSE.Framework.QVectors.SphericalQVectors import spherical_vectors
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 
-def fpsampling(q_vectors: np.ndarray, n_vecs: int) -> np.ndarray:
+def fpsampling(
+    q_vectors: np.ndarray, n_vecs: int, random_vector_func: Callable[[], np.ndarray]
+) -> np.ndarray:
     """Basic farthest point sampling function used to sample q-vectors.
     Q-vectors are normalised to avoid sampling vectors from the ends of
     the shell. Distances between vectors are calculated on the angle
@@ -34,6 +39,8 @@ def fpsampling(q_vectors: np.ndarray, n_vecs: int) -> np.ndarray:
         Array of q_vectors.
     n_vecs : int
         Number of vectors to sample.
+    random_vector_func : Callable[[], np.ndarray]
+        A function which generates a single random vector.
 
     Returns
     -------
@@ -57,7 +64,7 @@ def fpsampling(q_vectors: np.ndarray, n_vecs: int) -> np.ndarray:
     if np.any(mag_q == 0):
         # deal with the vector at the origin by turning into some
         # random unit vector
-        random_vector = spherical_vectors(1, 0, 1).T[0]
+        random_vector = random_vector_func().T[0]
         zero_idx = np.where(mag_q == 0)[0]
         q_vectors[zero_idx] = random_vector
         mag_q[zero_idx] = 1

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
@@ -15,8 +15,8 @@
 #
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
-from typing import Callable
 
 import numpy as np
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LinearLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LinearLatticeQVectors.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import random
+from functools import partial
 
 import numpy as np
 from scipy.spatial import KDTree
@@ -95,7 +96,11 @@ class LinearLatticeQVectors(LatticeQVectors):
             q_vectors = q_vectors.T[selection].T
             n_found = q_vectors.shape[1]
 
-            selection = fpsampling(q_vectors.T, nvecs_per_shell)
+            selection = fpsampling(
+                q_vectors.T,
+                nvecs_per_shell,
+                partial(linear_vectors, q=1, q_width=0, n_vecs=1, axis=axis),
+            )
             lattice_hkl_vectors = lattice_hkl_vectors.T[selection].T
             q_vectors = q_vectors.T[selection].T
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/SphericalLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/SphericalLatticeQVectors.py
@@ -15,6 +15,8 @@
 #
 from __future__ import annotations
 
+from functools import partial
+
 import numpy as np
 from scipy.spatial import KDTree
 
@@ -87,7 +89,11 @@ class SphericalLatticeQVectors(LatticeQVectors):
             q_vectors = q_vectors.T[selection].T
             n_found = q_vectors.shape[1]
 
-            selection = fpsampling(q_vectors.T, nvecs_per_shell)
+            selection = fpsampling(
+                q_vectors.T,
+                nvecs_per_shell,
+                partial(spherical_vectors, q=1, q_width=0, n_vecs=1),
+            )
             lattice_hkl_vectors = lattice_hkl_vectors.T[selection].T
             q_vectors = q_vectors.T[selection].T
 


### PR DESCRIPTION
**Description of work**
Adjust the fpsampling method used so q-vectors are normalized before selecting them. This should avoid selecting q-vectors on the edges of the shell. Distances between q-vectors are now determined based on the angle between them.

**To test**
DCSF and DISF calculations with the lattice-based q-vector generator should work as usual.
