### PR TITLE
Handle different formats of vector statistics in the plotter

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -442,7 +442,11 @@ def vector_q_statistics_datasets(
         linestyle=":",
         marker="o",
         data=available_vectors,
-        plot_axes={"|q|": qvals[valid_shells]},
+        plot_axes={
+            "|q|": qvals
+            if len(qvals) == len(available_vectors)
+            else qvals[valid_shells]
+        },
         axes_units={"|q|": "1/nm"},
         optional_filename=filename,
     )


### PR DESCRIPTION
**Description of work**
Some DCSF or DISF result files can fail to plot the vector statistics if empty shells are included in the output. This PR aims to support both the old files (where the empty shells are skipped) and the new ones (where the empty shells are shown with vector count 0).

**Fixes**
1. Try to match the length of the q axis to the length of the vector count dataset.

**To test**
Load old files with empty shells and plot vector statistics.
Generate a DCSF file with empty vector shells and plot vector statistics.
Check that the vector preview still plots correctly if some of the vector shells are empty.
