### PR TITLE
Initialise empty dicts in PropertyWidget

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
@@ -69,7 +69,10 @@ class PropertyWidget(QWidget):
         self.active = False
         self.viewer.frame_changed.connect(self.update_table)
         self._atom_props = {}
+        self._raw_props = {}
+        self._frame_props = {}
         self._trajectory_props = {}
+        self.curr_selection = {}
 
     @Slot(int)
     def _active(self, index: int):


### PR DESCRIPTION
**Description of work**
It is possible to trigger an error message using the following steps:
1. Start MDANSE_GUI,
2. Load a trajectory (but don't open it),
3. Delete the trajectory.
This does not create any problems, but it can be prevented by making sure that several dictionaries in `PropertyWidget` exist before their `.clear()` method is called.

**Fixes**
Create empty `dict`s in `PropertyWidget.__init__`.

**To test**
Start the GUI, load a trajectory and delete it. There should be no error message (as opposed to the main branch.

