### PR TITLE
Increase the PyQt6 version to 6.8.1

### DIFF
--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "matplotlib",
     "qtpy",
     "vtk>=9.4.0",
-    "PyQt6<=6.7.0",
+    "PyQt6<=6.8.1",
     "PyYAML",
     "tomlkit"
 ]


### PR DESCRIPTION
**Description of work**
We are switching from `PyQt6==6.7.0` to `6.8.1` as a compromise between supporting platforms with dated libraries and Python versions, and trying to stay up to date and using software that is still supported.

**Fixes**
1. Allowed PyQt6 version changed from 6.7.0 to 6.8.1.

**To test**
Please update the PyQt6 version on your platform and check if the GUI still runs correctly.

On a Mac I noticed at least one new glitch: in the trajectory view tab, scrolling up and down within the tab makes the 3D view move outside of its area:

<img width="1430" height="862" alt="Screenshot 2026-04-22 at 16 49 51" src="https://github.com/user-attachments/assets/89e01077-a800-4e08-bfb0-cd9f2870fde7" />
