### PR TITLE
Fix for the sphericalqvector with a set seed and update mdanse to use new numpy approach to random number generation

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/QVectors/CircularLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/CircularLatticeQVectors.py
@@ -63,10 +63,7 @@ class CircularLatticeQVectors(LatticeQVectors):
     )
 
     def _generate(self):
-        if self._configuration["seed"]["value"] != 0:
-            rng = np.random.default_rng(self._configuration["seed"]["value"])
-        else:
-            rng = np.random.default_rng()
+        rng = np.random.default_rng(self._configuration["seed"]["value"] or None)
 
         nvecs_per_shell = self._configuration["n_vectors"]["value"]
         n_samples = self._configuration["n_samples"]["value"]

--- a/MDANSE/Src/MDANSE/Framework/QVectors/CircularLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/CircularLatticeQVectors.py
@@ -15,7 +15,6 @@
 #
 from __future__ import annotations
 
-import random
 from functools import partial
 
 import numpy as np
@@ -65,8 +64,9 @@ class CircularLatticeQVectors(LatticeQVectors):
 
     def _generate(self):
         if self._configuration["seed"]["value"] != 0:
-            np.random.seed(self._configuration["seed"]["value"])
-            random.seed(self._configuration["seed"]["value"])
+            rng = np.random.default_rng(self._configuration["seed"]["value"])
+        else:
+            rng = np.random.default_rng()
 
         nvecs_per_shell = self._configuration["n_vectors"]["value"]
         n_samples = self._configuration["n_samples"]["value"]
@@ -83,7 +83,7 @@ class CircularLatticeQVectors(LatticeQVectors):
         self._configuration["q_vectors"] = {}
 
         for q in self._configuration["shells"]["value"]:
-            samples = circle_of_vectors(q, width, n_samples, rot_mat=rot_mat)
+            samples = circle_of_vectors(q, width, n_samples, rot_mat=rot_mat, rng=rng)
             lattice_hkl_vectors, _ = self.lattice_vectors_with_weights(
                 samples,
                 self._unit_cell,
@@ -106,7 +106,15 @@ class CircularLatticeQVectors(LatticeQVectors):
             selection = fpsampling(
                 q_vectors.T,
                 nvecs_per_shell,
-                partial(circle_of_vectors, q=1, q_width=0, n_vecs=1, rot_mat=rot_mat),
+                partial(
+                    circle_of_vectors,
+                    q=1,
+                    q_width=0,
+                    n_vecs=1,
+                    rot_mat=rot_mat,
+                    rng=rng,
+                ),
+                rng,
             )
             lattice_hkl_vectors = lattice_hkl_vectors.T[selection].T
             q_vectors = q_vectors.T[selection].T
@@ -114,7 +122,9 @@ class CircularLatticeQVectors(LatticeQVectors):
             if self._configuration["force_equal_weights"]["value"]:
                 weights = np.ones(q_vectors.shape[1])
             else:
-                samples = circle_of_vectors(q, width, n_samples, rot_mat=rot_mat)
+                samples = circle_of_vectors(
+                    q, width, n_samples, rot_mat=rot_mat, rng=rng
+                )
                 tree = KDTree(q_vectors.T)
                 _, indices = tree.query(samples.T)
                 weights = np.bincount(indices, minlength=q_vectors.shape[1])

--- a/MDANSE/Src/MDANSE/Framework/QVectors/CircularQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/CircularQVectors.py
@@ -120,10 +120,7 @@ class CircularQVectors(IQVectors):
     )
 
     def _generate(self):
-        if self._configuration["seed"]["value"] != 0:
-            rng = np.random.default_rng(self._configuration["seed"]["value"])
-        else:
-            rng = np.random.default_rng()
+        rng = np.random.default_rng(self._configuration["seed"]["value"] or None)
 
         nvecs_per_shell = self._configuration["n_vectors"]["value"]
         target_circle_axis = self._configuration["axis"]["value"] / np.linalg.norm(

--- a/MDANSE/Src/MDANSE/Framework/QVectors/CircularQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/CircularQVectors.py
@@ -49,6 +49,7 @@ def circle_of_vectors(
     q_width: float,
     n_vecs: int,
     rot_mat: npt.NDArray[float] | None,
+    rng: np.random.Generator,
 ) -> npt.NDArray[float]:
     """Generate vectors on a circle in plane.
 
@@ -65,13 +66,15 @@ def circle_of_vectors(
         Number of vectors to generate.
     rot_mat : npt.NDArray[float] | None
         Rotation matrix to be applied to the generated points.
+    rng : np.random.Generator
+        A numpy random number generator object.
 
     Returns
     -------
     npt.NDArray[float]
         Array of 3D vectors in a circle with an arbitrary orientation.
     """
-    parameter_points = np.random.uniform(0.0, 2 * np.pi, n_vecs)
+    parameter_points = rng.uniform(0.0, 2 * np.pi, n_vecs)
     regular_circle = np.vstack(
         (
             np.sin(parameter_points),
@@ -83,7 +86,7 @@ def circle_of_vectors(
         regular_circle = np.dot(rot_mat, regular_circle)
     qmin = max(0.01 * abs(q), q - q_width / 2)
     qmax = q + q_width / 2
-    all_radii = truncated_normal_distribution(n_vecs, qmin, qmax, q_width, q)
+    all_radii = truncated_normal_distribution(n_vecs, qmin, qmax, q_width, q, rng=rng)
     return np.array(all_radii)[None, :n_vecs] * regular_circle
 
 
@@ -118,7 +121,9 @@ class CircularQVectors(IQVectors):
 
     def _generate(self):
         if self._configuration["seed"]["value"] != 0:
-            np.random.seed(self._configuration["seed"]["value"])
+            rng = np.random.default_rng(self._configuration["seed"]["value"])
+        else:
+            rng = np.random.default_rng()
 
         nvecs_per_shell = self._configuration["n_vectors"]["value"]
         target_circle_axis = self._configuration["axis"]["value"] / np.linalg.norm(
@@ -134,7 +139,9 @@ class CircularQVectors(IQVectors):
         self._configuration["q_vectors"] = {}
 
         for q in self._configuration["shells"]["value"]:
-            q_vectors = circle_of_vectors(q, width, nvecs_per_shell, rot_mat=rot_mat)
+            q_vectors = circle_of_vectors(
+                q, width, nvecs_per_shell, rot_mat=rot_mat, rng=rng
+            )
             self._configuration["q_vectors"][q] = {
                 "q_vectors": q_vectors,
                 "n_q_vectors": nvecs_per_shell,

--- a/MDANSE/Src/MDANSE/Framework/QVectors/IQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/IQVectors.py
@@ -40,6 +40,7 @@ def truncated_normal_distribution(
     right_limit: float,
     width: float,
     centre: float,
+    rng: np.random.Generator,
     zero_width_limit: float = 0.1,
 ) -> npt.NDArray[float]:
     """Generate a normal distribution of values within the specified limits.
@@ -58,6 +59,8 @@ def truncated_normal_distribution(
         Position of the maximum of the distribution.
     zero_width_limit : float, optional
         Limits used when width is 0 to guarantee non-zero domain width, by default 0.1.
+    rng : np.random.Generator
+        A numpy random number generator object.
 
     Returns
     -------
@@ -71,6 +74,7 @@ def truncated_normal_distribution(
             loc=centre,
             scale=0,
             size=n_elements,
+            random_state=rng,
         )
     return truncnorm.rvs(
         GAUSS_WIDTH_FACTOR * (left_limit - centre) / width,
@@ -78,6 +82,7 @@ def truncated_normal_distribution(
         loc=centre,
         scale=width / GAUSS_WIDTH_FACTOR,
         size=n_elements,
+        random_state=rng,
     )
 
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
@@ -16,17 +16,18 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from functools import partial
 
 import numpy as np
 
 from MDANSE.Framework.QVectors.IQVectors import IQVectors
-from MDANSE.Framework.QVectors.SphericalQVectors import spherical_vectors
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 
 def fpsampling(
-    q_vectors: np.ndarray, n_vecs: int, random_vector_func: Callable[[], np.ndarray]
+    q_vectors: np.ndarray,
+    n_vecs: int,
+    random_vector_func: Callable[[], np.ndarray],
+    rng: np.random.Generator,
 ) -> np.ndarray:
     """Basic farthest point sampling function used to sample q-vectors.
     Q-vectors are normalised to avoid sampling vectors from the ends of
@@ -41,6 +42,8 @@ def fpsampling(
         Number of vectors to sample.
     random_vector_func : Callable[[], np.ndarray]
         A function which generates a single random vector.
+    rng : np.random.Generator
+        A numpy random number generator object.
 
     Returns
     -------
@@ -56,7 +59,7 @@ def fpsampling(
     if n_vecs >= n_points:
         return np.arange(n_points)
     elif n_points == 1:
-        return np.array([np.random.randint(0, n_points)])
+        return np.array([rng.integers(low=0, high=n_points)])
     elif n_points <= 0:
         raise ValueError("n_vecs should be greater than zero.")
 
@@ -71,7 +74,7 @@ def fpsampling(
     q_vectors = q_vectors / mag_q[:, None]
 
     dists = np.full(n_points, np.inf)
-    selected = np.random.randint(n_points)
+    selected = rng.integers(low=0, high=n_points)
     selection = np.zeros(n_vecs, dtype=int)
     selection[0] = selected
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
@@ -59,16 +59,16 @@ def fpsampling(
     if n_vecs >= n_points:
         return np.arange(n_points)
     elif n_points == 1:
-        return np.array([rng.integers(low=0, high=n_points)])
+        return rng.integers(low=0, high=n_points, size=1)
     elif n_points <= 0:
         raise ValueError("n_vecs should be greater than zero.")
 
     mag_q = np.linalg.norm(q_vectors, axis=1)
-    if np.any(mag_q == 0):
+    if np.any(mag_q < 1e-9):
         # deal with the vector at the origin by turning into some
         # random unit vector
         random_vector = random_vector_func().T[0]
-        zero_idx = np.where(mag_q == 0)[0]
+        zero_idx = np.where(mag_q < 1e-9)[0]
         q_vectors[zero_idx] = random_vector
         mag_q[zero_idx] = 1
     q_vectors = q_vectors / mag_q[:, None]

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LinearLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LinearLatticeQVectors.py
@@ -60,10 +60,7 @@ class LinearLatticeQVectors(LatticeQVectors):
     )
 
     def _generate(self):
-        if self._configuration["seed"]["value"] != 0:
-            rng = np.random.default_rng(self._configuration["seed"]["value"])
-        else:
-            rng = np.random.default_rng()
+        rng = np.random.default_rng(self._configuration["seed"]["value"] or None)
 
         width = self._configuration["width"]["value"]
         axis = self._configuration["axis"]["vector"].array

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LinearLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LinearLatticeQVectors.py
@@ -61,8 +61,9 @@ class LinearLatticeQVectors(LatticeQVectors):
 
     def _generate(self):
         if self._configuration["seed"]["value"] != 0:
-            np.random.seed(self._configuration["seed"]["value"])
-            random.seed(self._configuration["seed"]["value"])
+            rng = np.random.default_rng(self._configuration["seed"]["value"])
+        else:
+            rng = np.random.default_rng()
 
         width = self._configuration["width"]["value"]
         axis = self._configuration["axis"]["vector"].array
@@ -76,7 +77,7 @@ class LinearLatticeQVectors(LatticeQVectors):
         self._configuration["q_vectors"] = {}
 
         for q in self._configuration["shells"]["value"]:
-            samples = linear_vectors(q, width, n_samples, axis)
+            samples = linear_vectors(q, width, n_samples, axis, rng)
             lattice_hkl_vectors, _ = self.lattice_vectors_with_weights(
                 samples,
                 self._unit_cell,
@@ -99,7 +100,8 @@ class LinearLatticeQVectors(LatticeQVectors):
             selection = fpsampling(
                 q_vectors.T,
                 nvecs_per_shell,
-                partial(linear_vectors, q=1, q_width=0, n_vecs=1, axis=axis),
+                partial(linear_vectors, q=1, q_width=0, n_vecs=1, axis=axis, rng=rng),
+                rng,
             )
             lattice_hkl_vectors = lattice_hkl_vectors.T[selection].T
             q_vectors = q_vectors.T[selection].T
@@ -107,7 +109,7 @@ class LinearLatticeQVectors(LatticeQVectors):
             if self._configuration["force_equal_weights"]["value"]:
                 weights = np.ones(q_vectors.shape[1])
             else:
-                samples = linear_vectors(q, width, n_samples, axis)
+                samples = linear_vectors(q, width, n_samples, axis, rng)
                 tree = KDTree(q_vectors.T)
                 _, indices = tree.query(samples.T)
                 weights = np.bincount(indices, minlength=q_vectors.shape[1])

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LinearQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LinearQVectors.py
@@ -21,7 +21,9 @@ import numpy.typing as npt
 from MDANSE.Framework.QVectors.IQVectors import IQVectors, truncated_normal_distribution
 
 
-def linear_vectors(q: float, q_width: float, n_vecs: int, axis: npt.NDArray[float]):
+def linear_vectors(
+    q: float, q_width: float, n_vecs: int, axis: npt.NDArray[float], rng
+):
     """Generate vectors on a line.
 
     The distribution will be normal in the |q| values around the
@@ -37,6 +39,8 @@ def linear_vectors(q: float, q_width: float, n_vecs: int, axis: npt.NDArray[floa
         Number of vectors to generate.
     axis: npt.NDArray[float]
         Defines a line in space on which the vectors are generated.
+    rng : np.random.Generator
+        A numpy random number generator object.
 
     Returns
     -------
@@ -45,7 +49,7 @@ def linear_vectors(q: float, q_width: float, n_vecs: int, axis: npt.NDArray[floa
     """
     qmin = max(0.01 * abs(q), q - q_width / 2)
     qmax = q + q_width / 2
-    all_radii = truncated_normal_distribution(n_vecs, qmin, qmax, q_width, q)
+    all_radii = truncated_normal_distribution(n_vecs, qmin, qmax, q_width, q, rng=rng)
     fact = np.array(all_radii)[:n_vecs]
     return axis[:, np.newaxis] * fact
 
@@ -81,7 +85,9 @@ class LinearQVectors(IQVectors):
 
     def _generate(self):
         if self._configuration["seed"]["value"] != 0:
-            np.random.seed(self._configuration["seed"]["value"])
+            rng = np.random.default_rng(self._configuration["seed"]["value"])
+        else:
+            rng = np.random.default_rng()
 
         axis = self._configuration["axis"]["vector"].array
 
@@ -95,7 +101,7 @@ class LinearQVectors(IQVectors):
         self._configuration["q_vectors"] = {}
 
         for q in self._configuration["shells"]["value"]:
-            q_vectors = linear_vectors(q, width, nvecs_per_shell, axis)
+            q_vectors = linear_vectors(q, width, nvecs_per_shell, axis, rng)
 
             self._configuration["q_vectors"][q] = {
                 "q_vectors": q_vectors,

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LinearQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LinearQVectors.py
@@ -22,7 +22,11 @@ from MDANSE.Framework.QVectors.IQVectors import IQVectors, truncated_normal_dist
 
 
 def linear_vectors(
-    q: float, q_width: float, n_vecs: int, axis: npt.NDArray[float], rng
+    q: float,
+    q_width: float,
+    n_vecs: int,
+    axis: npt.NDArray[float],
+    rng: np.random.Generator,
 ):
     """Generate vectors on a line.
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LinearQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LinearQVectors.py
@@ -84,10 +84,7 @@ class LinearQVectors(IQVectors):
     )
 
     def _generate(self):
-        if self._configuration["seed"]["value"] != 0:
-            rng = np.random.default_rng(self._configuration["seed"]["value"])
-        else:
-            rng = np.random.default_rng()
+        rng = np.random.default_rng(self._configuration["seed"]["value"] or None)
 
         axis = self._configuration["axis"]["vector"].array
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/SphericalLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/SphericalLatticeQVectors.py
@@ -56,7 +56,9 @@ class SphericalLatticeQVectors(LatticeQVectors):
 
     def _generate(self):
         if self._configuration["seed"]["value"] != 0:
-            np.random.seed(self._configuration["seed"]["value"])
+            rng = np.random.default_rng(self._configuration["seed"]["value"])
+        else:
+            rng = np.random.default_rng()
 
         width = self._configuration["width"]["value"]
 
@@ -69,7 +71,7 @@ class SphericalLatticeQVectors(LatticeQVectors):
         self._configuration["q_vectors"] = {}
 
         for q in self._configuration["shells"]["value"]:
-            samples = spherical_vectors(q, width, n_samples)
+            samples = spherical_vectors(q, width, n_samples, rng)
             lattice_hkl_vectors, _ = self.lattice_vectors_with_weights(
                 samples,
                 self._unit_cell,
@@ -93,6 +95,7 @@ class SphericalLatticeQVectors(LatticeQVectors):
                 q_vectors.T,
                 nvecs_per_shell,
                 partial(spherical_vectors, q=1, q_width=0, n_vecs=1),
+                rng,
             )
             lattice_hkl_vectors = lattice_hkl_vectors.T[selection].T
             q_vectors = q_vectors.T[selection].T
@@ -100,7 +103,7 @@ class SphericalLatticeQVectors(LatticeQVectors):
             if self._configuration["force_equal_weights"]["value"]:
                 weights = np.ones(q_vectors.shape[1])
             else:
-                samples = spherical_vectors(q, width, n_samples)
+                samples = spherical_vectors(q, width, n_samples, rng)
                 tree = KDTree(q_vectors.T)
                 _, indices = tree.query(samples.T)
                 weights = np.bincount(indices, minlength=q_vectors.shape[1])

--- a/MDANSE/Src/MDANSE/Framework/QVectors/SphericalLatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/SphericalLatticeQVectors.py
@@ -55,10 +55,7 @@ class SphericalLatticeQVectors(LatticeQVectors):
     settings["width"] = ("FloatConfigurator", {"mini": 1.0e-6, "default": 1.0})
 
     def _generate(self):
-        if self._configuration["seed"]["value"] != 0:
-            rng = np.random.default_rng(self._configuration["seed"]["value"])
-        else:
-            rng = np.random.default_rng()
+        rng = np.random.default_rng(self._configuration["seed"]["value"] or None)
 
         width = self._configuration["width"]["value"]
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/SphericalQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/SphericalQVectors.py
@@ -86,10 +86,7 @@ class SphericalQVectors(IQVectors):
     settings["width"] = ("FloatConfigurator", {"mini": 0.0, "default": 1.0})
 
     def _generate(self):
-        if self._configuration["seed"]["value"] != 0:
-            rng = np.random.default_rng(self._configuration["seed"]["value"])
-        else:
-            rng = np.random.default_rng()
+        rng = np.random.default_rng(self._configuration["seed"]["value"] or None)
 
         width = self._configuration["width"]["value"]
 

--- a/MDANSE/Src/MDANSE/Framework/QVectors/SphericalQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/SphericalQVectors.py
@@ -21,7 +21,9 @@ import numpy.typing as npt
 from MDANSE.Framework.QVectors.IQVectors import IQVectors, truncated_normal_distribution
 
 
-def spherical_vectors(q: float, q_width: float, n_vecs: int) -> npt.NDArray[float]:
+def spherical_vectors(
+    q: float, q_width: float, n_vecs: int, rng: np.random.Generator
+) -> npt.NDArray[float]:
     """Generate vectors on a sphere.
 
     The distribution should be uniform in angles, and normal in the
@@ -35,6 +37,8 @@ def spherical_vectors(q: float, q_width: float, n_vecs: int) -> npt.NDArray[floa
         The width of the |q| distribution.
     n_vecs : int
         Number of vectors to generate.
+    rng : np.random.Generator
+        A numpy random number generator object.
 
     Returns
     -------
@@ -43,10 +47,10 @@ def spherical_vectors(q: float, q_width: float, n_vecs: int) -> npt.NDArray[floa
     """
     qmin = max(0.01 * abs(q), q - q_width / 2)
     qmax = q + q_width / 2
-    all_radii = truncated_normal_distribution(n_vecs, qmin, qmax, q_width, q)
+    all_radii = truncated_normal_distribution(n_vecs, qmin, qmax, q_width, q, rng=rng)
     radii = np.array(all_radii)[:n_vecs]
-    theta = np.arccos(2 * np.random.random(size=n_vecs) - 1)
-    phi = 2 * np.pi * np.random.random(size=n_vecs)
+    theta = np.arccos(2 * rng.random(size=n_vecs) - 1)
+    phi = 2 * np.pi * rng.random(size=n_vecs)
     return np.vstack(
         (
             radii * np.sin(theta) * np.cos(phi),
@@ -83,7 +87,9 @@ class SphericalQVectors(IQVectors):
 
     def _generate(self):
         if self._configuration["seed"]["value"] != 0:
-            np.random.seed(self._configuration["seed"]["value"])
+            rng = np.random.default_rng(self._configuration["seed"]["value"])
+        else:
+            rng = np.random.default_rng()
 
         width = self._configuration["width"]["value"]
 
@@ -95,7 +101,7 @@ class SphericalQVectors(IQVectors):
             self._status.start(len(self._configuration["shells"]["value"]))
 
         for q in self._configuration["shells"]["value"]:
-            q_vectors = spherical_vectors(q, width, nvecs_per_shell)
+            q_vectors = spherical_vectors(q, width, nvecs_per_shell, rng)
 
             self._configuration["q_vectors"][q] = {
                 "q_vectors": q_vectors,

--- a/MDANSE/Src/MDANSE/Framework/QVectors/SphericalQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/SphericalQVectors.py
@@ -45,9 +45,8 @@ def spherical_vectors(q: float, q_width: float, n_vecs: int) -> npt.NDArray[floa
     qmax = q + q_width / 2
     all_radii = truncated_normal_distribution(n_vecs, qmin, qmax, q_width, q)
     radii = np.array(all_radii)[:n_vecs]
-    rng = np.random.default_rng()
-    theta = np.arccos(2 * rng.random(size=n_vecs) - 1)
-    phi = 2 * np.pi * rng.random(size=n_vecs)
+    theta = np.arccos(2 * np.random.random(size=n_vecs) - 1)
+    phi = 2 * np.pi * np.random.random(size=n_vecs)
     return np.vstack(
         (
             radii * np.sin(theta) * np.cos(phi),


### PR DESCRIPTION
**Description of work**
Updated `def spherical_vectors(q: float, q_width: float, n_vecs: int)` so that it uses the random number generator, which should have its seed set by MDANSE and not randomly.

Updated MDANSE so that the new approach to random number generation is used.

**Fixes**
Fixes #1237

**To test**
Run a few of the same jobs with the sphericalqvector generator with a seed set to something other than zero, but the same. Check that the q-vectors in the vector plots are the same. Do this with sphericallatticeqvector generator, check that the weights are the same. 

Check setting the seed with the other q-vector generator circularlatticeqvector, circularqvector, linearlatticeqvector, and the linearqvector continue to work with the seed set and also continue to be random with the seed set to zero.
