### PR TITLE
Speed up scattering job loading in GUI

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/QVectorsConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/QVectorsConfigurator.py
@@ -43,7 +43,14 @@ class QVectorsConfigurator(IConfigurator):
 
     _default = (
         "SphericalLatticeQVectors",
-        {"shells": (0.1, 5, 0.1), "width": 0.1, "n_vectors": 1000, "seed": 0},
+        {
+            "shells": (0.0, 5.0, 1.0),
+            "width": 1.0,
+            "n_samples": 100000,
+            "n_vectors": 1000,
+            "seed": 0,
+            "force_equal_weights": False,
+        },
     )
     label = "Q vector generator"
     tooltip = "Determines how the q vectors will be generated and grouped into shells."

--- a/MDANSE/Src/MDANSE/Framework/QVectors/CircularLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/CircularLatticeQVectors.py
@@ -50,10 +50,10 @@ class CircularLatticeQVectors(LatticeQVectors):
             "valueType": float,
             "includeLast": True,
             "mini": 0.0,
-            "default": (0.0, 5.0, 0.5),
+            "default": (0.0, 5.0, 1.0),
         },
     )
-    settings["n_samples"] = ("IntegerConfigurator", {"mini": 1, "default": 100000})
+    settings["n_samples"] = ("IntegerConfigurator", {"mini": 1, "default": 50000})
     settings["n_vectors"] = ("IntegerConfigurator", {"mini": 1, "default": 100})
     settings["width"] = ("FloatConfigurator", {"mini": 1.0e-6, "default": 1.0})
     settings["force_equal_weights"] = ("BooleanConfigurator", {"default": False})

--- a/MDANSE/Src/MDANSE/Framework/QVectors/CircularQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/CircularQVectors.py
@@ -106,7 +106,7 @@ class CircularQVectors(IQVectors):
             "valueType": float,
             "includeLast": True,
             "mini": 0.0,
-            "default": (0.0, 5.0, 0.5),
+            "default": (0.0, 5.0, 1.0),
         },
     )
     settings["n_vectors"] = ("IntegerConfigurator", {"mini": 1, "default": 50})

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LinearLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LinearLatticeQVectors.py
@@ -46,10 +46,10 @@ class LinearLatticeQVectors(LatticeQVectors):
             "valueType": float,
             "includeLast": True,
             "mini": 0.0,
-            "default": (0, 5.0, 0.5),
+            "default": (0.0, 5.0, 1.0),
         },
     )
-    settings["n_samples"] = ("IntegerConfigurator", {"mini": 1, "default": 100000})
+    settings["n_samples"] = ("IntegerConfigurator", {"mini": 1, "default": 50000})
     settings["n_vectors"] = ("IntegerConfigurator", {"mini": 1, "default": 100})
     settings["width"] = ("FloatConfigurator", {"mini": 1.0e-6, "default": 1.0})
     settings["force_equal_weights"] = ("BooleanConfigurator", {"default": False})

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LinearQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LinearQVectors.py
@@ -69,7 +69,7 @@ class LinearQVectors(IQVectors):
             "valueType": float,
             "includeLast": True,
             "mini": 0.0,
-            "default": (0, 5.0, 0.5),
+            "default": (0.0, 5.0, 1.0),
         },
     )
     settings["n_vectors"] = ("IntegerConfigurator", {"mini": 1, "default": 50})

--- a/MDANSE/Src/MDANSE/Framework/QVectors/MillerIndicesQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/MillerIndicesQVectors.py
@@ -36,7 +36,7 @@ class MillerIndicesQVectors(LatticeQVectors):
             "valueType": float,
             "includeLast": True,
             "mini": 0.0,
-            "default": (0, 5.0, 0.5),
+            "default": (0.0, 5.0, 1.0),
         },
     )
     settings["width"] = ("FloatConfigurator", {"mini": 1.0e-6, "default": 1.0})

--- a/MDANSE/Src/MDANSE/Framework/QVectors/SphericalLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/SphericalLatticeQVectors.py
@@ -44,10 +44,10 @@ class SphericalLatticeQVectors(LatticeQVectors):
             "valueType": float,
             "includeLast": True,
             "mini": 0.0,
-            "default": (0, 5.0, 0.5),
+            "default": (0.0, 5.0, 1.0),
         },
     )
-    settings["n_samples"] = ("IntegerConfigurator", {"mini": 1, "default": 100000})
+    settings["n_samples"] = ("IntegerConfigurator", {"mini": 1, "default": 50000})
     settings["n_vectors"] = ("IntegerConfigurator", {"mini": 1, "default": 100})
     settings["force_equal_weights"] = ("BooleanConfigurator", {"default": False})
     settings["width"] = ("FloatConfigurator", {"mini": 1.0e-6, "default": 1.0})

--- a/MDANSE/Src/MDANSE/Framework/QVectors/SphericalQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/SphericalQVectors.py
@@ -76,7 +76,7 @@ class SphericalQVectors(IQVectors):
             "valueType": float,
             "includeLast": True,
             "mini": 0.0,
-            "default": (0, 5.0, 0.5),
+            "default": (0.0, 5.0, 1.0),
         },
     )
     settings["n_vectors"] = ("IntegerConfigurator", {"mini": 1, "default": 50})

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/QVectorsWidget.py
@@ -141,22 +141,25 @@ class VectorModel(QStandardItemModel):
         """Validate input types and return a dictionary of input parameters."""
         params = {}
         all_inputs_are_valid = True
-        for rownum in range(self.rowCount()):
-            name = str(self.item(rownum, 0).text())
-            value = str(self.item(rownum, 1).text())
-            vtype = str(self.item(rownum, 2).text())
-            try:
-                params[name] = self.parse_vtype(vtype, value, name)
-            except ValueError:
-                params[name] = "failed"
-            if params[name] == "failed":
-                self.item(rownum, 1).setData(
-                    QBrush(Qt.GlobalColor.red),
-                    role=Qt.ItemDataRole.BackgroundRole,
-                )
-                all_inputs_are_valid = False
-            else:
-                self.item(rownum, 1).setData(0, role=Qt.ItemDataRole.BackgroundRole)
+        with block_signals(self):
+            # block signals to stop updateValue call on the colour
+            # background change
+            for rownum in range(self.rowCount()):
+                name = str(self.item(rownum, 0).text())
+                value = str(self.item(rownum, 1).text())
+                vtype = str(self.item(rownum, 2).text())
+                try:
+                    params[name] = self.parse_vtype(vtype, value, name)
+                except ValueError:
+                    params[name] = "failed"
+                if params[name] == "failed":
+                    self.item(rownum, 1).setData(
+                        QBrush(Qt.GlobalColor.red),
+                        role=Qt.ItemDataRole.BackgroundRole,
+                    )
+                    all_inputs_are_valid = False
+                else:
+                    self.item(rownum, 1).setData(0, role=Qt.ItemDataRole.BackgroundRole)
         self.input_is_valid.emit(all_inputs_are_valid)
         return params
 


### PR DESCRIPTION
**Description of work**
Changed the default q-vectors setting so that the q-vectors are generated more quickly. Blocked signals when the q-vector table background colours are changed to stop q-vectors from being regenerated.

Selecting a scattering job that uses the q-vector generator should be faster.

**To test**
Run scattering jobs with different q-vector settings. Jobs should work as normal.
