### PR TITLE
Create MockTrajectory from an input JSON string

### DIFF
--- a/MDANSE/Src/MDANSE/MolecularDynamics/MockTrajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/MockTrajectory.py
@@ -507,14 +507,15 @@ class MockTrajectory:
         return list(grp.keys())
 
     @classmethod
-    def from_json(cls, filename: str) -> Trajectory:
-        """Builds and returns an instance of MockTrajectory
-        using the parameters in a JSON file.
+    def from_json(cls, text_input: str) -> Trajectory:
+        """Build and return an instance of MockTrajectory from a JSON definition.
+
+        It can be passed a JSON string or a filename of a JSON file.
 
         Parameters
         ----------
-        filename : str
-            must be a valid JSON file with "parameters",
+        text_input : str
+            Must be a JSON filename or a valid JSON string with "parameters",
             "coordinates" and "modulations" sections.
 
         Returns
@@ -522,8 +523,11 @@ class MockTrajectory:
         Trajectory
             a Trajectory instance with a MockTrajectory as internal object
         """
-        with open(filename, encoding="utf-8") as source:
-            struct = json.load(source)
+        try:
+            struct = json.loads(text_input)
+        except json.JSONDecodeError:
+            with open(text_input, encoding="utf-8") as source:
+                struct = json.load(source)
         temp = struct["parameters"]
         temp["box_size"] = np.array(temp["box_size"])
         instance = cls(**temp)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/MockTrajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/MockTrajectory.py
@@ -525,7 +525,7 @@ class MockTrajectory:
         """
         try:
             struct = json.loads(text_input)
-        except json.JSONDecodeError:
+        except (TypeError, json.JSONDecodeError):
             with open(text_input, encoding="utf-8") as source:
                 struct = json.load(source)
         temp = struct["parameters"]

--- a/MDANSE/Tests/UnitTests/test_mock_trajectory.py
+++ b/MDANSE/Tests/UnitTests/test_mock_trajectory.py
@@ -25,6 +25,24 @@ file_wd = os.path.dirname(os.path.realpath(__file__))
 
 mock_json = os.path.join(file_wd, "Data", "mock.json")
 
+mock_json_as_text = """{"parameters":
+{"number_of_frames": 100,
+"atoms_in_box": ["Si", "O", "H"],
+"box_repetitions": [3, 3, 3],
+"box_size": [[4.0, 0.0, 0.0], [0.0, 4.0, 0.0], [0.0, 0.0, 4.0]],
+"pbc": true},
+"coordinates":
+[[1.0, 1.0, 1.0], [1.0, 2.0, 1.0], [1.0, 2.0, 1.9]],
+"modulations": [
+    {"polarisation": [[1.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]],
+    "propagation_vector": [0.0, 0.0, 0.0],
+    "period": 20,
+    "amplitude": 0.2},
+    {"polarisation": [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
+    "propagation_vector": [1.0, 0.0, 0.0],
+    "period": 10,
+    "amplitude": 0.1}]}
+"""
 
 @pytest.fixture(scope="module")
 def static_trajectory():
@@ -129,6 +147,26 @@ def test_from_json(full_trajectory):
         0.1,
     )
     instance = MockTrajectory.from_json(mock_json)
+    assert full_trajectory._atom_types == instance.atom_types
+    print(full_trajectory.coordinates(25) - instance.coordinates(25))
+    assert np.allclose(full_trajectory.coordinates(25), instance.coordinates(25))
+    assert not np.allclose(full_trajectory.coordinates(25), instance.coordinates(22))
+
+
+def test_from_json_using_text(full_trajectory):
+    full_trajectory.modulate_structure(
+        np.array([[1.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]]),
+        np.array([0.0, 0.0, 0.0]),
+        20,
+        0.2,
+    )
+    full_trajectory.modulate_structure(
+        np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]]),
+        np.array([1.0, 0.0, 0.0]),
+        10,
+        0.1,
+    )
+    instance = MockTrajectory.from_json(mock_json_as_text)
     assert full_trajectory._atom_types == instance.atom_types
     print(full_trajectory.coordinates(25) - instance.coordinates(25))
     assert np.allclose(full_trajectory.coordinates(25), instance.coordinates(25))


### PR DESCRIPTION
**Description of work**
This does not affect the normal MDANSE workflow, but will be useful when using MDANSE as a library in other software.

**Fixes**
1. Allow passing a JSON string to `MockTrajectory.from_json` as an alternative to passing a file name of a file containing the JSON string.

**To test**
All tests should pass.
