### PR TITLE
HDF5 parameters for chunking and cache size

### DIFF
--- a/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
+++ b/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
@@ -19,11 +19,11 @@ import copy
 import itertools as it
 from collections import defaultdict
 from collections.abc import Iterable
-from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, SupportsInt
 
 import h5py
+import more_itertools
 import networkx as nx
 import numpy as np
 from more_itertools import padded
@@ -440,7 +440,7 @@ class ChemicalSystem:
         while len(atom_pool) > 0:
             last_atom = atom_pool.pop()
             temp_dict = nx.dfs_successors(total_graph, last_atom)
-            others = reduce(list.__iadd__, temp_dict.values(), [])
+            others = list(more_itertools.flatten(temp_dict.values()))
             for atom in others:
                 atom_pool.remove(atom)
             molecule = [last_atom, *others]

--- a/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
+++ b/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
@@ -84,7 +84,12 @@ def assign_molecules_after_atom_selection(
 class ChemicalSystem:
     """Stores the contents and topology of a trajectory."""
 
-    def __init__(self, name: str = "", trajectory: Trajectory | None = None):
+    def __init__(
+        self,
+        name: str = "",
+        trajectory: Trajectory | None = None,
+        fast_load: bool = False,
+    ):
         """Populate the arrays with values from the trajectory.
 
         Parameters
@@ -93,9 +98,12 @@ class ChemicalSystem:
             text label of this system
         trajectory : Trajectory, optional
             instance of the Trajectory class, by default None
+        fast_load : bool, optional
+            Skip molecule detection if True, by default False
         """
         self.name = str(name)
         self._database = ATOMS_DATABASE
+        self._fast_load = fast_load
         if trajectory is not None:
             self._database = trajectory
 

--- a/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
+++ b/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
@@ -71,14 +71,14 @@ def assign_molecules_after_atom_selection(
     new_cs.add_bonds(selected_bonds)
 
     selected_clusters = defaultdict(list)
-    for key, vals in original_cs._clusters.items():
+    for key, vals in original_cs.clusters.items():
         for val in vals:
             new_cluster = set(val) & selected_idxs
             if new_cluster:
                 new_cluster = sorted(indx_map[i] for i in new_cluster)
                 selected_clusters[key].append(new_cluster)
 
-    new_cs._clusters = selected_clusters
+    new_cs.clusters = selected_clusters
 
 
 class ChemicalSystem:
@@ -115,7 +115,7 @@ class ChemicalSystem:
 
         self._bonds: list[tuple[SupportsInt, SupportsInt]] = []
 
-        self._clusters: dict[str, list[list[int]]] = {}
+        self.clusters: dict[str, list[list[int]]] = {}
 
         self.rdkit_mol = Chem.RWMol()
         # rdkit DetermineBondOrders doesn't work with dummy atoms. we
@@ -130,7 +130,7 @@ class ChemicalSystem:
     def __str__(self):
         return (
             f"ChemicalSystem {self.name} consisting of {len(self._atom_types)}"
-            f" atoms in {len(self._clusters)} molecules"
+            f" atoms in {len(self.clusters)} molecules"
         )
 
     def initialise_atoms(
@@ -209,8 +209,8 @@ class ChemicalSystem:
         # types for all others. We also need to remove dummy atom before
         # using rdDetermineBonds.DetermineBondOrders because it can't
         # deal with them.
-        for cluster_name in self._clusters:
-            for idx, cluster in enumerate(self._clusters[cluster_name]):
+        for cluster_name in self.clusters:
+            for idx, cluster in enumerate(self.clusters[cluster_name]):
                 cluster_no_dummies = [
                     i for i in cluster if i not in self._rdkit_dummy_atms
                 ]
@@ -319,10 +319,10 @@ class ChemicalSystem:
                 for atom, count in zip(unique_atoms, counts, strict=True)
             )
 
-            if name not in self._clusters:
-                self._clusters[name] = [sorted_group]
-            elif sorted_group not in self._clusters[name]:
-                self._clusters[name].append(group)
+            if name not in self.clusters:
+                self.clusters[name] = [sorted_group]
+            elif sorted_group not in self.clusters[name]:
+                self.clusters[name].append(group)
 
     def has_substructure_match(self, smarts: str) -> bool:
         """Check if there is a substructure match.
@@ -449,11 +449,11 @@ class ChemicalSystem:
 
     def unique_molecules(self) -> list[str]:
         """Return the list of unique names in the chemical system."""
-        return [str(x) for x in self._clusters]
+        return [str(x) for x in self.clusters]
 
     def number_of_molecules(self, molecule_name: str) -> int:
         """Return the number of molecules with the given name in the system."""
-        return len(self._clusters[molecule_name])
+        return len(self.clusters[molecule_name])
 
     @property
     def number_of_atoms(self) -> int:
@@ -494,7 +494,7 @@ class ChemicalSystem:
         for key, value in self._labels.items():
             label_group.create_dataset(key, data=value)
         clusters_group = grp.create_group("clusters")
-        for key, vals in self._clusters.items():
+        for key, vals in self.clusters.items():
             # unable to store array with inhomogeneous row lengths
             # we will pad them with -1, we will ignore these values
             # when the trajectory get loaded up see self.load
@@ -547,7 +547,7 @@ class ChemicalSystem:
         }
 
         for cluster in grp["clusters"]:
-            self._clusters[str(cluster)] = [
+            self.clusters[str(cluster)] = [
                 [int(x) for x in line if int(x) >= 0]
                 for line in grp[f"clusters/{cluster}"]
             ]

--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/molecule_selection.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/molecule_selection.py
@@ -33,7 +33,7 @@ def select_molecules(
     trajectory : Trajectory
         A trajectory instance to which the selection is applied
     molecule_names : Sequence[str]
-        a list of molecule names (str) which are keys of ChemicalSystem._clusters
+        a list of molecule names (str) which are keys of ChemicalSystem.clusters
 
     Returns
     -------
@@ -45,7 +45,7 @@ def select_molecules(
     selection = {
         index
         for molecule in molecule_names
-        for cluster in system._clusters.get(molecule, ())
+        for cluster in system.clusters.get(molecule, ())
         for index in cluster
     }
     return selection

--- a/MDANSE/Src/MDANSE/Framework/AtomSelector/selection_builder.py
+++ b/MDANSE/Src/MDANSE/Framework/AtomSelector/selection_builder.py
@@ -271,7 +271,7 @@ class SelectionBuilder:
         operation_type: OperationType
             What set operation to perform.
         molecule_names : Sequence[str]
-            a list of molecule names (str) which are keys of ChemicalSystem._clusters
+            a list of molecule names (str) which are keys of ChemicalSystem.clusters
         """
         operation_type = OperationType(operation_type).name.lower()
         self.ops.append(

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -109,7 +109,9 @@ def guess_hdf5_trajectory_parameters(fname: str | Path) -> tuple[int, int]:
     traj_length = len(trajectory_instance)
     chunk_size = trajectory_instance.chunk_size()
     bytes_per_num = trajectory_instance.dtype_size()
-    cache_size = 2 * traj_length * chunk_size * 3 * bytes_per_num
+    if chunk_size < 0 or bytes_per_num < 0:
+        return None, None
+    cache_size = 200 * traj_length * chunk_size * 3 * bytes_per_num
     cache_slots = next_prime(80 * traj_length * 3)
     trajectory_instance.close()
     return cache_size, cache_slots

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -98,10 +98,10 @@ def next_prime(nchunks: int) -> int:
     int
         A prime number larger than the input number.
     """
-    for prime in PRIMES:
-        if prime > nchunks:
-            return prime
-    return nchunks
+    import bisect
+
+    ip = bisect.bisect_right(nchunks, PRIMES)
+    return nchunks if ip == len(PRIMES) else PRIMES[ip]
 
 
 def guess_hdf5_trajectory_parameters(
@@ -154,17 +154,18 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
         self.error_status = "OK"
         self.warning_status = ""
 
-        if isinstance(value, (str, Path)):
-            file_name = value
-            driver = None
-            rdcc_nbytes, rdcc_nslots = guess_hdf5_trajectory_parameters(value)
-            rdcc_w0 = None
-        else:
-            file_name = value[0]
-            driver = value[1] if value[1] in HDF5_DRIVERS else None
-            rdcc_nbytes = value[2]
-            rdcc_nslots = value[3]
-            rdcc_w0 = value[4]
+        match value:
+            case str() | Path():
+                file_name = value
+                driver = None
+                rdcc_nbytes, rdcc_nslots = guess_hdf5_trajectory_parameters(value)
+                rdcc_w0 = None
+            case (str(), str(), int(), int(), int()):
+                file_name, driver, rdcc_nbytes, rdcc_nslots, rdcc_w0 = value
+                driver = driver if driver in HDF5_DRIVERS else None
+            case _:
+                self.error_status = f"Invalid value {value!r}"
+                return 
 
         self["driver"] = driver
         self["rdcc_nbytes"] = rdcc_nbytes

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+import bisect
 from pathlib import Path
 
 import h5py
@@ -23,7 +24,7 @@ import numpy as np
 from MDANSE import PLATFORM
 from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
 from MDANSE.Framework.Configurators.InputFileConfigurator import InputFileConfigurator
-from MDANSE.MolecularDynamics.Trajectory import Trajectory, check_hdf5_driver
+from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
 TIME_STEP_TOL = 1e-8
 DATASET_CACHE_SIZE = 2**24
@@ -98,9 +99,7 @@ def next_prime(nchunks: int) -> int:
     int
         A prime number larger than the input number.
     """
-    import bisect
-
-    ip = bisect.bisect_right(nchunks, PRIMES)
+    ip = bisect.bisect_right(PRIMES, nchunks)
     return nchunks if ip == len(PRIMES) else PRIMES[ip]
 
 
@@ -160,12 +159,12 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
                 driver = None
                 rdcc_nbytes, rdcc_nslots = guess_hdf5_trajectory_parameters(value)
                 rdcc_w0 = None
-            case (str(), str(), int(), int(), int()):
+            case (str() | Path(), str(), int(), int(), float()):
                 file_name, driver, rdcc_nbytes, rdcc_nslots, rdcc_w0 = value
                 driver = driver if driver in HDF5_DRIVERS else None
             case _:
                 self.error_status = f"Invalid value {value!r}"
-                return 
+                return
 
         self["driver"] = driver
         self["rdcc_nbytes"] = rdcc_nbytes

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -104,7 +104,9 @@ def next_prime(nchunks: int) -> int:
     return nchunks
 
 
-def guess_hdf5_trajectory_parameters(fname: str | Path) -> tuple[int, int]:
+def guess_hdf5_trajectory_parameters(
+    fname: str | Path,
+) -> tuple[int, int] | tuple[None, None]:
     trajectory_instance = Trajectory(fname)
     traj_length = len(trajectory_instance)
     chunk_size = trajectory_instance.chunk_size()
@@ -169,17 +171,21 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
         self["rdcc_nslots"] = rdcc_nslots
         self["rdcc_w0"] = rdcc_w0
         InputFileConfigurator.configure(self, file_name)
-        try:
-            trajectory_instance = Trajectory(
-                self["value"],
-                hdf5_driver="core" if check_hdf5_driver() else None,
-                rdcc_nbytes=rdcc_nbytes,
-                rdcc_nslots=rdcc_nslots,
-                rdcc_w0=rdcc_w0,
-            )
-        except KeyError:
-            self.error_status = f"Could not use {value} as input trajectory."
-            return
+        self._original_input = value
+        if "instance" in self and isinstance(self["instance"], Trajectory):
+            trajectory_instance = self["instance"]
+        else:
+            try:
+                trajectory_instance = Trajectory(
+                    self["value"],
+                    hdf5_driver=driver,
+                    rdcc_nbytes=rdcc_nbytes,
+                    rdcc_nslots=rdcc_nslots,
+                    rdcc_w0=rdcc_w0,
+                )
+            except KeyError:
+                self.error_status = f"Could not use {value} as input trajectory."
+                return
         self.extract_information(trajectory_instance)
         if not trajectory_instance.non_dummy_elements:
             self.warning_status += (

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -15,6 +15,9 @@
 #
 from __future__ import annotations
 
+from pathlib import Path
+
+import h5py
 import numpy as np
 
 from MDANSE import PLATFORM
@@ -24,6 +27,92 @@ from MDANSE.MolecularDynamics.Trajectory import Trajectory, check_hdf5_driver
 
 TIME_STEP_TOL = 1e-8
 DATASET_CACHE_SIZE = 2**24
+
+HDF5_DRIVERS = h5py.registered_drivers()
+PRIMES = [
+    10831,
+    15991,
+    23599,
+    34871,
+    51511,
+    76099,
+    112429,
+    166099,
+    245383,
+    362521,
+    535571,
+    791251,
+    1168957,
+    1726993,
+    2551421,
+    3769397,
+    5568817,
+    8227259,
+    12154757,
+    17957167,
+    26529487,
+    39194117,
+    57904453,
+    85546733,
+    126384823,
+    186718139,
+    275853173,
+    407539309,
+    602089451,
+    889513501,
+    1314147377,
+    1941491989,
+    2868316837,
+    4237587173,
+    6260516599,
+    9249147301,
+    13664483509,
+    20187602569,
+    29824712917,
+    44062364303,
+    65096752333,
+    96172487161,
+    142083083267,
+    209910372047,
+    310116892681,
+    458159766907,
+    676875000961,
+    1000000000039,
+]
+
+
+def next_prime(nchunks: int) -> int:
+    """Return one of the precalculated prime numbers for HDF5 chunk list.
+
+    If the input number is larger than the largest prime from the list,
+    returns the input number, which is not a prime, but can still be
+    used by HDF5.
+
+    Parameters
+    ----------
+    nchunks : int
+        number of chunks that need to be cached.
+
+    Returns
+    -------
+    int
+        A prime number larger than the input number.
+    """
+    for prime in PRIMES:
+        if prime > nchunks:
+            return prime
+    return nchunks
+
+
+def guess_hdf5_trajectory_parameters(fname: str | Path) -> tuple[int, int]:
+    trajectory_instance = Trajectory(fname)
+    traj_length = len(trajectory_instance)
+    chunk_size = trajectory_instance.chunk_size()
+    bytes_per_num = trajectory_instance.dtype_size()
+    cache_size = 2 * traj_length * chunk_size * 3 * bytes_per_num
+    cache_slots = next_prime(80 * traj_length * 3)
+    trajectory_instance.close()
+    return cache_size, cache_slots
 
 
 @IConfigurator.register("HDFTrajectoryConfigurator")
@@ -55,24 +144,36 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
         self.extract_information(traj_instance)
 
     def configure(self, value):
-        """
-        Configure a HDF trajectory file.
-
-        :param value: the path for the HDF trajectory file.
-        :type value: str
-        """
         if value == self._original_input:
             return
         self._original_input = value
         self.error_status = "OK"
         self.warning_status = ""
 
-        InputFileConfigurator.configure(self, value)
+        if isinstance(value, (str, Path)):
+            file_name = value
+            driver = None
+            rdcc_nbytes, rdcc_nslots = guess_hdf5_trajectory_parameters(value)
+            rdcc_w0 = None
+        else:
+            file_name = value[0]
+            driver = value[1] if value[1] in HDF5_DRIVERS else None
+            rdcc_nbytes = value[2]
+            rdcc_nslots = value[3]
+            rdcc_w0 = value[4]
+
+        self["driver"] = driver
+        self["rdcc_nbytes"] = rdcc_nbytes
+        self["rdcc_nslots"] = rdcc_nslots
+        self["rdcc_w0"] = rdcc_w0
+        InputFileConfigurator.configure(self, file_name)
         try:
             trajectory_instance = Trajectory(
                 self["value"],
                 hdf5_driver="core" if check_hdf5_driver() else None,
-                dataset_cache_size=DATASET_CACHE_SIZE,
+                rdcc_nbytes=rdcc_nbytes,
+                rdcc_nslots=rdcc_nslots,
+                rdcc_w0=rdcc_w0,
             )
         except KeyError:
             self.error_status = f"Could not use {value} as input trajectory."

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -170,6 +170,7 @@ class HDFTrajectoryConfigurator(InputFileConfigurator):
         self["rdcc_nbytes"] = rdcc_nbytes
         self["rdcc_nslots"] = rdcc_nslots
         self["rdcc_w0"] = rdcc_w0
+        self["reopen_trajectory"] = True
         InputFileConfigurator.configure(self, file_name)
         self._original_input = value
         if "instance" in self and isinstance(self["instance"], Trajectory):

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
@@ -41,7 +41,7 @@ class OutputTrajectoryConfigurator(IConfigurator):
     """
 
     log_options = ("no logs", "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL")
-    _default = ("OUTPUT_TRAJECTORY", 64, 128, "none", "no logs")
+    _default = ("OUTPUT_TRAJECTORY", 64, (1, 128), "none", "no logs")
     label = "MDANSE output trajectory"
     tooltip = (
         "Values are: filename, data type, chunk size, compression, logfile output."

--- a/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/OutputTrajectoryConfigurator.py
@@ -66,8 +66,13 @@ class OutputTrajectoryConfigurator(IConfigurator):
     def configure(self, value: tuple):
         self._original_input = value
 
-        root, dtype, chunk_size, compression, logs = value
+        root, dtype, chunk_size, compression, logs = value[:5]
         root = Path(root)
+
+        try:
+            meta_block_size = int(value[5])
+        except Exception:
+            meta_block_size = 4096
 
         if logs not in self.log_options:
             self.error_status = "log level option not recognised"
@@ -112,4 +117,5 @@ class OutputTrajectoryConfigurator(IConfigurator):
         self["chunk_size"] = self._chunk_limit
         self["log_level"] = logs
         self["write_logs"] = logs != "no logs"
+        self["meta_block_size"] = meta_block_size
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
@@ -157,6 +157,7 @@ class ASE(Converter):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
             initial_charges=self._initial_charges,
         )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
@@ -224,15 +224,11 @@ class ASE(Converter):
 
         try:
             if self._isPeriodic:
-                real_conf = PeriodicRealConfiguration(
-                    self._trajectory.chemical_system, coords, unitCell, **variables
-                )
+                real_conf = PeriodicRealConfiguration(coords, unitCell, **variables)
                 if self._configuration["fold"]["value"]:
                     real_conf.fold_coordinates()
             else:
-                real_conf = RealConfiguration(
-                    self._trajectory.chemical_system, coords, **variables
-                )
+                real_conf = RealConfiguration(coords, **variables)
 
         except ValueError:
             self._keep_running = False

--- a/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/ASE.py
@@ -29,8 +29,8 @@ from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Units import INTERNAL_UNITS, UnitError, measure
 from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicRealConfiguration,
-    RealConfiguration,
+    AbsoluteConfiguration,
+    PeriodicAbsoluteConfiguration,
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
@@ -224,11 +224,11 @@ class ASE(Converter):
 
         try:
             if self._isPeriodic:
-                real_conf = PeriodicRealConfiguration(coords, unitCell, **variables)
+                real_conf = PeriodicAbsoluteConfiguration(coords, unitCell, **variables)
                 if self._configuration["fold"]["value"]:
                     real_conf.fold_coordinates()
             else:
-                real_conf = RealConfiguration(coords, **variables)
+                real_conf = AbsoluteConfiguration(coords, **variables)
 
         except ValueError:
             self._keep_running = False

--- a/MDANSE/Src/MDANSE/Framework/Converters/CASTEP.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/CASTEP.py
@@ -97,6 +97,7 @@ class CASTEP(Converter):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
         )
 
     def run_step(self, index: int) -> tuple[int, None]:

--- a/MDANSE/Src/MDANSE/Framework/Converters/CASTEP.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/CASTEP.py
@@ -22,7 +22,7 @@ from MDANSE.Framework.AtomMapping import get_element_from_mapping
 from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Parsers import CASTEPMDFile
-from MDANSE.MolecularDynamics.Configuration import PeriodicRealConfiguration
+from MDANSE.MolecularDynamics.Configuration import PeriodicAbsoluteConfiguration
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
@@ -123,7 +123,7 @@ class CASTEP(Converter):
             "gradients": np.vstack(tuple(arr[1] for arr in frame["F"])),
         }
 
-        conf = PeriodicRealConfiguration(coords, unit_cell, **variables)
+        conf = PeriodicAbsoluteConfiguration(coords, unit_cell, **variables)
 
         if self.configuration["fold"]["value"]:
             conf.fold_coordinates()

--- a/MDANSE/Src/MDANSE/Framework/Converters/CASTEP.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/CASTEP.py
@@ -123,9 +123,7 @@ class CASTEP(Converter):
             "gradients": np.vstack(tuple(arr[1] for arr in frame["F"])),
         }
 
-        conf = PeriodicRealConfiguration(
-            self._trajectory.chemical_system, coords, unit_cell, **variables
-        )
+        conf = PeriodicRealConfiguration(coords, unit_cell, **variables)
 
         if self.configuration["fold"]["value"]:
             conf.fold_coordinates()

--- a/MDANSE/Src/MDANSE/Framework/Converters/CP2K.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/CP2K.py
@@ -177,7 +177,6 @@ class CP2K(Converter):
         data["cell"] = UnitCell(data["cell"])
 
         real_conf = PeriodicRealConfiguration(
-            self._trajectory.chemical_system,
             data.pop("coordinates"),
             data.pop("cell"),
             **data,

--- a/MDANSE/Src/MDANSE/Framework/Converters/CP2K.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/CP2K.py
@@ -154,6 +154,7 @@ class CP2K(Converter):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
         )
 
         data_to_be_written = ["configuration", "time"]

--- a/MDANSE/Src/MDANSE/Framework/Converters/CP2K.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/CP2K.py
@@ -26,7 +26,7 @@ from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Parsers import CP2KCellFile, XYZFile
 from MDANSE.Framework.Units import measure
-from MDANSE.MolecularDynamics.Configuration import PeriodicRealConfiguration
+from MDANSE.MolecularDynamics.Configuration import PeriodicAbsoluteConfiguration
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
@@ -176,7 +176,7 @@ class CP2K(Converter):
         }
         data["cell"] = UnitCell(data["cell"])
 
-        real_conf = PeriodicRealConfiguration(
+        real_conf = PeriodicAbsoluteConfiguration(
             data.pop("coordinates"),
             data.pop("cell"),
             **data,

--- a/MDANSE/Src/MDANSE/Framework/Converters/DCD.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DCD.py
@@ -104,6 +104,7 @@ class DCD(Converter):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
         )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Converters/DCD.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DCD.py
@@ -22,7 +22,7 @@ import numpy as np
 from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Parsers import DCDFile, PDBFile
-from MDANSE.MolecularDynamics.Configuration import PeriodicRealConfiguration
+from MDANSE.MolecularDynamics.Configuration import PeriodicAbsoluteConfiguration
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 
 PI_2 = 0.5 * np.pi
@@ -119,7 +119,7 @@ class DCD(Converter):
         # The x, y and z values of the current frame.
         unit_cell, config = next(self.frames)
 
-        conf = PeriodicRealConfiguration(config, unit_cell)
+        conf = PeriodicAbsoluteConfiguration(config, unit_cell)
 
         if self.configuration["fold"]["value"]:
             conf.fold_coordinates()

--- a/MDANSE/Src/MDANSE/Framework/Converters/DCD.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DCD.py
@@ -119,9 +119,7 @@ class DCD(Converter):
         # The x, y and z values of the current frame.
         unit_cell, config = next(self.frames)
 
-        conf = PeriodicRealConfiguration(
-            self._trajectory._chemical_system, config, unit_cell
-        )
+        conf = PeriodicRealConfiguration(config, unit_cell)
 
         if self.configuration["fold"]["value"]:
             conf.fold_coordinates()

--- a/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
@@ -25,8 +25,8 @@ from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Parsers import DLPField, DLPHistory
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicRealConfiguration,
-    RealConfiguration,
+    AbsoluteConfiguration,
+    PeriodicAbsoluteConfiguration,
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 
@@ -138,9 +138,9 @@ class DL_POLY(Converter):
         frame = next(self.frames)
 
         if self.history_file.imcon:
-            conf = PeriodicRealConfiguration(frame["positions"], frame["unit_cell"])
+            conf = PeriodicAbsoluteConfiguration(frame["positions"], frame["unit_cell"])
         else:
-            conf = RealConfiguration(frame["positions"])
+            conf = AbsoluteConfiguration(frame["positions"])
 
         if self.configuration["fold"]["value"]:
             conf.fold_coordinates()

--- a/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
@@ -113,6 +113,7 @@ class DL_POLY(Converter):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
             initial_charges=self.field_file.get_atom_charges(),
         )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/DL_POLY.py
@@ -138,13 +138,9 @@ class DL_POLY(Converter):
         frame = next(self.frames)
 
         if self.history_file.imcon:
-            conf = PeriodicRealConfiguration(
-                self._trajectory.chemical_system, frame["positions"], frame["unit_cell"]
-            )
+            conf = PeriodicRealConfiguration(frame["positions"], frame["unit_cell"])
         else:
-            conf = RealConfiguration(
-                self._trajectory.chemical_system, frame["positions"]
-            )
+            conf = RealConfiguration(frame["positions"])
 
         if self.configuration["fold"]["value"]:
             conf.fold_coordinates()

--- a/MDANSE/Src/MDANSE/Framework/Converters/Forcite.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Forcite.py
@@ -24,8 +24,8 @@ from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Parsers import TrjFile, XTDFile
 from MDANSE.Framework.Units import measure
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicBoxConfiguration,
-    RealConfiguration,
+    AbsoluteConfiguration,
+    PeriodicFractionalConfiguration,
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 
@@ -110,11 +110,13 @@ class Forcite(Converter):
         self._chemical_system.find_clusters_from_bonds()
 
         if self.xtd_file.pbc:
-            boxConf = PeriodicBoxConfiguration(coordinates, self.xtd_file.cell)
-            real_conf = boxConf.to_real_configuration()
+            boxConf = PeriodicFractionalConfiguration(coordinates, self.xtd_file.cell)
+            real_conf = boxConf.to_absolute_configuration()
         else:
             coordinates *= measure(1.0, "ang").toval("nm")
-            real_conf = RealConfiguration(coordinates, unit_cell=self.xtd_file._cell)
+            real_conf = AbsoluteConfiguration(
+                coordinates, unit_cell=self.xtd_file._cell
+            )
 
         real_conf.fold_coordinates()
         self.system = real_conf

--- a/MDANSE/Src/MDANSE/Framework/Converters/Forcite.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Forcite.py
@@ -110,15 +110,11 @@ class Forcite(Converter):
         self._chemical_system.find_clusters_from_bonds()
 
         if self.xtd_file.pbc:
-            boxConf = PeriodicBoxConfiguration(
-                self._chemical_system, coordinates, self.xtd_file.cell
-            )
+            boxConf = PeriodicBoxConfiguration(coordinates, self.xtd_file.cell)
             real_conf = boxConf.to_real_configuration()
         else:
             coordinates *= measure(1.0, "ang").toval("nm")
-            real_conf = RealConfiguration(
-                self._chemical_system, coordinates, unit_cell=self.xtd_file._cell
-            )
+            real_conf = RealConfiguration(coordinates, unit_cell=self.xtd_file._cell)
 
         real_conf.fold_coordinates()
         self.system = real_conf

--- a/MDANSE/Src/MDANSE/Framework/Converters/Forcite.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Forcite.py
@@ -148,6 +148,7 @@ class Forcite(Converter):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
             initial_charges=charges,
         )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
@@ -149,6 +149,7 @@ class Gromacs(Converter):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
         )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
@@ -181,7 +181,6 @@ class Gromacs(Converter):
         coords = np.squeeze(coords)
 
         conf = PeriodicRealConfiguration(
-            self._trajectory.chemical_system,
             coords,
             UnitCell(box[0, :, :]),
             **variables,

--- a/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/Gromacs.py
@@ -22,7 +22,7 @@ import numpy as np
 from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Parsers import PDBFile
-from MDANSE.MolecularDynamics.Configuration import PeriodicRealConfiguration
+from MDANSE.MolecularDynamics.Configuration import PeriodicAbsoluteConfiguration
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
@@ -180,7 +180,7 @@ class Gromacs(Converter):
 
         coords = np.squeeze(coords)
 
-        conf = PeriodicRealConfiguration(
+        conf = PeriodicAbsoluteConfiguration(
             coords,
             UnitCell(box[0, :, :]),
             **variables,

--- a/MDANSE/Src/MDANSE/Framework/Converters/LAMMPS.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/LAMMPS.py
@@ -212,6 +212,7 @@ class LAMMPS(Converter):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
             initial_charges=charges,
         )
 

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
@@ -21,8 +21,8 @@ from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Units import measure
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicRealConfiguration,
-    RealConfiguration,
+    AbsoluteConfiguration,
+    PeriodicAbsoluteConfiguration,
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
@@ -213,11 +213,11 @@ class MDAnalysis(Converter):
         # see https://userguide.mdanalysis.org/stable/units.html for
         # default units in MDAnalysis
         if self.u.trajectory.ts.triclinic_dimensions is None:
-            conf = RealConfiguration(
+            conf = AbsoluteConfiguration(
                 self.u.trajectory.ts.positions * measure(1.0, "ang").toval("nm"),
             )
         else:
-            conf = PeriodicRealConfiguration(
+            conf = PeriodicAbsoluteConfiguration(
                 self.u.trajectory.ts.positions * measure(1.0, "ang").toval("nm"),
                 UnitCell(
                     self.u.trajectory.ts.triclinic_dimensions

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
@@ -181,6 +181,7 @@ class MDAnalysis(Converter):
             "positions_dtype": self.configuration["output_files"]["dtype"],
             "chunking_limit": self.configuration["output_files"]["chunk_size"],
             "compression": self.configuration["output_files"]["compression"],
+            "meta_block_size": self.configuration["output_files"]["meta_block_size"],
         }
         if hasattr(self.u.atoms, "charges"):
             kwargs["initial_charges"] = self.u.atoms.charges

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDAnalysis.py
@@ -214,12 +214,10 @@ class MDAnalysis(Converter):
         # default units in MDAnalysis
         if self.u.trajectory.ts.triclinic_dimensions is None:
             conf = RealConfiguration(
-                self._trajectory._chemical_system,
                 self.u.trajectory.ts.positions * measure(1.0, "ang").toval("nm"),
             )
         else:
             conf = PeriodicRealConfiguration(
-                self._trajectory._chemical_system,
                 self.u.trajectory.ts.positions * measure(1.0, "ang").toval("nm"),
                 UnitCell(
                     self.u.trajectory.ts.triclinic_dimensions

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -22,8 +22,8 @@ from MDANSE.Framework.AtomMapping import get_element_from_mapping
 from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicRealConfiguration,
-    RealConfiguration,
+    AbsoluteConfiguration,
+    PeriodicAbsoluteConfiguration,
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
@@ -187,11 +187,11 @@ class MDTraj(Converter):
             A tuple of the job index and None.
         """
         if self.traj.unitcell_vectors is None:
-            conf = RealConfiguration(
+            conf = AbsoluteConfiguration(
                 self.traj.xyz[index],
             )
         else:
-            conf = PeriodicRealConfiguration(
+            conf = PeriodicAbsoluteConfiguration(
                 self.traj.xyz[index],
                 UnitCell(
                     self.traj.unitcell_vectors[index],

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -163,6 +163,7 @@ class MDTraj(Converter):
             "positions_dtype": self.configuration["output_files"]["dtype"],
             "chunking_limit": self.configuration["output_files"]["chunk_size"],
             "compression": self.configuration["output_files"]["compression"],
+            "meta_block_size": self.configuration["output_files"]["meta_block_size"],
         }
         self._trajectory = TrajectoryWriter(
             self.configuration["output_files"]["file"],

--- a/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/MDTraj.py
@@ -188,12 +188,10 @@ class MDTraj(Converter):
         """
         if self.traj.unitcell_vectors is None:
             conf = RealConfiguration(
-                self._trajectory._chemical_system,
                 self.traj.xyz[index],
             )
         else:
             conf = PeriodicRealConfiguration(
-                self._trajectory._chemical_system,
                 self.traj.xyz[index],
                 UnitCell(
                     self.traj.unitcell_vectors[index],

--- a/MDANSE/Src/MDANSE/Framework/Converters/VASP.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/VASP.py
@@ -22,7 +22,7 @@ from MDANSE.Framework.AtomMapping import get_element_from_mapping
 from MDANSE.Framework.Converters.Converter import Converter
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Parsers import XDATCARFile
-from MDANSE.MolecularDynamics.Configuration import PeriodicBoxConfiguration
+from MDANSE.MolecularDynamics.Configuration import PeriodicFractionalConfiguration
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 
 
@@ -140,10 +140,10 @@ class VASP(Converter):
         coords = frame["coords"]
         unitCell = frame["unit_cell"]
 
-        conf = PeriodicBoxConfiguration(coords, unitCell)
+        conf = PeriodicFractionalConfiguration(coords, unitCell)
 
         # The coordinates in VASP are in box format. Convert them into real coordinates.
-        real_conf = conf.to_real_configuration()
+        real_conf = conf.to_absolute_configuration()
 
         if self.configuration["fold"]["value"]:
             # The real coordinates are folded then into the simulation box (-L/2,L/2).

--- a/MDANSE/Src/MDANSE/Framework/Converters/VASP.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/VASP.py
@@ -123,6 +123,7 @@ class VASP(Converter):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
         )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Converters/VASP.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/VASP.py
@@ -140,9 +140,7 @@ class VASP(Converter):
         coords = frame["coords"]
         unitCell = frame["unit_cell"]
 
-        conf = PeriodicBoxConfiguration(
-            self._trajectory.chemical_system, coords, unitCell
-        )
+        conf = PeriodicBoxConfiguration(coords, unitCell)
 
         # The coordinates in VASP are in box format. Convert them into real coordinates.
         real_conf = conf.to_real_configuration()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AreaPerMolecule.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AreaPerMolecule.py
@@ -90,7 +90,7 @@ class AreaPerMolecule(IJob):
 
         # The number of molecules that match the input name. Must be > 0.
         self._nMolecules = len(
-            self.trajectory.chemical_system._clusters[
+            self.trajectory.chemical_system.clusters[
                 self.configuration["molecule_name"]["value"]
             ]
         )

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -22,8 +22,8 @@ from MDANSE.Framework.Formats.HDFFormat import write_metadata
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Geometry import center_of_mass
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicRealConfiguration,
-    RealConfiguration,
+    AbsoluteConfiguration,
+    PeriodicAbsoluteConfiguration,
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.TrajectoryUtils import group_cluster_indices
@@ -88,8 +88,8 @@ class CenterOfMassesTrajectory(IJob):
         new_element_list = []
         used_up_atoms = set()
         new_chemical_system = ChemicalSystem()
-        for cluster_name in chemical_system._clusters:
-            for cluster in chemical_system._clusters[cluster_name]:
+        for cluster_name in chemical_system.clusters:
+            for cluster in chemical_system.clusters[cluster_name]:
                 if selected_indices and set(cluster) <= selected_indices:
                     if cluster_name not in self.cluster_composition:
                         self.cluster_composition[cluster_name] = [
@@ -114,10 +114,10 @@ class CenterOfMassesTrajectory(IJob):
         )
         self._unique_atoms = np.unique(new_element_list)
         self._molecule_radii = {
-            cluster_name: [] for cluster_name in chemical_system._clusters
+            cluster_name: [] for cluster_name in chemical_system.clusters
         }
         self.selected_indices = selected_indices
-        self.clusters = chemical_system._clusters
+        self.clusters = chemical_system.clusters
         self.masses = {
             atom_index: self.trajectory.get_atom_property(
                 chemical_system.atom_list[atom_index], "atomic_weight"
@@ -170,9 +170,9 @@ class CenterOfMassesTrajectory(IJob):
                 mol_index += 1
 
         if conf.is_periodic:
-            com_conf = PeriodicRealConfiguration(com_coords, conf.unit_cell)
+            com_conf = PeriodicAbsoluteConfiguration(com_coords, conf.unit_cell)
         else:
-            com_conf = RealConfiguration(com_coords)
+            com_conf = AbsoluteConfiguration(com_coords)
 
         if self.configuration["fold"]["value"]:
             com_conf.fold_coordinates()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -111,6 +111,7 @@ class CenterOfMassesTrajectory(IJob):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
         )
         self._unique_atoms = np.unique(new_element_list)
         self._molecule_radii = {

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -26,6 +26,7 @@ from MDANSE.MolecularDynamics.Configuration import (
     RealConfiguration,
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_cluster_indices
 
 
 @IJob.register("CenterOfMassesTrajectory")
@@ -116,6 +117,14 @@ class CenterOfMassesTrajectory(IJob):
             cluster_name: [] for cluster_name in chemical_system._clusters
         }
         self.selected_indices = selected_indices
+        self.clusters = chemical_system._clusters
+        self.masses = {
+            atom_index: self.trajectory.get_atom_property(
+                chemical_system.atom_list[atom_index], "atomic_weight"
+            )
+            for atom_index in self.trajectory.atom_indices
+        }
+        self.grouped_indices = group_cluster_indices(chemical_system)
 
     def run_step(self, index):
         """
@@ -130,33 +139,29 @@ class CenterOfMassesTrajectory(IJob):
 
         # get the Frame index
         frameIndex = self.configuration["frames"]["value"][index]
-        chemical_system = self.trajectory.chemical_system
-        atom_database = self.trajectory
 
         n_coms = self._output_trajectory.chemical_system.number_of_atoms
 
         conf = self.trajectory.configuration(frameIndex)
-        conf = conf.contiguous_configuration()
-        temp_radii = {cluster_name: [] for cluster_name in chemical_system._clusters}
+        conf = conf.contiguous_configuration(self.grouped_indices)
+        temp_radii = {cluster_name: [] for cluster_name in self.clusters}
 
         com_coords = np.empty((n_coms, 3), dtype=np.float64)
         mol_index = 0
-        for cluster_name in chemical_system._clusters:
-            for cluster in chemical_system._clusters[cluster_name]:
+        for cluster_name in self.clusters:
+            for cluster in self.clusters[cluster_name]:
                 if not set(cluster).issubset(self.selected_indices):
                     continue
-                masses = [
-                    atom_database.get_atom_property(
-                        chemical_system.atom_list[cluster_index], "atomic_weight"
-                    )
-                    for cluster_index in cluster
-                ]
+
                 individual_coordinates = conf.coordinates[cluster]
-                centre_of_mass = center_of_mass(individual_coordinates, masses)
+                centre_of_mass = center_of_mass(
+                    individual_coordinates,
+                    [self.masses[at_index] for at_index in cluster],
+                )
                 com_coords[mol_index] = centre_of_mass
                 average_radius = individual_coordinates - centre_of_mass.reshape(1, 3)
                 average_radius = np.linalg.norm(average_radius, axis=1)
-                average_radius = np.average(average_radius, weights=masses)
+                average_radius = np.average(average_radius, weights=self.masses)
                 temp_radii[cluster_name].append(average_radius)
                 mol_index += 1
         for atom_index in self.selected_indices:
@@ -165,13 +170,9 @@ class CenterOfMassesTrajectory(IJob):
                 mol_index += 1
 
         if conf.is_periodic:
-            com_conf = PeriodicRealConfiguration(
-                self._output_trajectory.chemical_system, com_coords, conf.unit_cell
-            )
+            com_conf = PeriodicRealConfiguration(com_coords, conf.unit_cell)
         else:
-            com_conf = RealConfiguration(
-                self._output_trajectory.chemical_system, com_coords
-            )
+            com_conf = RealConfiguration(com_coords)
 
         if self.configuration["fold"]["value"]:
             com_conf.fold_coordinates()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
@@ -20,6 +20,7 @@ from scipy.signal import correlate
 
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Geometry import center_of_mass
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_cluster_indices
 from MDANSE.util_types import FloatArray
 
 
@@ -78,6 +79,8 @@ class DipoleAutoCorrelationFunction(IJob):
             self.configuration["molecule_name"]["value"]
         ]
 
+        self.grouped_indices = group_cluster_indices(self.trajectory.chemical_system)
+
         self.numberOfSteps = len(self.molecules)
 
         # Will store the time.
@@ -129,7 +132,9 @@ class DipoleAutoCorrelationFunction(IJob):
                 for index in molecule
             ]
             charges = self.trajectory.charges(frame_index)
-            contiguous_configuration = configuration.contiguous_configuration()
+            contiguous_configuration = configuration.contiguous_configuration(
+                self.grouped_indices
+            )
             coords = contiguous_configuration.coordinates[molecule]
             com = center_of_mass(coords, masses)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DipoleAutoCorrelationFunction.py
@@ -75,7 +75,7 @@ class DipoleAutoCorrelationFunction(IJob):
             "instance"
         ].chemical_system
 
-        self.molecules = self.chemical_system._clusters[
+        self.molecules = self.chemical_system.clusters[
             self.configuration["molecule_name"]["value"]
         ]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Eccentricity.py
@@ -21,6 +21,7 @@ from more_itertools import always_iterable
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Geometry import center_of_mass, moment_of_inertia
 from MDANSE.MLogging import LOG
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_cluster_indices
 
 
 @IJob.register("Eccentricity")
@@ -90,6 +91,8 @@ class Eccentricity(IJob):
             ]
         )
 
+        self.grouped_indices = group_cluster_indices(self.trajectory.chemical_system)
+
     def run_step(self, index: int):
         """Calculate the eccentricity for the selected atoms at the
         frame index.
@@ -102,7 +105,7 @@ class Eccentricity(IJob):
         frameIndex = self.configuration["frames"]["value"][index]
 
         conf = self.trajectory.configuration(frameIndex)
-        conf = conf.contiguous_configuration()
+        conf = conf.contiguous_configuration(self.grouped_indices)
         series = conf["coordinates"][self._indices, :]
 
         if np.allclose(self._selectionMasses, 0.0):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -281,13 +281,16 @@ class IJob(Configurable, RegisterFactory, ABC):
         """
         if (trajectory := self.configuration.get("trajectory")) is None:
             return
-        self.trajectory = Trajectory(
-            trajectory["value"],
-            hdf5_driver=trajectory["driver"],
-            rdcc_nbytes=trajectory["rdcc_nbytes"],
-            rdcc_nslots=trajectory["rdcc_nslots"],
-            rdcc_w0=trajectory["rdcc_w0"],
-        )
+        if trajectory["reopen_trajectory"]:
+            self.trajectory = Trajectory(
+                trajectory["value"],
+                hdf5_driver=trajectory["driver"],
+                rdcc_nbytes=trajectory["rdcc_nbytes"],
+                rdcc_nslots=trajectory["rdcc_nslots"],
+                rdcc_w0=trajectory["rdcc_w0"],
+            )
+        else:
+            self.trajectory = trajectory["instance"]
         if (selection := self.configuration.get("atom_selection")) is not None:
             self.trajectory.set_selection(selection["flatten_indices"])
             array_length = self.trajectory.chemical_system._total_number_of_atoms

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -43,6 +43,7 @@ from MDANSE.Framework.Jobs.JobStatus import JobStates, JobStatus
 from MDANSE.Framework.OutputVariables.IOutputVariable import OutputData
 from MDANSE.IO.IOUtils import UCDict
 from MDANSE.MLogging import FMT, LOG
+from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -280,7 +281,13 @@ class IJob(Configurable, RegisterFactory, ABC):
         """
         if (trajectory := self.configuration.get("trajectory")) is None:
             return
-        self.trajectory = trajectory["instance"]
+        self.trajectory = Trajectory(
+            trajectory["value"],
+            hdf5_driver=trajectory["driver"],
+            rdcc_nbytes=trajectory["rdcc_nbytes"],
+            rdcc_nslots=trajectory["rdcc_nslots"],
+            rdcc_w0=trajectory["rdcc_w0"],
+        )
         if (selection := self.configuration.get("atom_selection")) is not None:
             self.trajectory.set_selection(selection["flatten_indices"])
             array_length = self.trajectory.chemical_system._total_number_of_atoms

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
@@ -21,6 +21,7 @@ from scipy.signal import correlate
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Geometry import center_of_mass
 from MDANSE.Mathematics.Signal import differentiate, get_spectrum
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_cluster_indices
 from MDANSE.util_types import FloatArray
 
 
@@ -101,6 +102,7 @@ class Infrared(IJob):
             self.configuration["instrument_resolution"]["kernel"].lower() != "ideal"
         )
 
+        self.grouped_indices = group_cluster_indices(self.trajectory.chemical_system)
         self._outputData.add(
             "ir/axes/time",
             "LineOutputVariable",
@@ -189,7 +191,9 @@ class Infrared(IJob):
                 for index in molecule
             ]
             charges = self.trajectory.charges(frame_index)
-            contiguous_configuration = configuration.contiguous_configuration()
+            contiguous_configuration = configuration.contiguous_configuration(
+                self.grouped_indices
+            )
             coords = contiguous_configuration.coordinates[molecule]
             com = center_of_mass(coords, masses)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Infrared.py
@@ -91,7 +91,7 @@ class Infrared(IJob):
             "instance"
         ].chemical_system
 
-        self.molecules = self.chemical_system._clusters[
+        self.molecules = self.chemical_system.clusters[
             self.configuration["molecule_name"]["value"]
         ]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MolecularTrace.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MolecularTrace.py
@@ -87,7 +87,7 @@ class MolecularTrace(IJob):
         for i in range(self.numberOfSteps):
             frameIndex = self.configuration["frames"]["value"][i]
             conf = self.trajectory.configuration(frameIndex)
-            conf = conf.continuous_configuration()
+            conf = conf.continuous_configuration(self.trajectory.chemical_system._bonds)
             coords = conf["coordinates"]
 
             minx_loc = coords[:, 0].min()
@@ -141,6 +141,7 @@ class MolecularTrace(IJob):
         )
 
         self._indices = self.trajectory.atom_indices
+        self.bonds = self.trajectory.chemical_system._bonds
 
     def run_step(self, index):
         """
@@ -154,7 +155,7 @@ class MolecularTrace(IJob):
         frameIndex = self.configuration["frames"]["value"][index]
 
         conf = self.trajectory.configuration(frameIndex)
-        conf = conf.continuous_configuration()
+        conf = conf.continuous_configuration(self.bonds)
 
         grid = np.zeros(self.gdim, dtype=np.int32)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ReorientationalTimeCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ReorientationalTimeCorrelationFunction.py
@@ -21,6 +21,7 @@ from scipy.special import legendre
 
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Geometry import center_of_mass, moment_of_inertia
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_cluster_indices
 from MDANSE.util_types import FloatArray
 
 
@@ -140,6 +141,8 @@ class ReorientationalTimeCorrelationFunction(IJob):
         self.legendre_order = self.configuration["polynomial_order"]["value"]
         self.numberOfSteps = len(self.molecules)
 
+        self.grouped_indices = group_cluster_indices(self.trajectory.chemical_system)
+
         self.masses = np.array(
             self.trajectory.chemical_system.atom_property(
                 "atomic_weight",
@@ -227,7 +230,9 @@ class ReorientationalTimeCorrelationFunction(IJob):
             configuration = self.trajectory.configuration(
                 frame_index,
             )
-            coordinates = configuration.contiguous_configuration().coordinates[molecule]
+            coordinates = configuration.contiguous_configuration(
+                self.grouped_indices
+            ).coordinates[molecule]
             if self.inner_index2 is not None:
                 ref_pos = coordinates[self.inner_index2]
             else:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ReorientationalTimeCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ReorientationalTimeCorrelationFunction.py
@@ -133,7 +133,7 @@ class ReorientationalTimeCorrelationFunction(IJob):
 
         self.molecules = self.configuration["trajectory"][
             "instance"
-        ].chemical_system._clusters[self.configuration["molecule_and_axis"]["value"]]
+        ].chemical_system.clusters[self.configuration["molecule_and_axis"]["value"]]
 
         self.inner_index1 = self.configuration["molecule_and_axis"]["index1"]
         self.inner_index2 = self.configuration["molecule_and_axis"]["index2"]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RotationAutocorrelation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RotationAutocorrelation.py
@@ -21,6 +21,7 @@ from scipy.spatial.transform import Rotation
 
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Geometry import center_of_mass
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_cluster_indices
 from MDANSE.util_types import FloatArray
 
 
@@ -87,6 +88,8 @@ class RotationAutocorrelation(IJob):
                 "atomic_weight",
             ),
         )
+
+        self.grouped_indices = group_cluster_indices(self.trajectory.chemical_system)
 
         self._outputData.add(
             "time",
@@ -162,7 +165,9 @@ class RotationAutocorrelation(IJob):
             configuration = self.trajectory.configuration(
                 frame_index,
             )
-            coordinates = configuration.contiguous_configuration().coordinates[molecule]
+            coordinates = configuration.contiguous_configuration(
+                self.grouped_indices
+            ).coordinates[molecule]
             current_coords = coordinates - center_of_mass(coordinates, masses)
             if i == 0:
                 ref_coords = current_coords

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RotationAutocorrelation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RotationAutocorrelation.py
@@ -71,7 +71,7 @@ class RotationAutocorrelation(IJob):
         """Initialize the input parameters and analysis self variables."""
         super().initialize()
 
-        molecules = self.trajectory.chemical_system._clusters[
+        molecules = self.trajectory.chemical_system.clusters[
             self.configuration["molecule"]["value"]
         ]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ScatteringLengthDensityProfile.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ScatteringLengthDensityProfile.py
@@ -184,7 +184,7 @@ class ScatteringLengthDensityProfile(IJob):
 
         conf = self.trajectory.configuration(frame_index)
 
-        box_coords = conf.to_box_coordinates()
+        box_coords = conf.to_fractional_coordinates()
         box_coords = box_coords - np.floor(box_coords)
 
         axis_index = self.configuration["axis"]["index"]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ScatteringLengthDensityProfile.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ScatteringLengthDensityProfile.py
@@ -185,7 +185,7 @@ class ScatteringLengthDensityProfile(IJob):
         conf = self.trajectory.configuration(frame_index)
 
         box_coords = conf.to_fractional_coordinates()
-        box_coords = box_coords - np.floor(box_coords)
+        box_coords -= np.floor(box_coords)
 
         axis_index = self.configuration["axis"]["index"]
         self._extent += np.linalg.norm(conf.unit_cell.direct[axis_index])

--- a/MDANSE/Src/MDANSE/Framework/Jobs/SolventAccessibleSurface.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/SolventAccessibleSurface.py
@@ -321,7 +321,7 @@ def identify_loose_atoms(
     if grouping_level == "molecule":
         for mol_name in trajectory.chemical_system.unique_molecules():
             atoms_in_molecule.setdefault(mol_name, set())
-            for mol_instance in trajectory.chemical_system._clusters[mol_name]:
+            for mol_instance in trajectory.chemical_system.clusters[mol_name]:
                 all_indices -= set(mol_instance)
                 atoms_in_molecule[mol_name].update(atom_types[mol_instance])
     loose_atoms = list(
@@ -485,7 +485,7 @@ class SolventAccessibleSurface(IJob):
         self.type_mapping, self.grouping_keys = create_type_mapping(
             atom_types,
             self.configuration["grouping_level"]["value"],
-            molecule_names=set(self.trajectory.chemical_system._clusters),
+            molecule_names=set(self.trajectory.chemical_system.clusters),
             atoms_in_molecule=atoms_in_molecule,
         )
 
@@ -514,7 +514,7 @@ class SolventAccessibleSurface(IJob):
             atom_types,
             self.type_mapping,
             self.configuration["grouping_level"]["value"],
-            self.trajectory.chemical_system._clusters,
+            self.trajectory.chemical_system.clusters,
         )
 
         self.bonds = self.trajectory.chemical_system._bonds

--- a/MDANSE/Src/MDANSE/Framework/Jobs/SolventAccessibleSurface.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/SolventAccessibleSurface.py
@@ -517,6 +517,8 @@ class SolventAccessibleSurface(IJob):
             self.trajectory.chemical_system._clusters,
         )
 
+        self.bonds = self.trajectory.chemical_system._bonds
+
     def run_step(self, index):
         """
         Runs a single step of the job.
@@ -532,7 +534,7 @@ class SolventAccessibleSurface(IJob):
         conf = self.trajectory.configuration(frameIndex)
 
         # The configuration is made continuous.
-        conf = conf.continuous_configuration()
+        conf = conf.continuous_configuration(self.bonds)
         unit_cell = conf._unit_cell
 
         if conf.is_periodic:

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -15,8 +15,7 @@
 #
 from __future__ import annotations
 
-from functools import reduce
-
+import more_itertools
 import numpy as np
 
 from MDANSE.Chemistry.ChemicalSystem import (
@@ -160,16 +159,17 @@ class TrajectoryEditor(IJob):
                 com_conf = AbsoluteConfiguration(
                     coords,
                 )
-            self.grouped_indices = list(more_itertools.flatten(new_chemical_system.clusters.values()))
+            self.grouped_indices = list(
+                more_itertools.flatten(new_chemical_system.clusters.values())
+            )
             coords = com_conf.contiguous_configuration(self.grouped_indices).coordinates
         else:
             assign_molecules_after_atom_selection(
                 self._indices, self._input_chemical_system, new_chemical_system
             )
-            self.grouped_indices = reduce(
-                list.__add__, new_chemical_system.clusters.values(), []
+            self.grouped_indices = list(
+                more_itertools.flatten(new_chemical_system.clusters.values())
             )
-
         # The output trajectory is opened for writing.
         self._output_trajectory = TrajectoryWriter(
             self.configuration["output_files"]["file"],

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -178,6 +178,7 @@ class TrajectoryEditor(IJob):
             positions_dtype=self.configuration["output_files"]["dtype"],
             chunking_limit=self.configuration["output_files"]["chunk_size"],
             compression=self.configuration["output_files"]["compression"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
         )
 
     def run_step(self, index):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -160,9 +160,7 @@ class TrajectoryEditor(IJob):
                 com_conf = AbsoluteConfiguration(
                     coords,
                 )
-            self.grouped_indices = reduce(
-                list.__add__, new_chemical_system.clusters.values(), []
-            )
+            self.grouped_indices = list(more_itertools.flatten(new_chemical_system.clusters.values()))
             coords = com_conf.contiguous_configuration(self.grouped_indices).coordinates
         else:
             assign_molecules_after_atom_selection(

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -26,8 +26,8 @@ from MDANSE.Chemistry.ChemicalSystem import (
 from MDANSE.Framework.Formats.HDFFormat import write_metadata
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicRealConfiguration,
-    RealConfiguration,
+    AbsoluteConfiguration,
+    PeriodicAbsoluteConfiguration,
 )
 from MDANSE.MolecularDynamics.Connectivity import Connectivity
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
@@ -152,16 +152,16 @@ class TrajectoryEditor(IJob):
             )
             coords = conf.coordinates[indices]
             if conf.is_periodic:
-                com_conf = PeriodicRealConfiguration(
+                com_conf = PeriodicAbsoluteConfiguration(
                     coords,
                     conf.unit_cell,
                 )
             else:
-                com_conf = RealConfiguration(
+                com_conf = AbsoluteConfiguration(
                     coords,
                 )
             self.grouped_indices = reduce(
-                list.__add__, new_chemical_system._clusters.values(), []
+                list.__add__, new_chemical_system.clusters.values(), []
             )
             coords = com_conf.contiguous_configuration(self.grouped_indices).coordinates
         else:
@@ -169,7 +169,7 @@ class TrajectoryEditor(IJob):
                 self._indices, self._input_chemical_system, new_chemical_system
             )
             self.grouped_indices = reduce(
-                list.__add__, new_chemical_system._clusters.values(), []
+                list.__add__, new_chemical_system.clusters.values(), []
             )
 
         # The output trajectory is opened for writing.
@@ -212,13 +212,13 @@ class TrajectoryEditor(IJob):
             ].astype(np.float64)
 
         if conf.is_periodic:
-            com_conf = PeriodicRealConfiguration(
+            com_conf = PeriodicAbsoluteConfiguration(
                 coords[self._indices],
                 conf.unit_cell,
                 **variables,
             )
         else:
-            com_conf = RealConfiguration(
+            com_conf = AbsoluteConfiguration(
                 coords[self._indices],
                 **variables,
             )

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -15,6 +15,8 @@
 #
 from __future__ import annotations
 
+from functools import reduce
+
 import numpy as np
 
 from MDANSE.Chemistry.ChemicalSystem import (
@@ -151,19 +153,23 @@ class TrajectoryEditor(IJob):
             coords = conf.coordinates[indices]
             if conf.is_periodic:
                 com_conf = PeriodicRealConfiguration(
-                    new_chemical_system,
                     coords,
                     conf.unit_cell,
                 )
             else:
                 com_conf = RealConfiguration(
-                    new_chemical_system,
                     coords,
                 )
-            coords = com_conf.contiguous_configuration().coordinates
+            self.grouped_indices = reduce(
+                list.__add__, new_chemical_system._clusters.values(), []
+            )
+            coords = com_conf.contiguous_configuration(self.grouped_indices).coordinates
         else:
             assign_molecules_after_atom_selection(
                 self._indices, self._input_chemical_system, new_chemical_system
+            )
+            self.grouped_indices = reduce(
+                list.__add__, new_chemical_system._clusters.values(), []
             )
 
         # The output trajectory is opened for writing.
@@ -191,7 +197,7 @@ class TrajectoryEditor(IJob):
         frameIndex = self.configuration["frames"]["value"][index]
 
         conf = self.trajectory.configuration(frameIndex)
-        conf = conf.contiguous_configuration(bring_to_centre=True)
+        conf = conf.contiguous_configuration(self.grouped_indices, bring_to_centre=True)
         charges = self.trajectory.charges(frameIndex)
         coords = conf.coordinates
 
@@ -207,14 +213,12 @@ class TrajectoryEditor(IJob):
 
         if conf.is_periodic:
             com_conf = PeriodicRealConfiguration(
-                self._output_trajectory.chemical_system,
                 coords[self._indices],
                 conf.unit_cell,
                 **variables,
             )
         else:
             com_conf = RealConfiguration(
-                self._output_trajectory.chemical_system,
                 coords[self._indices],
                 **variables,
             )

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -360,9 +360,8 @@ def get_output_configuration(
     """
     if parent.is_periodic:
         return PeriodicRealConfiguration(
-            output_chemical_system,
             output_coordinates,
             parent.unit_cell,
         )
 
-    return RealConfiguration(output_chemical_system, output_coordinates)
+    return RealConfiguration(output_coordinates)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -208,9 +208,11 @@ class TrajectoryFilter(IJob):
             self.configuration["output_files"]["file"],
             output_chemical_system,
             self.configuration["frames"]["number"],
-            None,
+            selected_atoms=None,
             positions_dtype=self.configuration["output_files"]["dtype"],
             compression=self.configuration["output_files"]["compression"],
+            chunking_limit=self.configuration["output_files"]["chunk_size"],
+            meta_block_size=self.configuration["output_files"]["meta_block_size"],
         )
 
         # Write trajectory

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -31,8 +31,8 @@ from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Signal import FILTER_MAP, Filter
 from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicRealConfiguration,
-    RealConfiguration,
+    AbsoluteConfiguration,
+    PeriodicAbsoluteConfiguration,
     _Configuration,
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
@@ -354,14 +354,14 @@ def get_output_configuration(
 
     Returns
     -------
-    RealConfiguration | PeriodicRealConfiguration
+    AbsoluteConfiguration | PeriodicAbsoluteConfiguration
         Output configuration for the trajectory.
 
     """
     if parent.is_periodic:
-        return PeriodicRealConfiguration(
+        return PeriodicAbsoluteConfiguration(
             output_coordinates,
             parent.unit_cell,
         )
 
-    return RealConfiguration(output_coordinates)
+    return AbsoluteConfiguration(output_coordinates)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
@@ -312,8 +312,8 @@ def intramolecular_lookup_dict(
     """
     result = -1 * np.arange(chemical_system.number_of_atoms, dtype=int)
     mol_index = 1
-    for molecule in chemical_system._clusters:
-        for mol_indices in chemical_system._clusters[molecule]:
+    for molecule in chemical_system.clusters:
+        for mol_indices in chemical_system.clusters[molecule]:
             for index in mol_indices:
                 result[index] = mol_index
             mol_index += 1

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
@@ -636,7 +636,7 @@ class VanHoveFunctionDistinct(IJob):
 
         def calc_func(
             label_i: str, label_j: str
-        ) -> Iterator[tuple[str, bool, npt.NDArray]]:
+        ) -> Iterator[tuple[str, bool, FloatArray]]:
             """Calculates the distinct part of the van Hove function
             for a given pair of element labels.
 
@@ -653,7 +653,7 @@ class VanHoveFunctionDistinct(IJob):
                 The results name.
             inter : bool
                 Whether results are for intermolecular atom pairs.
-            results : npt.NDArray
+            results : FloatArray
                 The results.
             """
             n_atms = self.trajectory.get_natoms()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 from collections.abc import Iterator
 
 import numpy as np
-import numpy.typing as npt
 from more_itertools import always_iterable
 
 from MDANSE.Framework.AtomGrouping.grouping import (
@@ -28,6 +27,7 @@ from MDANSE.Framework.AtomGrouping.grouping import (
 from MDANSE.Framework.Jobs.DistanceHistogram import DistanceHistogram
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
+from MDANSE.util_types import FloatArray
 
 
 def atomic_scattering_factor(element, qvalues, trajectory):
@@ -206,7 +206,7 @@ class XRayStaticStructureFactor(DistanceHistogram):
 
         def calc_func(
             label_i: str, label_j: str
-        ) -> Iterator[tuple[str, bool, npt.NDArray]]:
+        ) -> Iterator[tuple[str, bool, FloatArray]]:
             """Calculates the xray static structure factor for a given
             pair of element labels.
 
@@ -223,7 +223,7 @@ class XRayStaticStructureFactor(DistanceHistogram):
                 The results name.
             inter : bool
                 Whether results are for intermolecular atom pairs.
-            results : npt.NDArray
+            results : FloatArray
                 The results.
             """
             ni = nAtomsPerElement[label_i]

--- a/MDANSE/Src/MDANSE/Framework/Parsers/LAMMPS.py
+++ b/MDANSE/Src/MDANSE/Framework/Parsers/LAMMPS.py
@@ -610,9 +610,7 @@ class LAMMPScustom(LAMMPSReader):
 
             coords -= origin_recip
 
-            conf = PeriodicBoxConfiguration(
-                self._trajectory.chemical_system, coords, unit_cell
-            )
+            conf = PeriodicBoxConfiguration(coords, unit_cell)
 
             real_conf = conf.to_real_configuration()
 
@@ -621,9 +619,7 @@ class LAMMPScustom(LAMMPSReader):
             coords -= self._first_origin
             coords *= len_conv
 
-            real_conf = PeriodicRealConfiguration(
-                self._trajectory.chemical_system, coords, unit_cell
-            )
+            real_conf = PeriodicRealConfiguration(coords, unit_cell)
 
         if self._fold:
             # The whole configuration is folded in to the simulation box.
@@ -811,15 +807,11 @@ class LAMMPSxyz(LAMMPSReader):
         time = timestep * self._timestep * measure(1.0, self.units["time"]).toval("ps")
 
         if self._fractionalCoordinates:
-            conf = PeriodicBoxConfiguration(
-                self._trajectory.chemical_system, positions, unit_cell
-            )
+            conf = PeriodicBoxConfiguration(positions, unit_cell)
             real_conf = conf.to_real_configuration()
         else:
             positions *= measure(1.0, self.units["length"]).toval("nm")
-            real_conf = PeriodicRealConfiguration(
-                self._trajectory.chemical_system, positions, unit_cell
-            )
+            real_conf = PeriodicRealConfiguration(positions, unit_cell)
 
         if self._fold:
             # The whole configuration is folded in to the simulation box.

--- a/MDANSE/Src/MDANSE/Framework/Parsers/LAMMPS.py
+++ b/MDANSE/Src/MDANSE/Framework/Parsers/LAMMPS.py
@@ -32,8 +32,8 @@ from MDANSE.Framework.Units import measure
 from MDANSE.IO.IOUtils import UCEnum
 from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicBoxConfiguration,
-    PeriodicRealConfiguration,
+    PeriodicAbsoluteConfiguration,
+    PeriodicFractionalConfiguration,
 )
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
@@ -610,16 +610,16 @@ class LAMMPScustom(LAMMPSReader):
 
             coords -= origin_recip
 
-            conf = PeriodicBoxConfiguration(coords, unit_cell)
+            conf = PeriodicFractionalConfiguration(coords, unit_cell)
 
-            real_conf = conf.to_real_configuration()
+            real_conf = conf.to_absolute_configuration()
 
         else:
             # MDANSE origin is always 0,0,0
             coords -= self._first_origin
             coords *= len_conv
 
-            real_conf = PeriodicRealConfiguration(coords, unit_cell)
+            real_conf = PeriodicAbsoluteConfiguration(coords, unit_cell)
 
         if self._fold:
             # The whole configuration is folded in to the simulation box.
@@ -807,11 +807,11 @@ class LAMMPSxyz(LAMMPSReader):
         time = timestep * self._timestep * measure(1.0, self.units["time"]).toval("ps")
 
         if self._fractionalCoordinates:
-            conf = PeriodicBoxConfiguration(positions, unit_cell)
-            real_conf = conf.to_real_configuration()
+            conf = PeriodicFractionalConfiguration(positions, unit_cell)
+            real_conf = conf.to_absolute_configuration()
         else:
             positions *= measure(1.0, self.units["length"]).toval("nm")
-            real_conf = PeriodicRealConfiguration(positions, unit_cell)
+            real_conf = PeriodicAbsoluteConfiguration(positions, unit_cell)
 
         if self._fold:
             # The whole configuration is folded in to the simulation box.

--- a/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
+++ b/MDANSE/Src/MDANSE/Framework/QVectors/LatticeQVectors.py
@@ -25,7 +25,7 @@ from MDANSE.util_types import FloatArray
 
 
 def fpsampling(
-    q_vectors: np.ndarray,
+    q_vectors: FloatArray,
     n_vecs: int,
     random_vector_func: Callable[[], FloatArray],
     rng: np.random.Generator,

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Configuration.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Configuration.py
@@ -424,7 +424,7 @@ class _PeriodicConfiguration(_Configuration):
         variables = copy.deepcopy(self.variables)
         coords = variables.pop("coordinates")
 
-        return self.__class__(coords, unit_cell, **variables)
+        return type(self)(coords, unit_cell, **variables)
 
     def fold_coordinates(self):
         """Fold the coordinates into simulation box."""

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Configuration.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Configuration.py
@@ -29,7 +29,6 @@ from MDANSE.util_types import FloatArray, IntArray
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
-    from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
     from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 
@@ -291,12 +290,9 @@ class ConfigurationError(Exception):
 class _Configuration(metaclass=abc.ABCMeta):
     is_periodic: bool
 
-    def __init__(self, chemical_system: ChemicalSystem, coords: ArrayLike, **variables):
+    def __init__(self, coords: ArrayLike, **variables):
         """
         Constructor.
-
-        :param chemical_system: The chemical system described by this configuration.
-        :type chemical_system: :class: `MDANSE.Chemistry.ChemicalSystem.ChemicalSystem`
 
         :param coords: the coordinates of all the particles in the chemical system
         :type coords: numpy.ndarray
@@ -304,11 +300,10 @@ class _Configuration(metaclass=abc.ABCMeta):
         :param variables: keyword arguments for any other variables that should be saved to this configuration
         """
 
-        self._chemical_system = chemical_system
-
         self._variables = {}
 
         self["coordinates"] = np.array(coords, dtype=float)
+        self._n_atoms = len(self["coordinates"])
 
         for k, v in variables.items():
             if k in {"velocities", "forces"}:
@@ -363,31 +358,21 @@ class _Configuration(metaclass=abc.ABCMeta):
                 self._variables[name] = value
                 return
 
-        if item.shape != (self._chemical_system.number_of_atoms, 3):
+        if any(
+            item.shape != existing_item.shape
+            for existing_item in self._variables.values()
+        ):
             raise ValueError(
-                f"Invalid item dimensions for {name}; a shape of {(self._chemical_system.number_of_atoms, 3)} was "
+                f"Invalid item dimensions for {name}; a shape of {(self._n_atoms, 3)} was "
                 f"expected but data with shape of {item.shape} was provided."
             )
 
         self._variables[name] = value
 
-    @property
-    def chemical_system(self) -> ChemicalSystem:
-        """
-        Returns the chemical system stored in this configuration.
-
-        :return: the chemical system that this configuration describes
-        :rtype: :class: `MDANSE.Chemistry.ChemicalSystem.ChemicalSystem`
-        """
-        return self._chemical_system
-
     @abc.abstractmethod
-    def clone(self, chemical_system: ChemicalSystem):
+    def clone(self):
         """
         Clones this configuration.
-
-        :param chemical_system: the chemical system that this configuration describes
-        :type chemical_system: :class: `MDANSE.Chemistry.ChemicalSystem.ChemicalSystem`
         """
         pass
 
@@ -425,16 +410,12 @@ class _Configuration(metaclass=abc.ABCMeta):
 class _PeriodicConfiguration(_Configuration):
     def __init__(
         self,
-        chemical_system: ChemicalSystem,
         coords: ArrayLike,
         unit_cell: UnitCell,
         **variables,
     ):
         """
         Constructor.
-
-        :param chemical_system: The chemical system described by this configuration.
-        :type chemical_system: :class: `MDANSE.Chemistry.ChemicalSystem.ChemicalSystem`
 
         :param coords: the coordinates of all the particles in the chemical system
         :type coords: numpy.ndarray
@@ -445,39 +426,22 @@ class _PeriodicConfiguration(_Configuration):
         :param variables: keyword arguments for any other variables that should be saved to this configuration
         """
 
-        super().__init__(chemical_system, coords, **variables)
+        super().__init__(coords, **variables)
 
         if unit_cell.direct.shape != (3, 3):
             raise ValueError("Invalid unit cell dimensions")
         self._unit_cell = unit_cell
 
-    def clone(self, chemical_system: ChemicalSystem | None = None):
+    def clone(self):
         """
         Creates a deep copy of this configuration, using the provided chemical system.
-
-        :param chemical_system: the chemical system that is to be used for copying. It must have the same number of
-                                atoms as the chemical system that this configuration describes
-        :type chemical_system: :class: `MDANSE.Chemistry.ChemicalSystem.ChemicalSystem):
         """
-        if chemical_system is None:
-            chemical_system = self._chemical_system
-        elif (
-            chemical_system.total_number_of_atoms
-            != self.chemical_system.total_number_of_atoms
-        ):
-            raise ConfigurationError(
-                "Mismatch between the chemical systems; the provided chemical system, "
-                f"{chemical_system.name}, has {chemical_system.total_number_of_atoms} atoms "
-                f"which does not match the chemical system of this configuration, "
-                f"{self.chemical_system.name} which has "
-                f"{self.chemical_system.total_number_of_atoms} atoms."
-            )
 
         unit_cell = copy.deepcopy(self._unit_cell)
         variables = copy.deepcopy(self.variables)
         coords = variables.pop("coordinates")
 
-        return self.__class__(chemical_system, coords, unit_cell, **variables)
+        return self.__class__(coords, unit_cell, **variables)
 
     def fold_coordinates(self):
         """Fold the coordinates into simulation box."""
@@ -554,14 +518,12 @@ class PeriodicBoxConfiguration(_PeriodicConfiguration):
         variables = copy.deepcopy(self._variables)
         variables.pop("coordinates")
 
-        real_conf = PeriodicRealConfiguration(
-            self._chemical_system, coords, self._unit_cell, **variables
-        )
+        real_conf = PeriodicRealConfiguration(coords, self._unit_cell, **variables)
 
         return real_conf
 
     def contiguous_configuration(
-        self, bring_to_centre: bool = False
+        self, indices_grouped, bring_to_centre: bool = False
     ) -> PeriodicBoxConfiguration:
         """
         Return a configuration with chemical entities made contiguous.
@@ -569,10 +531,6 @@ class PeriodicBoxConfiguration(_PeriodicConfiguration):
         :return: the contiguous configuration
         :rtype: :class: `MDANSE.MolecularDynamics.Configuration.PeriodicBoxConfiguration`
         """
-
-        indices_grouped = reduce(
-            list.__add__, self._chemical_system._clusters.values(), []
-        )
 
         contiguous_coords = contiguous_coordinates_box(
             self._variables["coordinates"],
@@ -611,9 +569,7 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
         variables = copy.deepcopy(self._variables)
         variables.pop("coordinates")
 
-        box_conf = PeriodicBoxConfiguration(
-            self._chemical_system, coords, self._unit_cell, **variables
-        )
+        box_conf = PeriodicBoxConfiguration(coords, self._unit_cell, **variables)
 
         return box_conf
 
@@ -628,7 +584,7 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
         return self._variables["coordinates"]
 
     def contiguous_configuration(
-        self, bring_to_centre: bool = False
+        self, indices_grouped, bring_to_centre: bool = False
     ) -> PeriodicRealConfiguration:
         """
         Return a configuration with chemical entities made contiguous.
@@ -636,10 +592,6 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
         :return: the contiguous configuration
         :rtype: :class: `MDANSE.MolecularDynamics.Configuration.PeriodicBoxConfiguration`
         """
-
-        indices_grouped = reduce(
-            list.__add__, self._chemical_system._clusters.values(), []
-        )
 
         contiguous_coords = contiguous_coordinates_real(
             self._variables["coordinates"],
@@ -653,7 +605,7 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
         conf._variables["coordinates"] = contiguous_coords
         return conf
 
-    def continuous_configuration(self) -> PeriodicRealConfiguration:
+    def continuous_configuration(self, bonds) -> PeriodicRealConfiguration:
         """
         Return a configuration with chemical entities made continuous.
 
@@ -665,7 +617,7 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
             self._variables["coordinates"],
             self._unit_cell.direct,
             self._unit_cell.inverse,
-            self.chemical_system._bonds,
+            bonds,
         )
 
         conf = self.clone()
@@ -676,30 +628,19 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
 class RealConfiguration(_Configuration):
     is_periodic = False
 
-    def clone(self, chemical_system: ChemicalSystem | None = None) -> RealConfiguration:
+    def clone(self) -> RealConfiguration:
         """
         Creates a deep copy of this configuration, using the provided chemical system.
-
-        :param chemical_system: the chemical system that is to be used for copying. It must have the same number of
-                                atoms as the chemical system that this configuration describes
-        :type chemical_system: :class: `MDANSE.Chemistry.ChemicalSystem.ChemicalSystem`
 
         :return: the cloned configuration
         :rtype: :class: `MDANSE.MolecularDynamics.Configuration.RealConfiguration`
         """
-        if chemical_system is None:
-            chemical_system = self._chemical_system
-        elif (
-            chemical_system.total_number_of_atoms
-            != self.chemical_system.total_number_of_atoms
-        ):
-            raise ConfigurationError("Mismatch between the chemical systems")
 
         variables = copy.deepcopy(self.variables)
 
         coords = variables.pop("coordinates")
 
-        return self.__class__(chemical_system, coords, **variables)
+        return self.__class__(coords, **variables)
 
     def fold_coordinates(self) -> None:
         """Does nothing since coordinates can only be folded if the configuration has a unit cell."""
@@ -715,7 +656,7 @@ class RealConfiguration(_Configuration):
         return self._variables["coordinates"]
 
     def contiguous_configuration(
-        self, bring_to_centre: bool = False
+        self, _=None, bring_to_centre: bool = False
     ) -> RealConfiguration:
         """
         Return a configuration with chemical entities made contiguous, which is always itself.
@@ -725,7 +666,7 @@ class RealConfiguration(_Configuration):
         """
         return self
 
-    def continuous_configuration(self) -> RealConfiguration:
+    def continuous_configuration(self, _=None) -> RealConfiguration:
         """
         Return a configuration with chemical entities made continuous, which is always itself.
 

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Configuration.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Configuration.py
@@ -18,11 +18,12 @@ from __future__ import annotations
 import abc
 import copy
 from collections.abc import Sequence
-from functools import reduce
 from typing import TYPE_CHECKING, Any
 
+import more_itertools
 import networkx as nx
 import numpy as np
+import typing_extensions
 
 from MDANSE.MLogging import LOG
 from MDANSE.util_types import FloatArray, IntArray
@@ -200,7 +201,7 @@ def continuous_coordinates(
     while len(atom_pool) > 0:
         last_atom = atom_pool.pop()
         temp_dict = nx.dfs_successors(total_graph, last_atom)
-        others = reduce(list.__add__, temp_dict.values(), [])
+        others = list(more_itertools.flatten(temp_dict.values()))
         for atom in others:
             atom_pool.pop(atom_pool.index(atom))
         segment = [last_atom, *others]
@@ -292,7 +293,6 @@ class _Configuration(metaclass=abc.ABCMeta):
     is_periodic: bool
 
     def __init__(self, coords: ArrayLike, **variables):
-
         self._variables = {}
 
         self["coordinates"] = np.array(coords, dtype=float)
@@ -417,7 +417,7 @@ class _PeriodicConfiguration(_Configuration):
             raise ValueError("Invalid unit cell dimensions")
         self._unit_cell = unit_cell
 
-    def clone(self) -> _PeriodicConfiguration:
+    def clone(self) -> typing_extensions.Self:
         """Return a deep copy of this configuration."""
 
         unit_cell = copy.deepcopy(self._unit_cell)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Configuration.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Configuration.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 
 import abc
 import copy
+from collections.abc import Sequence
 from functools import reduce
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 import numpy as np
@@ -61,7 +62,7 @@ def remove_jumps(input_coords: FloatArray) -> FloatArray:
     return input_coords + offsets
 
 
-def contiguous_coordinates_real(
+def contiguous_coordinates_absolute(
     coords: FloatArray,
     cell: FloatArray,
     rcell: FloatArray,
@@ -117,7 +118,7 @@ def contiguous_coordinates_real(
     return contiguous_coords
 
 
-def contiguous_coordinates_box(
+def contiguous_coordinates_fractional(
     frac_coords: FloatArray,
     indices: list[tuple[int, ...]],
     bring_to_centre: bool = False,
@@ -204,7 +205,7 @@ def continuous_coordinates(
             atom_pool.pop(atom_pool.index(atom))
         segment = [last_atom, *others]
         segments.append(sorted(segment))
-    return contiguous_coordinates_real(coords, cell, rcell, segments)
+    return contiguous_coordinates_absolute(coords, cell, rcell, segments)
 
 
 def padded_coordinates(
@@ -291,14 +292,6 @@ class _Configuration(metaclass=abc.ABCMeta):
     is_periodic: bool
 
     def __init__(self, coords: ArrayLike, **variables):
-        """
-        Constructor.
-
-        :param coords: the coordinates of all the particles in the chemical system
-        :type coords: numpy.ndarray
-
-        :param variables: keyword arguments for any other variables that should be saved to this configuration
-        """
 
         self._variables = {}
 
@@ -312,38 +305,51 @@ class _Configuration(metaclass=abc.ABCMeta):
                 self[k] = v
 
     def __contains__(self, item: str) -> bool:
-        """
-        Returns True if the provided variable belongs to the configuration.
+        """Check if a variable is stored in this configuration.
 
-        :param item: the variable to be confirmed
-        :type item: str
+        Parameters
+        ----------
+        item : str
+            Name of the atom property array.
 
-        :return: True if the configuration has the given item, otherwise False
-        :rtype: bool
+        Returns
+        -------
+        bool
+            True if 'item' is the configuration's variables, False otherwise.
         """
         return item in self._variables
 
     def __getitem__(self, item: str) -> FloatArray:
-        """
-        Returns the configuration value for a given item.
+        """Return the selected atom property array.
 
-        :param item: the variable whose value is to be retrieved
-        :type item: str
+        Parameters
+        ----------
+        item : str
+            Name of the array, e.g. 'velocities'
 
-        :return: the value of the variable
+        Returns
+        -------
+        np.ndarray
+            An (N_ATOMS, 3) data array.
         """
         return self._variables[item]
 
     def __setitem__(self, name: str, value: ArrayLike) -> None:
-        """
-        Sets the provided variable to the provided value, but only if the value has the shape of
-        (number of atoms in the chemical system, 3).
+        """Store a data array in this Configuration instance.
 
-        :param name: the variable to be set
-        :type name: str
+        Parameters
+        ----------
+        name : str
+            Key under which the array will be stored.
+        value : ArrayLike
+            Input data array.
 
-        :param value: the value of the variable to be set
-        :type value: numpy.ndarray
+        Raises
+        ------
+        ValueError
+            If the unit cell array is not a (3, 3) array.
+        ValueError
+            If the shape of the array does not match the number of atoms.
         """
         item = np.array(value)
 
@@ -371,71 +377,48 @@ class _Configuration(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def clone(self):
-        """
-        Clones this configuration.
-        """
+        """Return a copy of this configuration."""
         pass
 
     @property
     def coordinates(self) -> FloatArray:
-        """
-        Returns the coordinates.
-
-        :return: the coordinates stored in this configuration
-        :rtype: numpy.ndarray
-        """
+        """The array of atom coordinates."""
         return self._variables["coordinates"]
 
     @abc.abstractmethod
-    def to_real_coordinates(self):
-        """
-        Return the coordinates of this configuration converted to real coordinates.
-
-        Returns:
-            ndarray: the real coordinates
-        """
+    def to_absolute_coordinates(self):
+        """Return the atom positions as absolute coordinates."""
         pass
 
     @property
     def variables(self) -> dict[str, FloatArray]:
-        """
-        Returns the configuration variable dictionary.
+        """Return all atom data arrays in a dictionary.
 
-        :return: all the variables stored in this configuration
-        :rtype: dict
+        Returns
+        -------
+        dict[str, np.ndarray]
+            Dictionary containing atom positions (optionally also velocities, ...)
         """
         return self._variables
 
 
 class _PeriodicConfiguration(_Configuration):
+    """Class storing atom positions with periodic boundary conditions."""
+
     def __init__(
         self,
         coords: ArrayLike,
         unit_cell: UnitCell,
         **variables,
     ):
-        """
-        Constructor.
-
-        :param coords: the coordinates of all the particles in the chemical system
-        :type coords: numpy.ndarray
-
-        :param unit_cell: the unit cell of the system in this configuration
-        :type unit_cell: :class: `MDANSE.MolecularDynamics.UnitCell.UnitCell`
-
-        :param variables: keyword arguments for any other variables that should be saved to this configuration
-        """
-
         super().__init__(coords, **variables)
 
         if unit_cell.direct.shape != (3, 3):
             raise ValueError("Invalid unit cell dimensions")
         self._unit_cell = unit_cell
 
-    def clone(self):
-        """
-        Creates a deep copy of this configuration, using the provided chemical system.
-        """
+    def clone(self) -> _PeriodicConfiguration:
+        """Return a deep copy of this configuration."""
 
         unit_cell = copy.deepcopy(self._unit_cell)
         variables = copy.deepcopy(self.variables)
@@ -453,86 +436,86 @@ class _PeriodicConfiguration(_Configuration):
         self._variables["coordinates"] = (coords @ inverse_unit_cell % 1) @ unit_cell
 
     @abc.abstractmethod
-    def to_box_coordinates(self):
-        """Return this configuration converted to box coordinates.
-
-        Returns:
-            ndarray: the box coordinates
-        """
+    def to_fractional_coordinates(self):
+        """Return this configuration converted to fractional coordinates."""
         pass
 
     @property
     def unit_cell(self) -> UnitCell:
-        """
-        Return the nit cell stored in this configuration.
+        """Return the unit cell of this configuration.
 
-        :return: the unit cell associated with this chemical system
-        :rtype: :class: `MDANSE.MolecularDynamics.UnitCell.UnitCell
+        Returns
+        -------
+        UnitCell
+            A unit cell with the current simulation box dimensions.
         """
         return self._unit_cell
 
     @unit_cell.setter
     def unit_cell(self, unit_cell: UnitCell) -> None:
-        """
-        Sets the unit cell.
+        """Replace the unit cell of the configuration with the input one.
 
-        :param unit_cell: the new unit cell
-        :type unit_cell: :class: `MDANSE.MolecularDynamics.UnitCell.UnitCell`
+        Parameters
+        ----------
+        unit_cell : UnitCell
+            Unit cell instance with the dimensions of the simulation box.
+
+        Raises
+        ------
+        ValueError
+            If the unit cell does not contain a valid (3, 3) cell array.
         """
         if unit_cell.direct.shape != (3, 3):
             raise ValueError("Invalid unit cell dimensions")
         self._unit_cell = unit_cell
 
 
-class PeriodicBoxConfiguration(_PeriodicConfiguration):
+class PeriodicFractionalConfiguration(_PeriodicConfiguration):
     is_periodic = True
 
-    def to_box_coordinates(self) -> FloatArray:
-        """
-        Return this configuration converted to box coordinates.
-
-        :return: the box coordinates
-        :rtype: numpy.ndarray
-        """
+    def to_fractional_coordinates(self) -> FloatArray:
+        """Return atom positions as fractional coordinates."""
         return self._variables["coordinates"]
 
-    def to_real_coordinates(self) -> FloatArray:
-        """
-        Return the coordinates of this configuration converted to real coordinates.
-
-        :return: the real coordinates
-        :rtype: numpy.ndarray
-        """
+    def to_absolute_coordinates(self) -> FloatArray:
+        """Return atom positions as absolute coordinates."""
         return np.matmul(self._variables["coordinates"], self._unit_cell.direct)
 
-    def to_real_configuration(self) -> PeriodicRealConfiguration:
-        """
-        Return this configuration converted to real coordinates.
+    def to_absolute_configuration(self) -> PeriodicAbsoluteConfiguration:
+        """Return atom positions as absolute coordinates in a configuration instance."""
 
-        :return: the configuration
-        :rtype: :class: `MDANSE.MolecularDynamics.Configuration.PeriodicRealConfiguration`
-        """
-
-        coords = self.to_real_coordinates()
+        coords = self.to_absolute_coordinates()
 
         variables = copy.deepcopy(self._variables)
         variables.pop("coordinates")
 
-        real_conf = PeriodicRealConfiguration(coords, self._unit_cell, **variables)
+        real_conf = PeriodicAbsoluteConfiguration(coords, self._unit_cell, **variables)
 
         return real_conf
 
     def contiguous_configuration(
-        self, indices_grouped, bring_to_centre: bool = False
-    ) -> PeriodicBoxConfiguration:
-        """
-        Return a configuration with chemical entities made contiguous.
+        self, indices_grouped: Sequence[Sequence[int]], bring_to_centre: bool = False
+    ) -> PeriodicFractionalConfiguration:
+        """Return a configuration with contiguous coordinates.
 
-        :return: the contiguous configuration
-        :rtype: :class: `MDANSE.MolecularDynamics.Configuration.PeriodicBoxConfiguration`
+        Atoms will be moved by unit cell vectors to minimise the distance
+        between atoms belonging to groups defined in the input list.
+
+        Parameters
+        ----------
+        indices_grouped : Sequence[Sequence[int]]
+            List containing a list of atom indices for every molecule in the system.
+        bring_to_centre : bool, optional
+            If True, atoms in each molecule will be shifted towards the molecule
+            centre. If False, they will be shifted to the first atom. By default False
+
+        Returns
+        -------
+        PeriodicFractionalConfiguration
+            A configuration instance containing shifted atom positions.
         """
 
-        contiguous_coords = contiguous_coordinates_box(
+        contiguous_coords = contiguous_coordinates_fractional(
             self._variables["coordinates"],
             indices_grouped,
             bring_to_centre,
@@ -543,57 +526,51 @@ class PeriodicBoxConfiguration(_PeriodicConfiguration):
         return conf
 
 
-class PeriodicRealConfiguration(_PeriodicConfiguration):
+class PeriodicAbsoluteConfiguration(_PeriodicConfiguration):
     is_periodic = True
 
-    def to_box_coordinates(self) -> FloatArray:
-        """
-        Returns the (real) coordinates stored in this configuration converted into box coordinates.
-
-        :return: box coordinates
-        :rtype: numpy.ndarray
-        """
-
+    def to_fractional_coordinates(self) -> FloatArray:
+        """Return atom positions as fractional coordinates in the current unit cell."""
         return np.matmul(self._variables["coordinates"], self._unit_cell.inverse)
 
-    def to_box_configuration(self) -> PeriodicBoxConfiguration:
-        """
-        Creates a copy of this configuration with its coordinates converted into box coordinates.
+    def to_fractional_configuration(self) -> PeriodicFractionalConfiguration:
+        """Return atom fractional coordinates in a configuration instance."""
 
-        :return: a configuration with all parameters the same except for coordinates which are box instead of real
-        :rtype: :class: `MDANSE.MolecularDynamics.Configuration.PeriodicBoxConfiguration`
-        """
-
-        coords = self.to_box_coordinates()
+        coords = self.to_fractional_coordinates()
 
         variables = copy.deepcopy(self._variables)
         variables.pop("coordinates")
 
-        box_conf = PeriodicBoxConfiguration(coords, self._unit_cell, **variables)
+        box_conf = PeriodicFractionalConfiguration(coords, self._unit_cell, **variables)
 
         return box_conf
 
-    def to_real_coordinates(self) -> FloatArray:
-        """
-        Return the coordinates of this configuration converted to real coordinates, i.e. the coordinates registered with
-        this configuration.
-
-        :return: the real coordinates
-        :rtype: numpy.ndarray
-        """
+    def to_absolute_coordinates(self) -> FloatArray:
+        """Return atom positions as an array of absolute coordinates."""
         return self._variables["coordinates"]
 
     def contiguous_configuration(
-        self, indices_grouped, bring_to_centre: bool = False
-    ) -> PeriodicRealConfiguration:
-        """
-        Return a configuration with chemical entities made contiguous.
+        self, indices_grouped: Sequence[Sequence[int]], bring_to_centre: bool = False
+    ) -> PeriodicAbsoluteConfiguration:
+        """Return atoms positions made contiguous in a configuration instance.
 
-        :return: the contiguous configuration
-        :rtype: :class: `MDANSE.MolecularDynamics.Configuration.PeriodicBoxConfiguration`
+        Normally, for each index list in the input, atoms are translated by
+        unit cell vectors to be as close as possible to the first atom in the list.
+
+        Parameters
+        ----------
+        indices_grouped : Sequence[Sequence[int]]
+            A list of atom coordinate lists, one per molecule.
+        bring_to_centre : bool, optional
+            Shift atoms closer to the molecule centre, by default False
+
+        Returns
+        -------
+        PeriodicAbsoluteConfiguration
+            Configuration instance containing the shifted coordinates.
         """
 
-        contiguous_coords = contiguous_coordinates_real(
+        contiguous_coords = contiguous_coordinates_absolute(
             self._variables["coordinates"],
             self._unit_cell.direct,
             self._unit_cell.inverse,
@@ -605,12 +582,25 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
         conf._variables["coordinates"] = contiguous_coords
         return conf
 
-    def continuous_configuration(self, bonds) -> PeriodicRealConfiguration:
-        """
-        Return a configuration with chemical entities made continuous.
+    def continuous_configuration(
+        self, bonds: Sequence[Sequence[int]]
+    ) -> PeriodicAbsoluteConfiguration:
+        """Return atom positions in a configuration with continuous molecules.
 
-        :return:  the continuous configuration
-        :rtype: :class: `MDANSE.MolecularDynamics.Configuration.PeriodicBoxConfiguration`
+        The continuous coordinates are made by translating atoms by unit cell vectors
+        to ensure that none of the bonds in the input list are broken. This may not
+        work for large molecules, and is certain not to work correctly for infinite
+        molecular chains.
+
+        Parameters
+        ----------
+        bonds : Sequence[Sequence[int]]
+            List of pairs of atom indices defining chemical bonds in the system.
+
+        Returns
+        -------
+        PeriodicAbsoluteConfiguration
+            Configuration instance containing shifted atoms with continuous molecules.
         """
 
         continuous_coords = continuous_coordinates(
@@ -625,16 +615,11 @@ class PeriodicRealConfiguration(_PeriodicConfiguration):
         return conf
 
 
-class RealConfiguration(_Configuration):
+class AbsoluteConfiguration(_Configuration):
     is_periodic = False
 
-    def clone(self) -> RealConfiguration:
-        """
-        Creates a deep copy of this configuration, using the provided chemical system.
-
-        :return: the cloned configuration
-        :rtype: :class: `MDANSE.MolecularDynamics.Configuration.RealConfiguration`
-        """
+    def clone(self) -> AbsoluteConfiguration:
+        """Return a copy of itself."""
 
         variables = copy.deepcopy(self.variables)
 
@@ -643,34 +628,43 @@ class RealConfiguration(_Configuration):
         return self.__class__(coords, **variables)
 
     def fold_coordinates(self) -> None:
-        """Does nothing since coordinates can only be folded if the configuration has a unit cell."""
+        """Do nothing. Folding is not possible without a unit cell."""
         return
 
-    def to_real_coordinates(self) -> FloatArray:
-        """
-        Return the coordinates of this configuration converted to real coordinates.
-
-        :return: the real coordinates
-        :rtype: numpy.ndarray
-        """
+    def to_absolute_coordinates(self) -> FloatArray:
+        """Return the atom coordinates."""
         return self._variables["coordinates"]
 
     def contiguous_configuration(
-        self, _=None, bring_to_centre: bool = False
-    ) -> RealConfiguration:
-        """
-        Return a configuration with chemical entities made contiguous, which is always itself.
+        self, _: Any = None, bring_to_centre: bool = False
+    ) -> AbsoluteConfiguration:
+        """Return itself. A dummy operation, included for compatibility.
 
-        :return: itself
-        :rtype: :class: `MDANSE.MolecularDynamics.Configuration.RealConfiguration`
+        Parameters
+        ----------
+        _ : Any, optional
+            Ignored, by default None
+        bring_to_centre : bool, optional
+            Ignored, by default False
+
+        Returns
+        -------
+        AbsoluteConfiguration
+            This configuration instance.
         """
         return self
 
-    def continuous_configuration(self, _=None) -> RealConfiguration:
-        """
-        Return a configuration with chemical entities made continuous, which is always itself.
+    def continuous_configuration(self, _: Any = None) -> AbsoluteConfiguration:
+        """Return itself. Included for compatibility with other configurations.
 
-        :return: itself
-        :rtype: :class: `MDANSE.MolecularDynamics.Configuration.RealConfiguration`
+        Parameters
+        ----------
+        _ : Any, optional
+            Ignored, by default None
+
+        Returns
+        -------
+        AbsoluteConfiguration
+            This configuration instance.
         """
         return self

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Configuration.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Configuration.py
@@ -329,7 +329,7 @@ class _Configuration(metaclass=abc.ABCMeta):
 
         Returns
         -------
-        np.ndarray
+        FloatArray
             An (N_ATOMS, 3) data array.
         """
         return self._variables[item]
@@ -396,7 +396,7 @@ class _Configuration(metaclass=abc.ABCMeta):
 
         Returns
         -------
-        dict[str, np.ndarray]
+        dict[str, FloatArray]
             Dictionary containing atom positions (optionally also velocities, ...)
         """
         return self._variables

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -179,7 +179,8 @@ class Trajectory:
                  hdf5_driver: str | None = None,
                  rdcc_nbytes: int | None = None,
                  rdcc_w0: float | None = None,
-                 rdcc_nslots: int | None = None):
+                 rdcc_nslots: int | None = None,
+                 fast_load: bool = False):
         self._filename = filename
         self._hdf5_driver = hdf5_driver
         self._rdcc_nbytes = rdcc_nbytes
@@ -194,6 +195,7 @@ class Trajectory:
                                                     self._rdcc_nbytes,
                                                     self._rdcc_w0,
                                                     self._rdcc_nslots,
+                                                    fast_load = fast_load
                                                     )
         self._min_span = None
         self._max_span = None
@@ -470,6 +472,7 @@ class Trajectory:
                         rdcc_nbytes,
                         rdcc_w0,
                         rdcc_nslots,
+                        fast_load: bool = False
                         ):
         trajectory_class = available_formats[trajectory_format]
         trajectory = trajectory_class(self._filename,
@@ -477,6 +480,7 @@ class Trajectory:
                                     rdcc_nbytes = rdcc_nbytes,
                                     rdcc_w0 = rdcc_w0,
                                     rdcc_nslots = rdcc_nslots,
+                                    fast_load = fast_load
                                       )
         return trajectory
 
@@ -506,7 +510,7 @@ class Trajectory:
 
     def __setstate__(self, state):
         self.__dict__ = state
-        self._trajectory = self.open_trajectory(self._format, self._hdf5_driver, self._rdcc_nbytes, self._rdcc_w0, self._rdcc_nslots)
+        self._trajectory = self.open_trajectory(self._format, self._hdf5_driver, self._rdcc_nbytes, self._rdcc_w0, self._rdcc_nslots, fast_load=True)
 
     def __len__(self):
         return len(self._trajectory)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -18,7 +18,6 @@ from MDANSE.util_types import FloatArray
 
 import copy
 import html
-import math
 import os
 from collections import Counter, defaultdict
 from enum import auto
@@ -177,9 +176,10 @@ class Trajectory:
                  filename,
                  trajectory_format: ValidFormats | None = None,
                  hdf5_driver: str | None = None,
+                 *,
                  rdcc_nbytes: int | None = None,
-                 rdcc_w0: float | None = None,
                  rdcc_nslots: int | None = None,
+                 rdcc_w0: float | None = None,
                  fast_load: bool = False):
         self._filename = filename
         self._hdf5_driver = hdf5_driver
@@ -192,9 +192,9 @@ class Trajectory:
 
         self._trajectory = self.open_trajectory(self._format,
                                                     self._hdf5_driver,
-                                                    self._rdcc_nbytes,
-                                                    self._rdcc_w0,
-                                                    self._rdcc_nslots,
+                                                    rdcc_nbytes=self._rdcc_nbytes,
+                                                    rdcc_nslots=self._rdcc_nslots,
+                                                    rdcc_w0=self._rdcc_w0,
                                                     fast_load = fast_load
                                                     )
         self._min_span = None
@@ -469,9 +469,10 @@ class Trajectory:
     def open_trajectory(self,
                         trajectory_format,
                         hdf5_driver,
-                        rdcc_nbytes,
-                        rdcc_w0,
-                        rdcc_nslots,
+                        *,
+                        rdcc_nbytes: int | None = None,
+                        rdcc_nslots: int | None = None,
+                        rdcc_w0: float | None = None,
                         fast_load: bool = False
                         ):
         trajectory_class = available_formats[trajectory_format]
@@ -510,7 +511,12 @@ class Trajectory:
 
     def __setstate__(self, state):
         self.__dict__ = state
-        self._trajectory = self.open_trajectory(self._format, self._hdf5_driver, self._rdcc_nbytes, self._rdcc_w0, self._rdcc_nslots, fast_load=True)
+        self._trajectory = self.open_trajectory(self._format,
+                                                self._hdf5_driver,
+                                                rdcc_nbytes=self._rdcc_nbytes,
+                                                rdcc_nslots=self._rdcc_nslots,
+                                                rdcc_w0=self._rdcc_w0,
+                                                fast_load=True)
 
     def __len__(self):
         return len(self._trajectory)
@@ -1026,10 +1032,12 @@ class TrajectoryWriter:
         chemical_system: ChemicalSystem,
         n_steps,
         selected_atoms=None,
+        *,
         positions_dtype=np.float64,
         chunking_limit=(1,128),
         compression="none",
         initial_charges=None,
+        meta_block_size: int = 65536
     ):
         """Constructor.
 
@@ -1044,7 +1052,7 @@ class TrajectoryWriter:
         """
         self._h5_filename = Path(h5_filename)
         PLATFORM.create_directory(self._h5_filename.parent)
-        self._h5_file = h5py.File(self._h5_filename, "w", meta_block_size=65536)
+        self._h5_file = h5py.File(self._h5_filename, "w", meta_block_size=meta_block_size)
 
         self._chemical_system = chemical_system
         self._last_configuration = None

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -1027,7 +1027,7 @@ class TrajectoryWriter:
         n_steps,
         selected_atoms=None,
         positions_dtype=np.float64,
-        chunking_limit=128,
+        chunking_limit=(1,128),
         compression="none",
         initial_charges=None,
     ):
@@ -1044,7 +1044,7 @@ class TrajectoryWriter:
         """
         self._h5_filename = Path(h5_filename)
         PLATFORM.create_directory(self._h5_filename.parent)
-        self._h5_file = h5py.File(self._h5_filename, "w")
+        self._h5_file = h5py.File(self._h5_filename, "w", meta_block_size=65536)
 
         self._chemical_system = chemical_system
         self._last_configuration = None
@@ -1070,16 +1070,14 @@ class TrajectoryWriter:
 
         self._dtype = positions_dtype
 
-        if self._n_atoms <= 1.5 * chunking_limit:
-            self._chunk_tuple = (1, self._n_atoms, 3)
-            self._padded_size = self._n_atoms
-            self._chunking_limit = self._n_atoms
+        if isinstance(chunking_limit, tuple):
+            frame_chunks, atom_chunks = chunking_limit
         else:
-            self._chunk_tuple = (1, chunking_limit, 3)
-            self._padded_size = (
-                math.ceil(self._n_atoms / chunking_limit) * chunking_limit
-            )
-            self._chunking_limit = chunking_limit
+            frame_chunks = 1
+            atom_chunks = chunking_limit
+        
+        self.frame_chunks = min(frame_chunks, self._n_steps)
+        self.atom_chunks = min(atom_chunks, self._n_atoms)
 
         self._compression = compression
 
@@ -1310,16 +1308,16 @@ class TrajectoryWriter:
             if self._compression in TrajectoryWriter.allowed_compression:
                 variable_charge_dset = self._h5_file.create_dataset(
                     "/configuration/charges",
-                    shape=(self._n_steps, self._padded_size),
-                    chunks=(1, self._chunking_limit),
+                    shape=(self._n_steps, self._n_atoms),
+                    chunks=(self.frame_chunks, self.atom_chunks),
                     dtype=self._dtype,
                     compression=self._compression,
                 )
             else:
                 variable_charge_dset = self._h5_file.create_dataset(
                     "/configuration/charges",
-                    shape=(self._n_steps, self._padded_size),
-                    chunks=(1, self._chunking_limit),
+                    shape=(self._n_steps, self._n_atoms),
+                    chunks=(self.frame_chunks, self.atom_chunks),
                     dtype=self._dtype,
                 )
         variable_charge_dset[index, : self._n_atoms] = charges
@@ -1374,16 +1372,16 @@ class TrajectoryWriter:
                 if self._compression in TrajectoryWriter.allowed_compression:
                     dset = configuration_grp.create_dataset(
                         k,
-                        shape=(self._n_steps, self._padded_size, 3),
-                        chunks=self._chunk_tuple,
+                        shape=(self._n_steps, self._n_atoms, 3),
+                        chunks=(self.frame_chunks, self.atom_chunks, 3),
                         dtype=self._dtype,
                         compression=self._compression,
                     )
                 else:
                     dset = configuration_grp.create_dataset(
                         k,
-                        shape=(self._n_steps, self._padded_size, 3),
-                        chunks=self._chunk_tuple,
+                        shape=(self._n_steps, self._n_atoms, 3),
+                        chunks=(self.frame_chunks, self.atom_chunks, 3),
                         dtype=self._dtype,
                     )
                 dset.attrs["units"] = units.get(k, "")
@@ -1397,7 +1395,7 @@ class TrajectoryWriter:
                 unit_cell_dset = self._h5_file.create_dataset(
                     "unit_cell",
                     shape=(self._n_steps, 3, 3),
-                    chunks=(1, 3, 3),
+                    chunks=True,
                     dtype=np.float64,
                 )
                 unit_cell_dset.attrs["units"] = units.get("unit_cell", "")
@@ -1409,7 +1407,7 @@ class TrajectoryWriter:
             time_dset = self._h5_file.create_dataset(
                 "time",
                 shape=(self._n_steps,),
-                chunks=(1,),
+                chunks=True,
                 dtype=np.float64,
             )
             time_dset.attrs["units"] = units.get("time", "")

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -651,7 +651,7 @@ class Trajectory:
         Returns
         -------
         ndarray
-            2D array containing the real coordinates converted from box coordinates.
+            2D array containing the absolute coordinates converted from fractionals.
 
         """
         return self._trajectory.to_absolute_coordinates(box_coordinates, first, last, step)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -173,20 +173,28 @@ class Trajectory:
     such as the atom selection, atom transmutation and grouping.
     """
 
-    def __init__(self, filename,
+    def __init__(self,
+                 filename,
                  trajectory_format: ValidFormats | None = None,
                  hdf5_driver: str | None = None,
-                 dataset_cache_size: int | None = None):
+                 rdcc_nbytes: int | None = None,
+                 rdcc_w0: float | None = None,
+                 rdcc_nslots: int | None = None):
         self._filename = filename
         self._hdf5_driver = hdf5_driver
-        self._dataset_cache_size = dataset_cache_size
+        self._rdcc_nbytes = rdcc_nbytes
+        self._rdcc_w0 = rdcc_w0
+        self._rdcc_nslots = rdcc_nslots
         self._format = (
             trajectory_format if trajectory_format else self.guess_correct_format()
         )
 
         self._trajectory = self.open_trajectory(self._format,
-                                                self._hdf5_driver,
-                                                self._dataset_cache_size)
+                                                    self._hdf5_driver,
+                                                    self._rdcc_nbytes,
+                                                    self._rdcc_w0,
+                                                    self._rdcc_nslots,
+                                                    )
         self._min_span = None
         self._max_span = None
         self._grouping_level = GroupingLevels.ATOM
@@ -451,9 +459,20 @@ class Trajectory:
 
         return "MDANSE"
 
-    def open_trajectory(self, trajectory_format, hdf5_driver, dataset_cache_size):
+    def open_trajectory(self,
+                        trajectory_format,
+                        hdf5_driver,
+                        rdcc_nbytes,
+                        rdcc_w0,
+                        rdcc_nslots,
+                        ):
         trajectory_class = available_formats[trajectory_format]
-        trajectory = trajectory_class(self._filename, hdf5_driver=hdf5_driver, rdcc_nbytes=dataset_cache_size)
+        trajectory = trajectory_class(self._filename,
+                                      hdf5_driver=hdf5_driver,
+                                    rdcc_nbytes = rdcc_nbytes,
+                                    rdcc_w0 = rdcc_w0,
+                                    rdcc_nslots = rdcc_nslots,
+                                      )
         return trajectory
 
     def close(self):

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -1052,7 +1052,10 @@ class TrajectoryWriter:
         """
         self._h5_filename = Path(h5_filename)
         PLATFORM.create_directory(self._h5_filename.parent)
-        self._h5_file = h5py.File(self._h5_filename, "w", meta_block_size=meta_block_size)
+        self._h5_file = h5py.File(self._h5_filename,
+                                  "w",
+                                  meta_block_size=meta_block_size,
+                                  libver=('earliest', 'v114'),)
 
         self._chemical_system = chemical_system
         self._last_configuration = None

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -142,7 +142,7 @@ def trajectory_summary(traj: Trajectory, *, use_html: bool = False) -> str:
             val.append(f"{k}: {v}")
 
     val.append("\nMolecular types found:")
-    for molname, mollist in traj.chemical_system._clusters.items():
+    for molname, mollist in traj.chemical_system.clusters.items():
         val.append(f"Molecule: {molname}; Count: {len(mollist)}")
 
     val = "\n".join(val)
@@ -157,7 +157,7 @@ def chemical_system_summary(cs: ChemicalSystem) -> str:
     atoms, counts = np.unique(cs.atom_list, return_counts=True)
     for atom, count in zip(atoms, counts, strict=False):
         text += f"Element: {atom}; Count: {count}\n"
-    for molname, mollist in cs._clusters.items():
+    for molname, mollist in cs.clusters.items():
         text += f"Molecule: {molname}; Count: {len(mollist)}\n"
     text += " ===== \n"
     return html.escape(text)
@@ -234,7 +234,7 @@ class Trajectory:
         mapping = {element: element for element in self.unique_elements}
         if self._grouping_level == GroupingLevels.MOLECULE:
             temp_names = {}
-            for mol_name, clusters in self.chemical_system._clusters.items():
+            for mol_name, clusters in self.chemical_system.clusters.items():
                 for cluster in clusters:
                     overlap = set(cluster).intersection(self.atom_indices)
                     for x in overlap:
@@ -252,9 +252,9 @@ class Trajectory:
         of all atoms belonging to the group.
         """
         temp_dict = {}
-        for mol_name in self.chemical_system._clusters:
+        for mol_name in self.chemical_system.clusters:
             temp_dict.setdefault(mol_name, 0)
-            for cluster in self.chemical_system._clusters[mol_name]:
+            for cluster in self.chemical_system.clusters[mol_name]:
                 overlap = set(cluster).intersection(self.atom_indices)
                 temp_dict[mol_name] += len(overlap)
         return {k: v for k, v in temp_dict.items() if v}
@@ -285,7 +285,7 @@ class Trajectory:
         return sorted(
             {
                 self.atom_types[x]
-                for cluster in self.chemical_system._clusters[grp_name]
+                for cluster in self.chemical_system.clusters[grp_name]
                 for x in cluster
                 if x in self.atom_indices
             }
@@ -296,7 +296,7 @@ class Trajectory:
         """Labels of ALL the atoms, after transmutation."""
         if self._grouping_level == GroupingLevels.MOLECULE:
             temp_names = {}
-            for mol_name, clusters in self.chemical_system._clusters.items():
+            for mol_name, clusters in self.chemical_system.clusters.items():
                 for cluster in clusters:
                     overlap = set(cluster).intersection(self.atom_indices)
                     for x in overlap:
@@ -628,7 +628,7 @@ class Trajectory:
             self.calculate_coordinate_span()
         return self._min_span
 
-    def to_real_coordinates(
+    def to_absolute_coordinates(
         self,
         box_coordinates: FloatArray,
         first: int = 0,
@@ -654,7 +654,7 @@ class Trajectory:
             2D array containing the real coordinates converted from box coordinates.
 
         """
-        return self._trajectory.to_real_coordinates(box_coordinates, first, last, step)
+        return self._trajectory.to_absolute_coordinates(box_coordinates, first, last, step)
 
     def read_atomic_trajectory(
         self,

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -262,6 +262,11 @@ class Trajectory:
         dataset_type = TrajDataArray[array_name.upper()]
         return self._trajectory.chunk_size(dataset_type)
 
+    def dtype_size(self, array_name: str = "position") -> int:
+        """Return the number of atoms in a single chunk of the HDF5 dataset."""
+        dataset_type = TrajDataArray[array_name.upper()]
+        return self._trajectory.dtype_size(dataset_type)
+
     def group_elements(self, grp_name):
         """The elements in the group with the name grp_name.
 
@@ -501,7 +506,7 @@ class Trajectory:
 
     def __setstate__(self, state):
         self.__dict__ = state
-        self._trajectory = self.open_trajectory(self._format, self._hdf5_driver, self._dataset_cache_size)
+        self._trajectory = self.open_trajectory(self._format, self._hdf5_driver, self._rdcc_nbytes, self._rdcc_w0, self._rdcc_nslots)
 
     def __len__(self):
         return len(self._trajectory)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
@@ -20,7 +20,7 @@ from itertools import pairwise
 from typing import TYPE_CHECKING
 
 import numpy as np
-from more_itertools import chunked_even
+from more_itertools import chunked_even, flatten
 
 from MDANSE.util_types import FloatArray
 

--- a/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
@@ -289,3 +289,23 @@ def balance_index_groups(
         if len(index_sets) < min_count:
             max_size = max(3 * max_size // 4, 1)
     return index_sets
+
+
+def group_cluster_indices(chemical_system: ChemicalSystem) -> list[list[int]]:
+    """Return a list of index list, one for each molecule in the system.
+
+    This function is meant to show which atoms belong to the same structural unit,
+    independent of what that unit may be. This is typically used by Configuration
+    classes in the contiguous_coordinates function.
+
+    Parameters
+    ----------
+    chemical_system : ChemicalSystem
+        ChemicalSystem instance containing the _clusters attribute.
+
+    Returns
+    -------
+    list[list[int]]
+        A list of atom index lists, one per molecule instance.
+    """
+    return list(flatten(chemical_system.clusters.values()))

--- a/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 from more_itertools import chunked_even
 
+from MDANSE.util_types import FloatArray
+
 if TYPE_CHECKING:
     from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
@@ -29,8 +31,6 @@ mb_ram_per_process = os.environ.get("MDANSE_MAX_RAM_PER_PROCESS", "512")
 CHUNK_SIZE_LIMIT = (
     int(mb_ram_per_process) * 2**20
 )  # 512 MB memory limit per process for now
-
-from MDANSE.util_types import FloatArray
 
 
 class MolecularDynamicsError(Exception):

--- a/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
@@ -25,6 +25,7 @@ from more_itertools import chunked_even
 from MDANSE.util_types import FloatArray
 
 if TYPE_CHECKING:
+    from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
     from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
 mb_ram_per_process = os.environ.get("MDANSE_MAX_RAM_PER_PROCESS", "512")

--- a/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
+++ b/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
@@ -24,6 +24,7 @@ import numpy as np
 import numpy.typing as npt
 
 from MDANSE.Chemistry import ATOMS_DATABASE
+from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.TrajectoryUtils import (
     atomic_trajectory,
     atomic_trajectory_many,
@@ -131,10 +132,35 @@ class TrajectoryFile(ABC):
     @abstractmethod
     def time(self) -> FloatArray: ...
 
-    @abstractmethod
-    def chunk_size(
-        self, dataset_type: TrajDataArray = TrajDataArray.POSITION
-    ) -> int: ...
+    def chunk_size(self, dataset_type: TrajDataArray = TrajDataArray.POSITION) -> int:
+        data_key = self.KEYS[dataset_type.name.lower()]
+        try:
+            dataset = self._h5_file[data_key]
+        except KeyError:
+            LOG.error("Dataset %s was not in the trajectory file", data_key)
+            return -1
+        if (chunk_shape := getattr(dataset, "chunks", None)) is None:
+            LOG.warning("Dataset %s is not chunked, and was expected to be", data_key)
+            return -1
+        if len(chunk_shape) < 2:
+            LOG.warning("Dataset %s does not have enough dimensions", data_key)
+            return -1
+        return chunk_shape[1]
+
+    def dtype_size(self, dataset_type: TrajDataArray = TrajDataArray.POSITION) -> int:
+        data_key = self.KEYS[dataset_type.name.lower()]
+        dataset = self._h5_file[data_key]
+        match dataset.dtype:
+            case np.float16:
+                return 2
+            case np.float32:
+                return 4
+            case np.float64:
+                return 8
+            case np.float128:
+                return 16
+            case _:
+                return 8
 
     @abstractmethod
     def unit_cell(self, frame: int) -> UnitCell | None: ...

--- a/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
+++ b/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
@@ -231,7 +231,7 @@ class TrajectoryFile(ABC):
 
         return self.variable(variable)[slc, index, :].astype(np.float64)
 
-    def to_real_coordinates(
+    def to_absolute_coordinates(
         self,
         box_coordinates: FloatArray,
         first: int = 0,

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -17,11 +17,11 @@ from __future__ import annotations
 
 from collections import ChainMap
 from enum import Enum
-from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import h5py
+import more_itertools
 import numpy as np
 
 from MDANSE.Chemistry import ATOMS_DATABASE
@@ -135,9 +135,10 @@ class H5MDTrajectory(TrajectoryFile):
         self,
         h5_filename: Path | str,
         hdf5_driver: str | None = None,
+        *,
         rdcc_nbytes: int | None = None,
-        rdcc_w0: float | None = None,
         rdcc_nslots: int | None = None,
+        rdcc_w0: float | None = None,
         fast_load: bool = False,
     ):
         """Constructor.
@@ -158,8 +159,8 @@ class H5MDTrajectory(TrajectoryFile):
             "r",
             driver=hdf5_driver,
             rdcc_nbytes=rdcc_nbytes,
-            rdcc_w0=rdcc_w0,
             rdcc_nslots=rdcc_nslots,
+            rdcc_w0=rdcc_w0,
         )
 
         particle_types = self._h5_file["/particles/all/species"]
@@ -204,8 +205,8 @@ class H5MDTrajectory(TrajectoryFile):
 
         if self._chemical_system.rdkit_mol.GetNumBonds() > 0:
             configuration = self.configuration(0)
-            grouped_indices = reduce(
-                list.__add__, self._chemical_system.clusters.values(), []
+            grouped_indices = list(
+                more_itertools.flatten(self._chemical_system.clusters.values())
             )
             contiguous_configuration = configuration.contiguous_configuration(
                 grouped_indices

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -135,6 +135,8 @@ class H5MDTrajectory(TrajectoryFile):
         h5_filename: Path | str,
         hdf5_driver: str | None = None,
         rdcc_nbytes: int | None = None,
+        rdcc_w0: float | None = None,
+        rdcc_nslots: int | None = None,
     ):
         """Constructor.
 
@@ -152,8 +154,10 @@ class H5MDTrajectory(TrajectoryFile):
         self._h5_file = h5py.File(
             self._h5_filename,
             "r",
-            driver=self._h5_driver,
-            rdcc_nbytes=self._h5_cache_size,
+            driver=hdf5_driver,
+            rdcc_nbytes=rdcc_nbytes,
+            rdcc_w0=rdcc_w0,
+            rdcc_nslots=rdcc_nslots,
         )
 
         particle_types = self._h5_file["/particles/all/species"]

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -29,8 +29,8 @@ from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
 from MDANSE.Framework.Units import measure
 from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicRealConfiguration,
-    RealConfiguration,
+    AbsoluteConfiguration,
+    PeriodicAbsoluteConfiguration,
     _Configuration,
 )
 from MDANSE.MolecularDynamics.UnitCell import (
@@ -205,7 +205,7 @@ class H5MDTrajectory(TrajectoryFile):
         if self._chemical_system.rdkit_mol.GetNumBonds() > 0:
             configuration = self.configuration(0)
             grouped_indices = reduce(
-                list.__add__, self._chemical_system._clusters.values(), []
+                list.__add__, self._chemical_system.clusters.values(), []
             )
             contiguous_configuration = configuration.contiguous_configuration(
                 grouped_indices
@@ -396,9 +396,9 @@ class H5MDTrajectory(TrajectoryFile):
         coordinates = self.coordinates(frame)
 
         if unit_cell is None:
-            conf = RealConfiguration(coordinates, **variables)
+            conf = AbsoluteConfiguration(coordinates, **variables)
         else:
-            conf = PeriodicRealConfiguration(coordinates, unit_cell, **variables)
+            conf = PeriodicAbsoluteConfiguration(coordinates, unit_cell, **variables)
 
         return conf
 

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections import ChainMap
 from enum import Enum
+from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -137,6 +138,7 @@ class H5MDTrajectory(TrajectoryFile):
         rdcc_nbytes: int | None = None,
         rdcc_w0: float | None = None,
         rdcc_nslots: int | None = None,
+        fast_load: bool = False,
     ):
         """Constructor.
 
@@ -181,7 +183,16 @@ class H5MDTrajectory(TrajectoryFile):
             chemical_elements = [
                 reverse_lookup[type_number] for type_number in particle_types
             ]
-        self._chemical_system = ChemicalSystem(self._h5_filename.stem)
+        self._chemical_system = ChemicalSystem(
+            self._h5_filename.stem, fast_load=fast_load
+        )
+
+        self._variables_to_skip = set()
+        self._load_units()
+        self._load_unit_cells()
+
+        if fast_load:
+            return
 
         try:
             self._chemical_system.initialise_atoms(chemical_elements)
@@ -191,13 +202,14 @@ class H5MDTrajectory(TrajectoryFile):
             )
             return
 
-        self._variables_to_skip = set()
-        self._load_units()
-        self._load_unit_cells()
-
         if self._chemical_system.rdkit_mol.GetNumBonds() > 0:
             configuration = self.configuration(0)
-            contiguous_configuration = configuration.contiguous_configuration()
+            grouped_indices = reduce(
+                list.__add__, self._chemical_system._clusters.values(), []
+            )
+            contiguous_configuration = configuration.contiguous_configuration(
+                grouped_indices
+            )
             coords = contiguous_configuration.coordinates
             self._chemical_system.set_bond_orders(coords)
 
@@ -384,11 +396,9 @@ class H5MDTrajectory(TrajectoryFile):
         coordinates = self.coordinates(frame)
 
         if unit_cell is None:
-            conf = RealConfiguration(self._chemical_system, coordinates, **variables)
+            conf = RealConfiguration(coordinates, **variables)
         else:
-            conf = PeriodicRealConfiguration(
-                self._chemical_system, coordinates, unit_cell, **variables
-            )
+            conf = PeriodicRealConfiguration(coordinates, unit_cell, **variables)
 
         return conf
 

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -329,21 +329,6 @@ class H5MDTrajectory(TrajectoryFile):
 
         return charge.astype(np.float64)
 
-    def chunk_size(self, dataset_type: TrajDataArray = TrajDataArray.POSITION) -> int:
-        data_key = self.KEYS[dataset_type.name.lower()]
-        try:
-            dataset = self._h5_file[data_key]
-        except KeyError:
-            LOG.error("Dataset %s was not in the trajectory file", data_key)
-            return -1
-        if (chunk_shape := getattr(dataset, "chunks", None)) is None:
-            LOG.warning("Dataset %s is not chunked, and was expected to be", data_key)
-            return -1
-        if len(chunk_shape) < 2:
-            LOG.warning("Dataset %s does not have enough dimensions", data_key)
-            return -1
-        return chunk_shape[1]
-
     def coordinates(
         self,
         frame: slice | int,

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -241,21 +241,6 @@ class MdanseTrajectory(TrajectoryFile):
         n_req = len(range(*indices.indices(self.chemical_system.number_of_atoms)))
         return np.zeros(n_req, dtype=np.float64)
 
-    def chunk_size(self, dataset_type: TrajDataArray = TrajDataArray.POSITION) -> int:
-        data_key = self.KEYS[dataset_type.name.lower()]
-        try:
-            dataset = self._h5_file[data_key]
-        except KeyError:
-            LOG.error("Dataset %s was not in the trajectory file", data_key)
-            return -1
-        if (chunk_shape := getattr(dataset, "chunks", None)) is None:
-            LOG.warning("Dataset %s is not chunked, and was expected to be", data_key)
-            return -1
-        if len(chunk_shape) < 2:
-            LOG.warning("Dataset %s does not have enough dimensions", data_key)
-            return -1
-        return chunk_shape[1]
-
     def coordinates(
         self, frame: slice | int, indices: slice | int = np.s_[:]
     ) -> FloatArray:

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -31,8 +31,8 @@ from MDANSE.Chemistry.Databases import str_to_num
 from MDANSE.Framework.Units import measure
 from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicRealConfiguration,
-    RealConfiguration,
+    AbsoluteConfiguration,
+    PeriodicAbsoluteConfiguration,
 )
 from MDANSE.MolecularDynamics.UnitCell import (
     BAD_CELL,
@@ -114,7 +114,7 @@ class MdanseTrajectory(TrajectoryFile):
         if self._chemical_system.rdkit_mol.GetNumBonds() > 0:
             configuration = self.configuration(0)
             grouped_indices = reduce(
-                list.__add__, self._chemical_system._clusters.values(), []
+                list.__add__, self._chemical_system.clusters.values(), []
             )
             contiguous_configuration = configuration.contiguous_configuration(
                 grouped_indices
@@ -283,7 +283,7 @@ class MdanseTrajectory(TrajectoryFile):
     def configuration(
         self,
         frame: int = 0,
-    ) -> RealConfiguration | PeriodicRealConfiguration:
+    ) -> AbsoluteConfiguration | PeriodicAbsoluteConfiguration:
         """Return the atom configuration for a specific frame.
 
         Parameters
@@ -293,7 +293,7 @@ class MdanseTrajectory(TrajectoryFile):
 
         Returns
         -------
-        Union[RealConfiguration, PeriodicRealConfiguration]
+        Union[AbsoluteConfiguration, PeriodicAbsoluteConfiguration]
             Atom configuration, with unit cell (if defined)
 
         """
@@ -310,9 +310,9 @@ class MdanseTrajectory(TrajectoryFile):
         coordinates = variables.pop("coordinates")
 
         if unit_cell is None:
-            conf = RealConfiguration(coordinates, **variables)
+            conf = AbsoluteConfiguration(coordinates, **variables)
         else:
-            conf = PeriodicRealConfiguration(
+            conf = PeriodicAbsoluteConfiguration(
                 coordinates,
                 unit_cell,
                 **variables,

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -66,6 +66,8 @@ class MdanseTrajectory(TrajectoryFile):
         h5_filename: Path | str,
         hdf5_driver: str | None = None,
         rdcc_nbytes: int | None = None,
+        rdcc_w0: float | None = None,
+        rdcc_nslots: int | None = None,
     ):
         """Open the file and build a trajectory.
 
@@ -89,8 +91,10 @@ class MdanseTrajectory(TrajectoryFile):
         self._h5_file = h5py.File(
             self._h5_filename,
             "r",
-            driver=self._h5_driver,
-            rdcc_nbytes=self._h5_cache_size,
+            driver=hdf5_driver,
+            rdcc_nbytes=rdcc_nbytes,
+            rdcc_w0=rdcc_w0,
+            rdcc_nslots=rdcc_nslots,
         )
         self._has_database = "atom_database" in self._h5_file
         self._has_atoms = []

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -15,14 +15,14 @@
 #
 from __future__ import annotations
 
-from collections import ChainMap, defaultdict
-from collections.abc import Iterable, Mapping
-from functools import cached_property, reduce
+from collections import ChainMap
+from collections.abc import Mapping
+from functools import cached_property
 from pathlib import Path
 
 import h5py
 import numpy as np
-from more_itertools import first
+from more_itertools import first, flatten
 
 import MDANSE
 from MDANSE.Chemistry import ATOMS_DATABASE
@@ -65,9 +65,10 @@ class MdanseTrajectory(TrajectoryFile):
         self,
         h5_filename: Path | str,
         hdf5_driver: str | None = None,
+        *,
         rdcc_nbytes: int | None = None,
-        rdcc_w0: float | None = None,
         rdcc_nslots: int | None = None,
+        rdcc_w0: float | None = None,
         fast_load: bool = False,
     ):
         """Open the file and build a trajectory.
@@ -94,8 +95,8 @@ class MdanseTrajectory(TrajectoryFile):
             "r",
             driver=hdf5_driver,
             rdcc_nbytes=rdcc_nbytes,
-            rdcc_w0=rdcc_w0,
             rdcc_nslots=rdcc_nslots,
+            rdcc_w0=rdcc_w0,
         )
         self._has_database = "atom_database" in self._h5_file
         self._has_atoms = []
@@ -113,9 +114,7 @@ class MdanseTrajectory(TrajectoryFile):
 
         if self._chemical_system.rdkit_mol.GetNumBonds() > 0:
             configuration = self.configuration(0)
-            grouped_indices = reduce(
-                list.__add__, self._chemical_system.clusters.values(), []
-            )
+            grouped_indices = list(flatten(self._chemical_system.clusters.values()))
             contiguous_configuration = configuration.contiguous_configuration(
                 grouped_indices
             )

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from collections import ChainMap, defaultdict
 from collections.abc import Iterable, Mapping
-from functools import cached_property
+from functools import cached_property, reduce
 from pathlib import Path
 
 import h5py
@@ -68,6 +68,7 @@ class MdanseTrajectory(TrajectoryFile):
         rdcc_nbytes: int | None = None,
         rdcc_w0: float | None = None,
         rdcc_nslots: int | None = None,
+        fast_load: bool = False,
     ):
         """Open the file and build a trajectory.
 
@@ -103,12 +104,21 @@ class MdanseTrajectory(TrajectoryFile):
         self._load_unit_cells()
 
         # Load the chemical system
-        self._chemical_system = ChemicalSystem(self._h5_filename.stem, self)
+        self._chemical_system = ChemicalSystem(
+            self._h5_filename.stem, self, fast_load=fast_load
+        )
+        if fast_load:
+            return
         self._chemical_system.load(self._h5_file)
 
         if self._chemical_system.rdkit_mol.GetNumBonds() > 0:
             configuration = self.configuration(0)
-            contiguous_configuration = configuration.contiguous_configuration()
+            grouped_indices = reduce(
+                list.__add__, self._chemical_system._clusters.values(), []
+            )
+            contiguous_configuration = configuration.contiguous_configuration(
+                grouped_indices
+            )
             coords = contiguous_configuration.coordinates
             self._chemical_system.set_bond_orders(coords)
 
@@ -300,10 +310,9 @@ class MdanseTrajectory(TrajectoryFile):
         coordinates = variables.pop("coordinates")
 
         if unit_cell is None:
-            conf = RealConfiguration(self._chemical_system, coordinates, **variables)
+            conf = RealConfiguration(coordinates, **variables)
         else:
             conf = PeriodicRealConfiguration(
-                self._chemical_system,
                 coordinates,
                 unit_cell,
                 **variables,

--- a/MDANSE/Tests/UnitTests/molecules/test_connectivity.py
+++ b/MDANSE/Tests/UnitTests/molecules/test_connectivity.py
@@ -41,6 +41,6 @@ def test_identify_molecules(trajectory, connectivity):
 
     molstrings = []
     assert all(len(mollist) == 20
-               for mollist in chemical_system._clusters.values())
+               for mollist in chemical_system.clusters.values())
     assert all(ms == molstrings[0] for ms in molstrings[1:])
     assert len(chemical_system.unique_molecules()) == 1

--- a/MDANSE/Tests/UnitTests/test_HDF5Trajectory.py
+++ b/MDANSE/Tests/UnitTests/test_HDF5Trajectory.py
@@ -44,7 +44,6 @@ def sample_configuration(chemical_system):
     coords[2] = [10.0, 1.0, 5.11]
     coords[3] = [10.0, 2.0, 5.09]
     temp = RealConfiguration(
-        chemical_system,
         coords,
         # unit_cell
     )

--- a/MDANSE/Tests/UnitTests/test_HDF5Trajectory.py
+++ b/MDANSE/Tests/UnitTests/test_HDF5Trajectory.py
@@ -20,7 +20,7 @@ import os
 import numpy as np
 
 from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
-from MDANSE.MolecularDynamics.Configuration import RealConfiguration
+from MDANSE.MolecularDynamics.Configuration import AbsoluteConfiguration
 from MDANSE.MolecularDynamics.Trajectory import Trajectory, TrajectoryWriter
 
 N_ATOMS = 4
@@ -43,7 +43,7 @@ def sample_configuration(chemical_system):
     coords[1] = [1.0, 2.0, 1.0]
     coords[2] = [10.0, 1.0, 5.11]
     coords[3] = [10.0, 2.0, 5.09]
-    temp = RealConfiguration(
+    temp = AbsoluteConfiguration(
         coords,
         # unit_cell
     )

--- a/MDANSE/Tests/UnitTests/test_configuration.py
+++ b/MDANSE/Tests/UnitTests/test_configuration.py
@@ -24,6 +24,7 @@ from MDANSE.MolecularDynamics.Configuration import (
     RealConfiguration,
     ConfigurationError,
 )
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_cluster_indices
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 
@@ -48,9 +49,8 @@ class TestConfiguration(unittest.TestCase):
     def test_dunder_init_valid(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         vels = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coords, velocities=vels)
+        conf = RealConfiguration(coords, velocities=vels)
 
-        self.assertEqual(self.chem_system, conf._chemical_system)
         self.assertEqual(["coordinates", "velocities"], list(conf._variables.keys()))
         self.assertTrue(
             np.allclose(coords, conf._variables["coordinates"]),
@@ -64,7 +64,7 @@ class TestConfiguration(unittest.TestCase):
     def test_dunder_contains(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         vels = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coords, velocities=vels)
+        conf = RealConfiguration(coords, velocities=vels)
 
         self.assertTrue("coordinates" in conf)
         self.assertTrue("velocities" in conf)
@@ -73,7 +73,7 @@ class TestConfiguration(unittest.TestCase):
     def test_dunder_getitem(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         vels = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coords, velocities=vels)
+        conf = RealConfiguration(coords, velocities=vels)
 
         self.assertTrue(
             np.allclose(coords, conf["coordinates"]),
@@ -88,7 +88,7 @@ class TestConfiguration(unittest.TestCase):
     def test_dunder_setitem_valid(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         gradients = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coords)
+        conf = RealConfiguration(coords)
 
         conf["gradients"] = gradients
         self.assertTrue(
@@ -97,7 +97,7 @@ class TestConfiguration(unittest.TestCase):
 
     def test_dunder_setitem_invalid_shape(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coords)
+        conf = RealConfiguration(coords)
 
         with self.assertRaises(ValueError):
             conf["velocities"] = np.random.uniform(0, 1, (self._nAtoms + 1, 3))
@@ -107,9 +107,8 @@ class TestConfiguration(unittest.TestCase):
     def test_properties(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         vels = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coords, velocities=vels)
+        conf = RealConfiguration(coords, velocities=vels)
 
-        self.assertEqual(self.chem_system, conf.chemical_system)
         self.assertTrue(
             np.allclose(coords, conf.coordinates), f"\nactual = {conf.coordinates}"
         )
@@ -142,11 +141,10 @@ class TestPeriodicConfiguration(unittest.TestCase):
         self.coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         self.unit_cell = UnitCell(np.random.uniform(0, 1, (3, 3)))
         self.conf = PeriodicBoxConfiguration(
-            self.chem_system, self.coords, self.unit_cell
+            self.coords, self.unit_cell
         )
 
     def test_instantiation_valid(self):
-        self.assertEqual(self.chem_system, self.conf.chemical_system)
         self.assertTrue(np.allclose(self.coords, self.conf["coordinates"]))
         self.assertEqual(self.unit_cell, self.conf.unit_cell)
 
@@ -154,17 +152,9 @@ class TestPeriodicConfiguration(unittest.TestCase):
         with self.assertRaises(ValueError):
             UnitCell(np.random.uniform(0, 1, (4, 4)))
 
-    def test_clone_valid_chemical_system(self):
-        clone = self.conf.clone(self.chem_system)
-
-        self.assertEqual(self.chem_system, clone.chemical_system)
-        self.assertTrue(np.allclose(self.coords, clone["coordinates"]))
-        self.assertEqual(self.unit_cell, clone.unit_cell)
-
     def test_clone_valid_none(self):
         clone = self.conf.clone()
 
-        self.assertEqual(self.chem_system, clone.chemical_system)
         self.assertTrue(np.allclose(self.coords, clone["coordinates"]))
         self.assertEqual(self.unit_cell, clone.unit_cell)
 
@@ -199,7 +189,7 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicBoxConfiguration(coords, unit_cell)
 
         self.assertTrue(
             np.allclose(
@@ -220,7 +210,7 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
         coords = np.array(([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]))
-        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicBoxConfiguration(coords, unit_cell)
 
         self.assertTrue(
             np.allclose(coords, conf.to_box_coordinates()),
@@ -232,7 +222,7 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
         coords = np.array(([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]))
-        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicBoxConfiguration(coords, unit_cell)
 
         self.assertTrue(
             np.allclose(
@@ -252,11 +242,10 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
         coords = np.array(([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]))
-        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicBoxConfiguration(coords, unit_cell)
         real = conf.to_real_configuration()
 
         self.assertTrue(isinstance(real, PeriodicRealConfiguration))
-        self.assertEqual(repr(self.chem_system), repr(real._chemical_system))
         self.assertEqual(["coordinates"], list(real._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -275,11 +264,10 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
     def test_contiguous_configuration(self):
         unit_cell = UnitCell(np.array([[2, 1, 0], [-3, 2, 0], [2, 1, -4]]))
         coords = [[0.1, 0.1, 0.1], [0.3, 0.2, 0.4], [-1.3, -1.1, -1.3], [1.9, 1.5, 1.9]]
-        conf = PeriodicBoxConfiguration(self.chem_system, coords, unit_cell)
-        contiguous_conf = conf.contiguous_configuration()
+        conf = PeriodicBoxConfiguration(coords, unit_cell)
+        contiguous_conf = conf.contiguous_configuration(group_cluster_indices(self.chem_system))
 
         self.assertTrue(isinstance(contiguous_conf, PeriodicBoxConfiguration))
-        self.assertEqual(repr(self.chem_system), repr(contiguous_conf._chemical_system))
         self.assertEqual(["coordinates"], list(contiguous_conf._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -318,7 +306,7 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
             ]
         )
         unit_cell = UnitCell(np.array([[2, 1, 0], [-3, 2, 0], [2, 1, -4]]))
-        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicRealConfiguration(coords, unit_cell)
         conf.fold_coordinates()
 
         self.assertTrue(
@@ -347,7 +335,7 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicRealConfiguration(coords, unit_cell)
 
         box = conf.to_box_coordinates()
         self.assertTrue(
@@ -367,11 +355,10 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicRealConfiguration(coords, unit_cell)
 
         box_conf = conf.to_box_configuration()
         self.assertTrue(isinstance(box_conf, PeriodicBoxConfiguration))
-        self.assertEqual(repr(self.chem_system), repr(box_conf._chemical_system))
         self.assertEqual(["coordinates"], list(box_conf._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -393,7 +380,7 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicRealConfiguration(coords, unit_cell)
 
         real = conf.to_real_coordinates()
         self.assertTrue(np.allclose(coords, real), f"\nactual = {real}")
@@ -410,11 +397,10 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicRealConfiguration(coords, unit_cell)
 
-        result = conf.contiguous_configuration()
+        result = conf.contiguous_configuration(group_cluster_indices(self.chem_system))
         self.assertTrue(isinstance(result, PeriodicRealConfiguration))
-        self.assertEqual(repr(self.chem_system), repr(result._chemical_system))
         self.assertEqual(["coordinates"], list(result._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -448,8 +434,8 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
                 [-1.8123033523559569, -0.3780877590179443, -0.5149454593658447],
             ]
         )
-        conf = PeriodicRealConfiguration(self.chem_system, coords.copy(), unit_cell)
-        result = conf.contiguous_configuration()
+        conf = PeriodicRealConfiguration(coords.copy(), unit_cell)
+        result = conf.contiguous_configuration(group_cluster_indices(self.chem_system))
         new_coords = result.coordinates
         assert np.allclose(coords, new_coords)
 
@@ -465,11 +451,10 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicRealConfiguration(coords, unit_cell)
 
-        result = conf.continuous_configuration()
+        result = conf.continuous_configuration([])
         self.assertTrue(isinstance(result, PeriodicRealConfiguration))
-        self.assertEqual(repr(self.chem_system), repr(result._chemical_system))
         self.assertEqual(["coordinates"], list(result._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -498,11 +483,10 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
         self.chem_system.add_bonds([(0, 1), (2, 3)])
-        conf = PeriodicRealConfiguration(self.chem_system, coords, unit_cell)
+        conf = PeriodicRealConfiguration(coords, unit_cell)
 
-        result = conf.continuous_configuration()
+        result = conf.continuous_configuration(self.chem_system._bonds)
         self.assertTrue(isinstance(result, PeriodicRealConfiguration))
-        self.assertEqual(repr(self.chem_system), repr(result._chemical_system))
         self.assertEqual(["coordinates"], list(result._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -534,7 +518,7 @@ class TestRealConfiguration(unittest.TestCase):
 
     def test_clone_valid_no_input(self):
         coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coordinates)
+        conf = RealConfiguration(coordinates)
         clone = conf.clone()
 
         self.assertTrue(isinstance(clone, RealConfiguration))
@@ -546,8 +530,8 @@ class TestRealConfiguration(unittest.TestCase):
 
     def test_clone_valid_chemical_system_provided(self):
         coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coordinates)
-        clone = conf.clone(self.chem_system)
+        conf = RealConfiguration(coordinates)
+        clone = conf.clone()
 
         self.assertTrue(isinstance(clone, RealConfiguration))
         self.assertEqual(["coordinates"], list(clone._variables.keys()))
@@ -556,17 +540,9 @@ class TestRealConfiguration(unittest.TestCase):
             f'\nactual = {clone["coordinates"]}',
         )
 
-    def test_clone_invalid_system(self):
-        coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coordinates)
-
-        cs = ChemicalSystem()
-        with self.assertRaises(ConfigurationError):
-            conf.clone(cs)
-
     def test_fold_coordinates(self):
         coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coordinates)
+        conf = RealConfiguration(coordinates)
         conf.fold_coordinates()
 
         self.assertTrue(
@@ -576,19 +552,19 @@ class TestRealConfiguration(unittest.TestCase):
 
     def test_to_real_coordinates(self):
         coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coordinates)
+        conf = RealConfiguration(coordinates)
         real = conf.to_real_coordinates()
 
         self.assertTrue(np.allclose(coordinates, real), f"\nactual = {real}")
 
     def test_contiguous_configuration(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coords)
+        conf = RealConfiguration(coords)
 
         self.assertEqual(conf, conf.contiguous_configuration())
 
     def test_continuous_configuration(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(self.chem_system, coords)
+        conf = RealConfiguration(coords)
 
         self.assertEqual(conf, conf.continuous_configuration())

--- a/MDANSE/Tests/UnitTests/test_configuration.py
+++ b/MDANSE/Tests/UnitTests/test_configuration.py
@@ -19,9 +19,9 @@ import numpy as np
 
 from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
 from MDANSE.MolecularDynamics.Configuration import (
-    PeriodicBoxConfiguration,
-    PeriodicRealConfiguration,
-    RealConfiguration,
+    PeriodicFractionalConfiguration,
+    PeriodicAbsoluteConfiguration,
+    AbsoluteConfiguration,
     ConfigurationError,
 )
 from MDANSE.MolecularDynamics.TrajectoryUtils import group_cluster_indices
@@ -30,7 +30,7 @@ from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 class TestConfiguration(unittest.TestCase):
     """
-    Uses :class: `MDNASE.MolecularDynamics.Configuration.RealConfiguration` to test methods of the abstract base
+    Uses :class: `MDNASE.MolecularDynamics.Configuration.AbsoluteConfiguration` to test methods of the abstract base
     class :class: `MDANSE.MolecularDynamics.Configuration._Configuration`.
     """
 
@@ -49,7 +49,7 @@ class TestConfiguration(unittest.TestCase):
     def test_dunder_init_valid(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         vels = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coords, velocities=vels)
+        conf = AbsoluteConfiguration(coords, velocities=vels)
 
         self.assertEqual(["coordinates", "velocities"], list(conf._variables.keys()))
         self.assertTrue(
@@ -64,7 +64,7 @@ class TestConfiguration(unittest.TestCase):
     def test_dunder_contains(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         vels = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coords, velocities=vels)
+        conf = AbsoluteConfiguration(coords, velocities=vels)
 
         self.assertTrue("coordinates" in conf)
         self.assertTrue("velocities" in conf)
@@ -73,7 +73,7 @@ class TestConfiguration(unittest.TestCase):
     def test_dunder_getitem(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         vels = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coords, velocities=vels)
+        conf = AbsoluteConfiguration(coords, velocities=vels)
 
         self.assertTrue(
             np.allclose(coords, conf["coordinates"]),
@@ -88,7 +88,7 @@ class TestConfiguration(unittest.TestCase):
     def test_dunder_setitem_valid(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         gradients = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coords)
+        conf = AbsoluteConfiguration(coords)
 
         conf["gradients"] = gradients
         self.assertTrue(
@@ -97,7 +97,7 @@ class TestConfiguration(unittest.TestCase):
 
     def test_dunder_setitem_invalid_shape(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coords)
+        conf = AbsoluteConfiguration(coords)
 
         with self.assertRaises(ValueError):
             conf["velocities"] = np.random.uniform(0, 1, (self._nAtoms + 1, 3))
@@ -107,7 +107,7 @@ class TestConfiguration(unittest.TestCase):
     def test_properties(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         vels = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coords, velocities=vels)
+        conf = AbsoluteConfiguration(coords, velocities=vels)
 
         self.assertTrue(
             np.allclose(coords, conf.coordinates), f"\nactual = {conf.coordinates}"
@@ -124,7 +124,7 @@ class TestConfiguration(unittest.TestCase):
 
 
 class TestPeriodicConfiguration(unittest.TestCase):
-    """Uses PeriodicBoxConfiguration to test the methods of its abstract base class, _PeriodicConfiguration."""
+    """Uses PeriodicFractionalConfiguration to test the methods of its abstract base class, _PeriodicConfiguration."""
 
     def setUp(self):
         self.chem_system = ChemicalSystem()
@@ -140,7 +140,7 @@ class TestPeriodicConfiguration(unittest.TestCase):
 
         self.coords = np.random.uniform(0, 1, (self._nAtoms, 3))
         self.unit_cell = UnitCell(np.random.uniform(0, 1, (3, 3)))
-        self.conf = PeriodicBoxConfiguration(
+        self.conf = PeriodicFractionalConfiguration(
             self.coords, self.unit_cell
         )
 
@@ -164,7 +164,7 @@ class TestPeriodicConfiguration(unittest.TestCase):
         self.assertEqual(unit_cell_new, self.conf.unit_cell)
 
 
-class TestPeriodicBoxConfiguration(unittest.TestCase):
+class TestPeriodicFractionalConfiguration(unittest.TestCase):
     def setUp(self):
         self.chem_system = ChemicalSystem()
         self._nAtoms = 4
@@ -189,7 +189,7 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicBoxConfiguration(coords, unit_cell)
+        conf = PeriodicFractionalConfiguration(coords, unit_cell)
 
         self.assertTrue(
             np.allclose(
@@ -205,24 +205,24 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
             f'actual = {conf["coordinates"]}',
         )
 
-    def test_to_box_coordinates(self):
+    def test_to_fractional_coordinates(self):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
         coords = np.array(([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]))
-        conf = PeriodicBoxConfiguration(coords, unit_cell)
+        conf = PeriodicFractionalConfiguration(coords, unit_cell)
 
         self.assertTrue(
-            np.allclose(coords, conf.to_box_coordinates()),
-            f"\nactual = {conf.to_box_coordinates()}",
+            np.allclose(coords, conf.to_fractional_coordinates()),
+            f"\nactual = {conf.to_fractional_coordinates()}",
         )
 
-    def test_to_real_coordinates(self):
+    def test_to_absolute_coordinates(self):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
         coords = np.array(([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]))
-        conf = PeriodicBoxConfiguration(coords, unit_cell)
+        conf = PeriodicFractionalConfiguration(coords, unit_cell)
 
         self.assertTrue(
             np.allclose(
@@ -232,20 +232,20 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
                     [50.0, 15.0, 24.0],
                     [68.0, 21.0, 33.0],
                 ],
-                conf.to_real_coordinates(),
+                conf.to_absolute_coordinates(),
             ),
-            f"\nactual = {conf.to_real_coordinates()}",
+            f"\nactual = {conf.to_absolute_coordinates()}",
         )
 
-    def test_to_real_configuration(self):
+    def test_to_absolute_configuration(self):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
         coords = np.array(([1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]))
-        conf = PeriodicBoxConfiguration(coords, unit_cell)
-        real = conf.to_real_configuration()
+        conf = PeriodicFractionalConfiguration(coords, unit_cell)
+        real = conf.to_absolute_configuration()
 
-        self.assertTrue(isinstance(real, PeriodicRealConfiguration))
+        self.assertTrue(isinstance(real, PeriodicAbsoluteConfiguration))
         self.assertEqual(["coordinates"], list(real._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -264,10 +264,10 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
     def test_contiguous_configuration(self):
         unit_cell = UnitCell(np.array([[2, 1, 0], [-3, 2, 0], [2, 1, -4]]))
         coords = [[0.1, 0.1, 0.1], [0.3, 0.2, 0.4], [-1.3, -1.1, -1.3], [1.9, 1.5, 1.9]]
-        conf = PeriodicBoxConfiguration(coords, unit_cell)
+        conf = PeriodicFractionalConfiguration(coords, unit_cell)
         contiguous_conf = conf.contiguous_configuration(group_cluster_indices(self.chem_system))
 
-        self.assertTrue(isinstance(contiguous_conf, PeriodicBoxConfiguration))
+        self.assertTrue(isinstance(contiguous_conf, PeriodicFractionalConfiguration))
         self.assertEqual(["coordinates"], list(contiguous_conf._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -283,7 +283,7 @@ class TestPeriodicBoxConfiguration(unittest.TestCase):
         )
 
 
-class TestPeriodicRealConfiguration(unittest.TestCase):
+class TestPeriodicAbsoluteConfiguration(unittest.TestCase):
     def setUp(self):
         self.chem_system = ChemicalSystem()
         self._nAtoms = 4
@@ -306,7 +306,7 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
             ]
         )
         unit_cell = UnitCell(np.array([[2, 1, 0], [-3, 2, 0], [2, 1, -4]]))
-        conf = PeriodicRealConfiguration(coords, unit_cell)
+        conf = PeriodicAbsoluteConfiguration(coords, unit_cell)
         conf.fold_coordinates()
 
         self.assertTrue(
@@ -323,7 +323,7 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
             f'actual = {conf["coordinates"]}',
         )
 
-    def test_to_box_coordinates(self):
+    def test_to_fractional_coordinates(self):
         coords = np.array(
             [
                 [14.0, 3.0, 6.0],
@@ -335,15 +335,15 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicRealConfiguration(coords, unit_cell)
+        conf = PeriodicAbsoluteConfiguration(coords, unit_cell)
 
-        box = conf.to_box_coordinates()
+        box = conf.to_fractional_coordinates()
         self.assertTrue(
             np.allclose([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], box),
             f"\nactual = {box}",
         )
 
-    def test_to_box_configuration(self):
+    def test_to_fractional_configuration(self):
         coords = np.array(
             [
                 [14.0, 3.0, 6.0],
@@ -355,10 +355,10 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicRealConfiguration(coords, unit_cell)
+        conf = PeriodicAbsoluteConfiguration(coords, unit_cell)
 
-        box_conf = conf.to_box_configuration()
-        self.assertTrue(isinstance(box_conf, PeriodicBoxConfiguration))
+        box_conf = conf.to_fractional_configuration()
+        self.assertTrue(isinstance(box_conf, PeriodicFractionalConfiguration))
         self.assertEqual(["coordinates"], list(box_conf._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -368,7 +368,7 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         )
         self.assertEqual(unit_cell, box_conf._unit_cell)
 
-    def test_to_real_coordinates(self):
+    def test_to_absolute_coordinates(self):
         coords = np.array(
             [
                 [14.0, 3.0, 6.0],
@@ -380,9 +380,9 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicRealConfiguration(coords, unit_cell)
+        conf = PeriodicAbsoluteConfiguration(coords, unit_cell)
 
-        real = conf.to_real_coordinates()
+        real = conf.to_absolute_coordinates()
         self.assertTrue(np.allclose(coords, real), f"\nactual = {real}")
 
     def test_contiguous_configuration(self):
@@ -397,10 +397,10 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicRealConfiguration(coords, unit_cell)
+        conf = PeriodicAbsoluteConfiguration(coords, unit_cell)
 
         result = conf.contiguous_configuration(group_cluster_indices(self.chem_system))
-        self.assertTrue(isinstance(result, PeriodicRealConfiguration))
+        self.assertTrue(isinstance(result, PeriodicAbsoluteConfiguration))
         self.assertEqual(["coordinates"], list(result._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -434,7 +434,7 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
                 [-1.8123033523559569, -0.3780877590179443, -0.5149454593658447],
             ]
         )
-        conf = PeriodicRealConfiguration(coords.copy(), unit_cell)
+        conf = PeriodicAbsoluteConfiguration(coords.copy(), unit_cell)
         result = conf.contiguous_configuration(group_cluster_indices(self.chem_system))
         new_coords = result.coordinates
         assert np.allclose(coords, new_coords)
@@ -451,10 +451,10 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         unit_cell = UnitCell(
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
-        conf = PeriodicRealConfiguration(coords, unit_cell)
+        conf = PeriodicAbsoluteConfiguration(coords, unit_cell)
 
         result = conf.continuous_configuration([])
-        self.assertTrue(isinstance(result, PeriodicRealConfiguration))
+        self.assertTrue(isinstance(result, PeriodicAbsoluteConfiguration))
         self.assertEqual(["coordinates"], list(result._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -483,10 +483,10 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
             np.array([[1.0, 2.0, 1.0], [2.0, -1.0, 1.0], [3.0, 1.0, 1.0]])
         )
         self.chem_system.add_bonds([(0, 1), (2, 3)])
-        conf = PeriodicRealConfiguration(coords, unit_cell)
+        conf = PeriodicAbsoluteConfiguration(coords, unit_cell)
 
         result = conf.continuous_configuration(self.chem_system._bonds)
-        self.assertTrue(isinstance(result, PeriodicRealConfiguration))
+        self.assertTrue(isinstance(result, PeriodicAbsoluteConfiguration))
         self.assertEqual(["coordinates"], list(result._variables.keys()))
         self.assertTrue(
             np.allclose(
@@ -503,7 +503,7 @@ class TestPeriodicRealConfiguration(unittest.TestCase):
         self.assertEqual(unit_cell, result._unit_cell)
 
 
-class TestRealConfiguration(unittest.TestCase):
+class TestAbsoluteConfiguration(unittest.TestCase):
     def setUp(self):
         self.chem_system = ChemicalSystem()
         self._nAtoms = 4
@@ -518,10 +518,10 @@ class TestRealConfiguration(unittest.TestCase):
 
     def test_clone_valid_no_input(self):
         coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coordinates)
+        conf = AbsoluteConfiguration(coordinates)
         clone = conf.clone()
 
-        self.assertTrue(isinstance(clone, RealConfiguration))
+        self.assertTrue(isinstance(clone, AbsoluteConfiguration))
         self.assertEqual(["coordinates"], list(clone._variables.keys()))
         self.assertTrue(
             np.allclose(coordinates, clone["coordinates"]),
@@ -530,10 +530,10 @@ class TestRealConfiguration(unittest.TestCase):
 
     def test_clone_valid_chemical_system_provided(self):
         coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coordinates)
+        conf = AbsoluteConfiguration(coordinates)
         clone = conf.clone()
 
-        self.assertTrue(isinstance(clone, RealConfiguration))
+        self.assertTrue(isinstance(clone, AbsoluteConfiguration))
         self.assertEqual(["coordinates"], list(clone._variables.keys()))
         self.assertTrue(
             np.allclose(coordinates, clone["coordinates"]),
@@ -542,7 +542,7 @@ class TestRealConfiguration(unittest.TestCase):
 
     def test_fold_coordinates(self):
         coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coordinates)
+        conf = AbsoluteConfiguration(coordinates)
         conf.fold_coordinates()
 
         self.assertTrue(
@@ -550,21 +550,21 @@ class TestRealConfiguration(unittest.TestCase):
             f'\nactual = {conf["coordinates"]}',
         )
 
-    def test_to_real_coordinates(self):
+    def test_to_absolute_coordinates(self):
         coordinates = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coordinates)
-        real = conf.to_real_coordinates()
+        conf = AbsoluteConfiguration(coordinates)
+        real = conf.to_absolute_coordinates()
 
         self.assertTrue(np.allclose(coordinates, real), f"\nactual = {real}")
 
     def test_contiguous_configuration(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coords)
+        conf = AbsoluteConfiguration(coords)
 
         self.assertEqual(conf, conf.contiguous_configuration())
 
     def test_continuous_configuration(self):
         coords = np.random.uniform(0, 1, (self._nAtoms, 3))
-        conf = RealConfiguration(coords)
+        conf = AbsoluteConfiguration(coords)
 
         self.assertEqual(conf, conf.continuous_configuration())

--- a/MDANSE/Tests/UnitTests/test_trajectory.py
+++ b/MDANSE/Tests/UnitTests/test_trajectory.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 import numpy as np
 from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
-from MDANSE.MolecularDynamics.Configuration import PeriodicRealConfiguration
+from MDANSE.MolecularDynamics.Configuration import PeriodicAbsoluteConfiguration
 from MDANSE.MolecularDynamics.Trajectory import Trajectory, TrajectoryWriter
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
@@ -41,7 +41,7 @@ class TestTrajectory(unittest.TestCase):
             allTimes.append(i)
             allUnitCells.append(np.random.uniform(0, 10, (3, 3)))
             allCoordinates.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
-            conf = PeriodicRealConfiguration(
+            conf = PeriodicAbsoluteConfiguration(
                 allCoordinates[-1], UnitCell(allUnitCells[-1])
             )
             tw.dump_configuration(conf, i)
@@ -74,7 +74,7 @@ class TestTrajectory(unittest.TestCase):
             allUnitCells.append(np.random.uniform(0, 10, (3, 3)))
             allCoordinates.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
             allVelocities.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
-            conf = PeriodicRealConfiguration(
+            conf = PeriodicAbsoluteConfiguration(
                 allCoordinates[-1], UnitCell(allUnitCells[-1])
             )
             conf.variables["velocities"] = allVelocities[-1]
@@ -113,7 +113,7 @@ class TestTrajectory(unittest.TestCase):
             allCoordinates.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
             allVelocities.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
             allGradients.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
-            conf = PeriodicRealConfiguration(
+            conf = PeriodicAbsoluteConfiguration(
                 allCoordinates[-1], UnitCell(allUnitCells[-1])
             )
             conf.variables["velocities"] = allVelocities[-1]

--- a/MDANSE/Tests/UnitTests/test_trajectory.py
+++ b/MDANSE/Tests/UnitTests/test_trajectory.py
@@ -42,7 +42,7 @@ class TestTrajectory(unittest.TestCase):
             allUnitCells.append(np.random.uniform(0, 10, (3, 3)))
             allCoordinates.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
             conf = PeriodicRealConfiguration(
-                self._chemical_system, allCoordinates[-1], UnitCell(allUnitCells[-1])
+                allCoordinates[-1], UnitCell(allUnitCells[-1])
             )
             tw.dump_configuration(conf, i)
 
@@ -75,7 +75,7 @@ class TestTrajectory(unittest.TestCase):
             allCoordinates.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
             allVelocities.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
             conf = PeriodicRealConfiguration(
-                self._chemical_system, allCoordinates[-1], UnitCell(allUnitCells[-1])
+                allCoordinates[-1], UnitCell(allUnitCells[-1])
             )
             conf.variables["velocities"] = allVelocities[-1]
             tw.dump_configuration(conf, i)
@@ -114,7 +114,7 @@ class TestTrajectory(unittest.TestCase):
             allVelocities.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
             allGradients.append(np.random.uniform(0, 10, (self._nAtoms, 3)))
             conf = PeriodicRealConfiguration(
-                self._chemical_system, allCoordinates[-1], UnitCell(allUnitCells[-1])
+                allCoordinates[-1], UnitCell(allUnitCells[-1])
             )
             conf.variables["velocities"] = allVelocities[-1]
             conf.variables["gradients"] = allGradients[-1]

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
@@ -27,6 +27,7 @@ from qtpy.QtWidgets import (
     QLabel,
     QSpinBox,
     QVBoxLayout,
+    QWidget,
 )
 
 from MDANSE.Framework.Configurators.HDFTrajectoryConfigurator import (
@@ -56,6 +57,8 @@ class HDFTrajectoryWidget(WidgetBase):
             self._layout.addWidget(label)
             trajectory_path, _ = os.path.split(filename)
             self.default_path = PurePath(trajectory_path)
+        visibility_switch = QCheckBox("Show advanced settings")
+        self._layout.addWidget(visibility_switch)
         self.build_fields(
             init_guess=guess_hdf5_trajectory_parameters(self._configurator["value"])
         )
@@ -65,6 +68,10 @@ class HDFTrajectoryWidget(WidgetBase):
         )
         hdf5_info_text.setWordWrap(True)
         self._layout.addWidget(hdf5_info_text)
+        visibility_switch.stateChanged.connect(self.extra_bar.setVisible)
+        visibility_switch.stateChanged.connect(hdf5_info_text.setVisible)
+        self.extra_bar.setVisible(False)
+        hdf5_info_text.setVisible(False)
         self.default_labels()
         self.update_labels()
         if self._tooltip:
@@ -75,7 +82,9 @@ class HDFTrajectoryWidget(WidgetBase):
         self._label = label
 
     def build_fields(self, init_guess: tuple[int, int] = (None, None)):
+        bar_widget = QWidget()
         bar_layout = QHBoxLayout()
+        bar_widget.setLayout(bar_layout)
         self._extra_widgets = {}
         combobox_inputs = [
             ("HDF5 driver", "default"),
@@ -125,7 +134,8 @@ class HDFTrajectoryWidget(WidgetBase):
             sublayout.addWidget(widget)
             bar_layout.addLayout(sublayout)
             self._extra_widgets[label.split()[0]] = widget
-        self._layout.addLayout(bar_layout)
+        self._layout.addWidget(bar_widget)
+        self.extra_bar = bar_widget
 
     def configure_using_default(self):
         """This is too static to have a default value"""

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
@@ -56,7 +56,9 @@ class HDFTrajectoryWidget(WidgetBase):
             self._layout.addWidget(label)
             trajectory_path, _ = os.path.split(filename)
             self.default_path = PurePath(trajectory_path)
-        self.build_fields()
+        self.build_fields(
+            init_guess=guess_hdf5_trajectory_parameters(self._configurator["value"])
+        )
         hdf5_info_text = QLabel(
             "Check https://docs.h5py.org/en/stable/high/file.html#chunk-cache for parameter details.\n"
             "Uncheck the boxes to use the default values (old behaviour)."
@@ -72,14 +74,30 @@ class HDFTrajectoryWidget(WidgetBase):
         label.setToolTip(tooltip_text)
         self._label = label
 
-    def build_fields(self):
+    def build_fields(self, init_guess: tuple[int, int] = (None, None)):
         bar_layout = QHBoxLayout()
+        self._extra_widgets = {}
         combobox_inputs = [
-            ("HDF5 driver", "None"),
+            ("HDF5 driver", "default"),
         ]
+        init_nbytes, init_nslots = init_guess
         spinbox_inputs = [
-            ("rdcc_nbytes (MB)", -1, QSpinBox, 8, 4096, 4),
-            ("rdcc_nslots", -1, QSpinBox, 8191, 2147483647, 1000),
+            (
+                "rdcc_nbytes (MB)",
+                8 if init_nbytes is None else int(init_nbytes / 1024**2),
+                QSpinBox,
+                8,
+                4096,
+                4,
+            ),
+            (
+                "rdcc_nslots",
+                init_nslots if init_nslots is not None else 8191,
+                QSpinBox,
+                8191,
+                2147483647,
+                1000,
+            ),
             ("rdcc_w0", 1.0, QDoubleSpinBox, 0, 1.0, 0.05),
         ]
         for label, init_value in combobox_inputs:
@@ -91,6 +109,7 @@ class HDFTrajectoryWidget(WidgetBase):
             widget.setCurrentText(init_value)
             sublayout.addWidget(widget)
             bar_layout.addLayout(sublayout)
+            self._driver_widget = widget
         for label, init_value, widget_type, minval, maxval, step in spinbox_inputs:
             sublayout = QVBoxLayout()
             sublayout.addWidget(QLabel(label))
@@ -105,6 +124,7 @@ class HDFTrajectoryWidget(WidgetBase):
             checkbox.stateChanged.connect(widget.setEnabled)
             sublayout.addWidget(widget)
             bar_layout.addLayout(sublayout)
+            self._extra_widgets[label.split()[0]] = widget
         self._layout.addLayout(bar_layout)
 
     def configure_using_default(self):
@@ -131,4 +151,15 @@ class HDFTrajectoryWidget(WidgetBase):
             self._label.setToolTip(self._configurator.warning_status)
         else:
             self._label.setToolTip(self._tooltip)
-        return result
+        hdf5_driver = self._driver_widget.currentText()
+        hdf5_driver = None if hdf5_driver == "default" else hdf5_driver
+        rdcc = {}
+        for name, widget in self._extra_widgets.items():
+            rdcc[name] = widget.value() if widget.isEnabled() else None
+        return (
+            result,
+            hdf5_driver,
+            rdcc["rdcc_nbytes"] * 1024**2 if rdcc["rdcc_nbytes"] is not None else None,
+            rdcc["rdcc_nslots"],
+            rdcc["rdcc_w0"],
+        )

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
@@ -162,12 +162,11 @@ class HDFTrajectoryWidget(WidgetBase):
         else:
             self._label.setToolTip(self._tooltip)
         hdf5_driver = self._driver_widget.currentText()
-        hdf5_driver = None if hdf5_driver == "default" else hdf5_driver
         rdcc = {}
         for name, widget in self._extra_widgets.items():
             rdcc[name] = widget.value() if widget.isEnabled() else None
         return (
-            result,
+            str(result),
             hdf5_driver,
             rdcc["rdcc_nbytes"] * 1024**2 if rdcc["rdcc_nbytes"] is not None else None,
             rdcc["rdcc_nslots"],

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/HDFTrajectoryWidget.py
@@ -19,15 +19,28 @@ import html
 import os
 from pathlib import PurePath
 
-from qtpy.QtWidgets import QLabel
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QHBoxLayout,
+    QLabel,
+    QSpinBox,
+    QVBoxLayout,
+)
 
+from MDANSE.Framework.Configurators.HDFTrajectoryConfigurator import (
+    HDF5_DRIVERS,
+    PRIMES,
+    guess_hdf5_trajectory_parameters,
+)
 from MDANSE.MolecularDynamics.Trajectory import Trajectory
 from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
 
 
 class HDFTrajectoryWidget(WidgetBase):
     def __init__(self, *args, trajectory_instance: Trajectory | None = None, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, layout_type="QVBoxLayout", **kwargs)
         filename = kwargs.get("source_object")
         if trajectory_instance:
             self._configurator._instance = trajectory_instance
@@ -43,6 +56,13 @@ class HDFTrajectoryWidget(WidgetBase):
             self._layout.addWidget(label)
             trajectory_path, _ = os.path.split(filename)
             self.default_path = PurePath(trajectory_path)
+        self.build_fields()
+        hdf5_info_text = QLabel(
+            "Check https://docs.h5py.org/en/stable/high/file.html#chunk-cache for parameter details.\n"
+            "Uncheck the boxes to use the default values (old behaviour)."
+        )
+        hdf5_info_text.setWordWrap(True)
+        self._layout.addWidget(hdf5_info_text)
         self.default_labels()
         self.update_labels()
         if self._tooltip:
@@ -51,6 +71,41 @@ class HDFTrajectoryWidget(WidgetBase):
             tooltip_text = "A single logical value that can be True of False"
         label.setToolTip(tooltip_text)
         self._label = label
+
+    def build_fields(self):
+        bar_layout = QHBoxLayout()
+        combobox_inputs = [
+            ("HDF5 driver", "None"),
+        ]
+        spinbox_inputs = [
+            ("rdcc_nbytes (MB)", -1, QSpinBox, 8, 4096, 4),
+            ("rdcc_nslots", -1, QSpinBox, 8191, 2147483647, 1000),
+            ("rdcc_w0", 1.0, QDoubleSpinBox, 0, 1.0, 0.05),
+        ]
+        for label, init_value in combobox_inputs:
+            sublayout = QVBoxLayout()
+            sublayout.addWidget(QLabel(label))
+            widget = QComboBox()
+            widget.addItems(HDF5_DRIVERS)
+            widget.addItem(init_value)
+            widget.setCurrentText(init_value)
+            sublayout.addWidget(widget)
+            bar_layout.addLayout(sublayout)
+        for label, init_value, widget_type, minval, maxval, step in spinbox_inputs:
+            sublayout = QVBoxLayout()
+            sublayout.addWidget(QLabel(label))
+            checkbox = QCheckBox("Set value manually")
+            sublayout.addWidget(checkbox)
+            checkbox.setChecked(True)
+            widget = widget_type()
+            widget.setValue(init_value)
+            widget.setMinimum(minval)
+            widget.setMaximum(maxval)
+            widget.setSingleStep(step)
+            checkbox.stateChanged.connect(widget.setEnabled)
+            sublayout.addWidget(widget)
+            bar_layout.addLayout(sublayout)
+        self._layout.addLayout(bar_layout)
 
     def configure_using_default(self):
         """This is too static to have a default value"""

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MoleculeWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/MoleculeWidget.py
@@ -53,8 +53,8 @@ class MoleculeWidget(WidgetBase):
         self.atom_database = trajectory
         self.mol_dict = {}
         for mol_name in unique_molecules:
-            no_of_molecules = len(trajectory.chemical_system._clusters[mol_name])
-            atom_indices = trajectory.chemical_system._clusters[mol_name][0]
+            no_of_molecules = len(trajectory.chemical_system.clusters[mol_name])
+            atom_indices = trajectory.chemical_system.clusters[mol_name][0]
             atom_symbols = [
                 trajectory.chemical_system.atom_list[index] for index in atom_indices
             ]

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
@@ -69,8 +69,9 @@ class OutputTrajectoryWidget(WidgetBase):
         self.chunk_atom_box = QSpinBox(self._base)
         self.chunk_frame_box = QSpinBox(self._base)
         for typ, chunk_box in zip(
-           ("atoms", "frames"),
-           (self.chunk_atom_box, self.chunk_frame_box)
+            ("atoms", "frames"),
+            (self.chunk_atom_box, self.chunk_frame_box),
+            strict=True,
         ):
             chunk_box.setMinimum(1)
             chunk_box.setMaximum(0xFFFF)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
@@ -66,15 +66,17 @@ class OutputTrajectoryWidget(WidgetBase):
         self.dtype_box = QComboBox(self._base)
         self.dtype_box.addItems(["float16", "float32", "float64"])
         self.dtype_box.setCurrentText("float64")
-        self.chunk_box = QSpinBox(self._base)
-        self.chunk_box.setMinimum(1)
-        self.chunk_box.setMaximum(0xFFFF)
-        self.chunk_box.setValue(128)
-        self.chunk_box.setSingleStep(32)
-        self.chunk_box.setToolTip(
-            "Specifies the size of a single chunk in the HDF5 file."
-            "Affects the performance of reading and writing the trajectory."
-        )
+        self.chunk_atom_box = QSpinBox(self._base)
+        self.chunk_frame_box = QSpinBox(self._base)
+        for index, chunk_box in enumerate((self.chunk_atom_box, self.chunk_frame_box)):
+            chunk_box.setMinimum(1)
+            chunk_box.setMaximum(0xFFFF)
+            chunk_box.setValue(1 if index else 128)
+            chunk_box.setSingleStep(1 if index else 32)
+            chunk_box.setToolTip(
+                f"Specifies the number of {'frames' if index else 'atoms'} in a single chunk of the HDF5 file."
+                "Affects the performance of reading and writing the trajectory."
+            )
         self.compression_box = QComboBox(self._base)
         self.compression_box.addItems(["none", "gzip"])
         self.compression_box.setCurrentText("gzip")
@@ -86,7 +88,13 @@ class OutputTrajectoryWidget(WidgetBase):
         label2 = QLabel("Atoms per chunk")
         label2.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         label2.setToolTip(
-            "Specifies the size of a single chunk in the HDF5 file."
+            "Specifies the number of atoms in a single chunk of the HDF5 file."
+            "Affects the performance of reading and writing the trajectory."
+        )
+        label3 = QLabel("Frames per chunk")
+        label3.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        label3.setToolTip(
+            "Specifies the number of frames in a single chunk of the HDF5 file."
             "Affects the performance of reading and writing the trajectory."
         )
         self.logs_combo = QComboBox(self._base)
@@ -98,7 +106,9 @@ class OutputTrajectoryWidget(WidgetBase):
         self._layout.addWidget(label, 1, 0)
         self._layout.addWidget(self.logs_combo, 1, 1)
         self._layout.addWidget(label2, 1, 2)
-        self._layout.addWidget(self.chunk_box, 1, 3)
+        self._layout.addWidget(self.chunk_atom_box, 1, 3)
+        self._layout.addWidget(label3, 2, 2)
+        self._layout.addWidget(self.chunk_frame_box, 2, 3)
         self._default_value = default_value
         self._field.textChanged.connect(self.updateValue)
         self.default_labels()
@@ -152,7 +162,7 @@ class OutputTrajectoryWidget(WidgetBase):
         if len(filename) < 1:
             filename = self._default_value[0]
         dtype = dtype_lookup[self.dtype_box.currentText()]
-        chunk_size = self.chunk_box.value()
+        chunk_size = (self.chunk_frame_box.value(), self.chunk_atom_box.value())
         compression = self.compression_box.currentText()
         logs = self.logs_combo.currentText()
         return (filename, dtype, chunk_size, compression, logs)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
@@ -68,13 +68,16 @@ class OutputTrajectoryWidget(WidgetBase):
         self.dtype_box.setCurrentText("float64")
         self.chunk_atom_box = QSpinBox(self._base)
         self.chunk_frame_box = QSpinBox(self._base)
-        for index, chunk_box in enumerate((self.chunk_atom_box, self.chunk_frame_box)):
+        for typ, chunk_box in zip(
+           ("atoms", "frames"),
+           (self.chunk_atom_box, self.chunk_frame_box)
+        ):
             chunk_box.setMinimum(1)
             chunk_box.setMaximum(0xFFFF)
-            chunk_box.setValue(1 if index else 128)
-            chunk_box.setSingleStep(1 if index else 32)
+            chunk_box.setValue(1 if typ == "frames" else 128)
+            chunk_box.setSingleStep(1 if typ == "frames" else 32)
             chunk_box.setToolTip(
-                f"Specifies the number of {'frames' if index else 'atoms'} in a single chunk of the HDF5 file."
+                f"Specifies the number of {typ} in a single chunk of the HDF5 file."
                 "Affects the performance of reading and writing the trajectory."
             )
         self.compression_box = QComboBox(self._base)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/OutputTrajectoryWidget.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import NamedTuple
 
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import (
@@ -35,6 +36,36 @@ from MDANSE.MLogging import LOG
 from MDANSE_GUI.InputWidgets.WidgetBase import WidgetBase
 
 dtype_lookup = {"float16": 16, "float32": 32, "float64": 64}
+
+
+class SpinBoxDefaults(NamedTuple):
+    minimum: int = 1
+    maximum: int = 0xFFFFFF
+    step: int = 1
+    start_value: int = 1
+    tooltip: str = "Input spin box"
+
+
+SPIN_BOX_SETTINGS = {
+    "frames": SpinBoxDefaults(
+        tooltip="Specifies the number of frames in a single chunk of the HDF5 file. "
+        "Affects the performance of reading and writing the trajectory."
+    ),
+    "atoms": SpinBoxDefaults(
+        step=32,
+        start_value=128,
+        tooltip="Specifies the number of atoms in a single chunk of the HDF5 file. "
+        "Affects the performance of reading and writing the trajectory.",
+    ),
+    "meta_block": SpinBoxDefaults(
+        minimum=0,
+        maximum=0x80000,
+        step=2048,
+        start_value=4096,
+        tooltip="Size of a single metadata block in the HDF5 file. "
+        "Larger values (e.g. 32768) may work better on cloud-based virtual machines (Ada, VISA, etc.).",
+    ),
+}
 
 
 class OutputTrajectoryWidget(WidgetBase):
@@ -68,19 +99,18 @@ class OutputTrajectoryWidget(WidgetBase):
         self.dtype_box.setCurrentText("float64")
         self.chunk_atom_box = QSpinBox(self._base)
         self.chunk_frame_box = QSpinBox(self._base)
+        self.meta_block_box = QSpinBox(self._base)
         for typ, chunk_box in zip(
-            ("atoms", "frames"),
-            (self.chunk_atom_box, self.chunk_frame_box),
+            ("atoms", "frames", "meta_block"),
+            (self.chunk_atom_box, self.chunk_frame_box, self.meta_block_box),
             strict=True,
         ):
-            chunk_box.setMinimum(1)
-            chunk_box.setMaximum(0xFFFF)
-            chunk_box.setValue(1 if typ == "frames" else 128)
-            chunk_box.setSingleStep(1 if typ == "frames" else 32)
-            chunk_box.setToolTip(
-                f"Specifies the number of {typ} in a single chunk of the HDF5 file."
-                "Affects the performance of reading and writing the trajectory."
-            )
+            settings = SPIN_BOX_SETTINGS[typ]
+            chunk_box.setMinimum(settings.minimum)
+            chunk_box.setMaximum(settings.maximum)
+            chunk_box.setValue(settings.start_value)
+            chunk_box.setSingleStep(settings.step)
+            chunk_box.setToolTip(settings.tooltip)
         self.compression_box = QComboBox(self._base)
         self.compression_box.addItems(["none", "gzip"])
         self.compression_box.setCurrentText("gzip")
@@ -91,28 +121,27 @@ class OutputTrajectoryWidget(WidgetBase):
         label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         label2 = QLabel("Atoms per chunk")
         label2.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        label2.setToolTip(
-            "Specifies the number of atoms in a single chunk of the HDF5 file."
-            "Affects the performance of reading and writing the trajectory."
-        )
+        label2.setToolTip(SPIN_BOX_SETTINGS["atoms"].tooltip)
         label3 = QLabel("Frames per chunk")
         label3.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        label3.setToolTip(
-            "Specifies the number of frames in a single chunk of the HDF5 file."
-            "Affects the performance of reading and writing the trajectory."
-        )
+        label3.setToolTip(SPIN_BOX_SETTINGS["frames"].tooltip)
+        label4 = QLabel("HDF5 meta_block_size")
+        label4.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        label4.setToolTip(SPIN_BOX_SETTINGS["meta_block"].tooltip)
         self.logs_combo = QComboBox(self._base)
         self.logs_combo.addItems(OutputTrajectoryConfigurator.log_options)
         self._layout.addWidget(self._field, 0, 0)
         self._layout.addWidget(self.dtype_box, 0, 1)
         self._layout.addWidget(self.compression_box, 0, 2)
         self._layout.addWidget(browse_button, 0, 3)
-        self._layout.addWidget(label, 1, 0)
-        self._layout.addWidget(self.logs_combo, 1, 1)
-        self._layout.addWidget(label2, 1, 2)
-        self._layout.addWidget(self.chunk_atom_box, 1, 3)
-        self._layout.addWidget(label3, 2, 2)
-        self._layout.addWidget(self.chunk_frame_box, 2, 3)
+        self._layout.addWidget(label2, 1, 0)
+        self._layout.addWidget(self.chunk_atom_box, 1, 1)
+        self._layout.addWidget(label3, 1, 2)
+        self._layout.addWidget(self.chunk_frame_box, 1, 3)
+        self._layout.addWidget(label4, 2, 0)
+        self._layout.addWidget(self.meta_block_box, 2, 1)
+        self._layout.addWidget(label, 2, 2)
+        self._layout.addWidget(self.logs_combo, 2, 3)
         self._default_value = default_value
         self._field.textChanged.connect(self.updateValue)
         self.default_labels()
@@ -169,4 +198,5 @@ class OutputTrajectoryWidget(WidgetBase):
         chunk_size = (self.chunk_frame_box.value(), self.chunk_atom_box.value())
         compression = self.compression_box.currentText()
         logs = self.logs_combo.currentText()
-        return (filename, dtype, chunk_size, compression, logs)
+        meta_block_size = self.meta_block_box.value()
+        return (filename, dtype, chunk_size, compression, logs, meta_block_size)

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/WidgetBase.py
@@ -120,7 +120,7 @@ class WidgetBase(QObject):
             self._base.setTitle(self._label_text)
 
         for widget in self._layout.children():
-            if issubclass(widget, QWidget):
+            if isinstance(widget, QWidget):
                 widget.setToolTip(self._tooltip)
 
     def default_labels(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/MolecularViewer.py
@@ -382,7 +382,7 @@ class MolecularViewer(QtWidgets.QWidget):
             case AtomLabelType.ATOM:
                 labels = self._atoms
             case AtomLabelType.MOLECULE if (
-                label_dict := self._reader._trajectory.chemical_system._clusters
+                label_dict := self._reader._trajectory.chemical_system.clusters
             ):
                 label_dict = {
                     k: list(more_itertools.collapse(v)) for k, v in label_dict.items()

--- a/MDANSE_GUI/Tests/UnitTests/test_hdf5wrapper.py
+++ b/MDANSE_GUI/Tests/UnitTests/test_hdf5wrapper.py
@@ -46,7 +46,6 @@ def sample_configuration(chemical_system):
     coords[2] = [10.0, 1.0, 5.11]
     coords[3] = [10.0, 2.0, 5.09]
     temp = RealConfiguration(
-        chemical_system,
         coords,
         # unit_cell
     )

--- a/MDANSE_GUI/Tests/UnitTests/test_hdf5wrapper.py
+++ b/MDANSE_GUI/Tests/UnitTests/test_hdf5wrapper.py
@@ -20,7 +20,7 @@ import os
 import numpy as np
 
 from MDANSE.Chemistry.ChemicalSystem import ChemicalSystem
-from MDANSE.MolecularDynamics.Configuration import RealConfiguration
+from MDANSE.MolecularDynamics.Configuration import AbsoluteConfiguration
 from MDANSE.MolecularDynamics.Trajectory import Trajectory, TrajectoryWriter
 
 from MDANSE_GUI.MolecularViewer.readers.hdf5wrapper import HDF5Wrapper
@@ -45,7 +45,7 @@ def sample_configuration(chemical_system):
     coords[1] = [1.0, 2.0, 1.0]
     coords[2] = [10.0, 1.0, 5.11]
     coords[3] = [10.0, 2.0, 5.09]
-    temp = RealConfiguration(
+    temp = AbsoluteConfiguration(
         coords,
         # unit_cell
     )


### PR DESCRIPTION
**Description of work**
As mentioned in #1162, on certain platforms (especially using cloud storage) it may be necessary to use different chunking scheme, HDF5 drivers or HDF5 cache size. This PR is meant to let the users control the HDF5 parameters so we can try out different parameter combinations easily.

**Fixes**
1. Added "frames per chunk" to the "atoms per chunk" in the trajectory output.
2. Added HDF5 cache parameters to the trajectory input widget.
3. Suppressed `ChemicalSystem` creation in subprocesses.
4. Removed `ChemicalSystem` from `Configuration` classes.

**To test**
All tests must pass.
Manual testing of CLI and GUI is recommended.
