### PR TITLE
Modernise pyprojects to use dependency-groups and uv workspaces

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install MDANSE
         working-directory: MDANSE
-        run: python -m pip install ".[test]"
+        run: python -m pip install --group test .
 
       - name: Run unit tests
         working-directory: MDANSE
@@ -66,11 +66,11 @@ jobs:
 
       - name: Install MDANSE
         working-directory: MDANSE
-        run: python -m pip install ".[test]"
+        run: python -m pip install --group test .
 
       - name: Install MDANSE_GUI
         working-directory: MDANSE_GUI
-        run: python -m pip install ".[test]"
+        run: python -m pip install --group test .
 
       - name: Run GUI unit tests
         working-directory: MDANSE_GUI

--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -43,11 +43,16 @@ dependencies = [
     "more-itertools",
 ]
 
-[project.optional-dependencies]
-cli=["tqdm"]
+[dependency-groups]
+dev = [
+  {include-group = "test"},
+  {include-group = "lint"}
+]
 test=["pytest", "pytest-timeout"]
 lint=["ruff<0.14"]
-# dynamic = ["version", "description"]
+
+[project.optional-dependencies]
+cli=["tqdm"]
 
 [project.urls]
 homepage = "https://pypi.org/project/MDANSE"

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -42,7 +42,11 @@ dependencies = [
     "tomlkit"
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
+dev = [
+  {include-group = "test"},
+  {include-group = "lint"}
+]
 test=["pytest", "pytest-timeout", "pytest-qt"]
 lint=["ruff<0.14"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "mdanse_project"
+version = "2.0.1"
+requires-python = ">=3.10"
+
+[tool.uv.sources]
+MDANSE = { workspace = true }
+MDANSE_GUI = { workspace = true }
+
+[tool.uv.workspace]
+members = ["MDANSE", "MDANSE_GUI"]


### PR DESCRIPTION
**Description of work**
Modernise pyproject.toml to exploit new (Oct. 2024; pip 25.1) features.

**Fixes**
For `pip install`:
- this should make no difference (besides PyPI not being able to also install lint/test) and changing to `pip install --group dev` to get lint/test groups.

For `uv`:
- This will automatically sync the `dev` group installing those packages.
- This will install both MDANSE/MDANSE_GUI (with deps) as editable in a shared venv which will be automatically updated. (`uv sync --all-packages`)

**To test**
Install with pip/uv