### PR TITLE
Add a workaround so that GUI works with later version of pyqt6 on macOS

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -86,6 +86,7 @@ class SafeQVTKRenderWindowInteractor(QVTKRenderWindowInteractor):
     This prevents the known deadlock on macOS with Qt 6.9+ where
     vtkCocoaRenderWindow and Qt conflict over the Cocoa event loop.
     """
+
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent, **kwargs)
         self._is_exposed = False

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -1010,35 +1010,27 @@ class MolecularViewer(QtWidgets.QWidget):
         )
         self._colour_manager.rebuild_colours()
 
-        self.du_log = np.array(
-            [
-                self._element_database.get_atom_property(at, "dummy") == 0
-                for at in self._reader.atom_types
-            ]
-        )
-        self.not_du = np.array(
-            [
-                i
-                for i, at in enumerate(self._reader.atom_types)
-                if self._element_database.get_atom_property(at, "dummy") == 0
-            ]
-        )
-        self.covs = np.array(
-            [
-                self._element_database.get_atom_property(at, "covalent_radius")
-                for at in self._reader.atom_types
-            ]
-        )
+        self.du_log = np.array([
+            self._element_database.get_atom_property(at, "dummy") == 0
+            for at in self._reader.atom_types
+        ])
+        self.not_du = np.array([
+            i
+            for i, at in enumerate(self._reader.atom_types)
+            if self._element_database.get_atom_property(at, "dummy") == 0
+        ])
+        self.covs = np.array([
+            self._element_database.get_atom_property(at, "covalent_radius")
+            for at in self._reader.atom_types
+        ])
         self._current_coords = self._reader.read_frame(self._current_frame)
 
         self.clear_atom_trace()
 
-        self.set_atm_polydata_scalars(
-            (
-                self._colour_manager.colours,
-                self._colour_manager.radii,
-            )
-        )
+        self.set_atm_polydata_scalars((
+            self._colour_manager.colours,
+            self._colour_manager.radii,
+        ))
         self.update_atm_polydata()
         self.change_atm_polydata_lines()
         self.update_uc_polydata()

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import copy
 import math
+import sys
 from collections import ChainMap
 from enum import Enum
 from typing import Any, TypeAlias
@@ -25,7 +26,7 @@ import more_itertools
 import numpy as np
 import vtk
 from qtpy import QtWidgets
-from qtpy.QtCore import Signal, Slot
+from qtpy.QtCore import QTimer, Signal, Slot
 from qtpy.QtWidgets import QSizePolicy
 from scipy.interpolate import CubicSpline
 from scipy.spatial import cKDTree as KDTree
@@ -80,6 +81,39 @@ class BondCalc(Enum):
     FILE = "from file"
 
 
+class SafeQVTKRenderWindowInteractor(QVTKRenderWindowInteractor):
+    """Defers VTK rendering outside of Qt's synchronous paintEvent cycle.
+    This prevents the known deadlock on macOS with Qt 6.9+ where
+    vtkCocoaRenderWindow and Qt conflict over the Cocoa event loop.
+    """
+    def __init__(self, parent=None, **kwargs):
+        super().__init__(parent, **kwargs)
+        self._is_exposed = False
+        self._render_timer = QTimer(self)
+        self._render_timer.setSingleShot(True)
+        self._render_timer.timeout.connect(self._do_render)
+
+    def showEvent(self, ev):
+        super().showEvent(ev)
+        self._is_exposed = True
+
+    def hideEvent(self, ev):
+        super().hideEvent(ev)
+        self._is_exposed = False
+
+    def _do_render(self):
+        if self._is_exposed:
+            self._Iren.Render()
+
+    def paintEvent(self, ev):
+        if sys.platform == "darwin":
+            # Defer the render to avoid the nested event loop deadlock
+            self._render_timer.start(0)
+        else:
+            # Normal behavior on Windows/Linux
+            super().paintEvent(ev)
+
+
 class MolecularViewer(QtWidgets.QWidget):
     """MolecularViewer is a Qt widget containing a 3D viewer
     of molecular structures, currently implemented in VTK."""
@@ -98,7 +132,7 @@ class MolecularViewer(QtWidgets.QWidget):
         self._viewer_is_visible = False
         self.tab_index = -1
 
-        self._iren = QVTKRenderWindowInteractor(self)
+        self._iren = SafeQVTKRenderWindowInteractor(self)
         self._iren.keyPressEvent = lambda *args, **kwargs: None
 
         # the main render which includes the trajectory

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -1010,27 +1010,35 @@ class MolecularViewer(QtWidgets.QWidget):
         )
         self._colour_manager.rebuild_colours()
 
-        self.du_log = np.array([
-            self._element_database.get_atom_property(at, "dummy") == 0
-            for at in self._reader.atom_types
-        ])
-        self.not_du = np.array([
-            i
-            for i, at in enumerate(self._reader.atom_types)
-            if self._element_database.get_atom_property(at, "dummy") == 0
-        ])
-        self.covs = np.array([
-            self._element_database.get_atom_property(at, "covalent_radius")
-            for at in self._reader.atom_types
-        ])
+        self.du_log = np.array(
+            [
+                self._element_database.get_atom_property(at, "dummy") == 0
+                for at in self._reader.atom_types
+            ]
+        )
+        self.not_du = np.array(
+            [
+                i
+                for i, at in enumerate(self._reader.atom_types)
+                if self._element_database.get_atom_property(at, "dummy") == 0
+            ]
+        )
+        self.covs = np.array(
+            [
+                self._element_database.get_atom_property(at, "covalent_radius")
+                for at in self._reader.atom_types
+            ]
+        )
         self._current_coords = self._reader.read_frame(self._current_frame)
 
         self.clear_atom_trace()
 
-        self.set_atm_polydata_scalars((
-            self._colour_manager.colours,
-            self._colour_manager.radii,
-        ))
+        self.set_atm_polydata_scalars(
+            (
+                self._colour_manager.colours,
+                self._colour_manager.radii,
+            )
+        )
         self.update_atm_polydata()
         self.change_atm_polydata_lines()
         self.update_uc_polydata()

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "matplotlib",
     "qtpy",
     "vtk>=9.4.0",
-    "PyQt6<=6.7.0",
+    "PyQt6",
     "PyYAML",
     "tomlkit"
 ]


### PR DESCRIPTION
**Description of work**
Added a workaround to fix molecule viewer for macOS with later version of pyqt6. This change is similar to an update that pyvistaqt did, https://github.com/pyvista/pyvistaqt/pull/810.

**Fixes**
macOS with pyqt6 >= 6.9.0
closes #1154

**To test**
Test all part of the molecule viewer and molecule viewer in the atom selection with version 6.7, 6.8, 6.9, 6.10, and 6.11. Try resizing the GUI, minimising windows etc.
