### PR TITLE
Chunk-aware analysis

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Converters/VASP.py
+++ b/MDANSE/Src/MDANSE/Framework/Converters/VASP.py
@@ -143,11 +143,11 @@ class VASP(Converter):
 
         conf = PeriodicFractionalConfiguration(coords, unitCell)
 
-        # The coordinates in VASP are in box format. Convert them into real coordinates.
+        # The coordinates in VASP are in fractional format. Convert them into absolute coordinates.
         real_conf = conf.to_absolute_configuration()
 
         if self.configuration["fold"]["value"]:
-            # The real coordinates are folded then into the simulation box (-L/2,L/2).
+            # The absolute coordinates are folded then into the simulation box (-L/2,L/2).
             real_conf.fold_coordinates()
 
         # Compute the actual time

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
@@ -93,7 +93,10 @@ class AverageStructure(IJob):
         super().initialize()
 
         self.grouped_indices = group_atom_indices(
-            self.trajectory, n_proc=1, memory_scale_factor=2
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=1,
+            memory_scale_factor=2,
         )
         self.numberOfSteps = len(self.grouped_indices)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
@@ -22,6 +22,7 @@ import numpy as np
 from MDANSE import PLATFORM
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Units import measure
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 try:
     from ase.atoms import Atom, Atoms
@@ -91,7 +92,10 @@ class AverageStructure(IJob):
         """
         super().initialize()
 
-        self.numberOfSteps = self.trajectory.get_total_natoms()
+        self.grouped_indices = group_atom_indices(
+            self.trajectory, n_proc=1, memory_scale_factor=2
+        )
+        self.numberOfSteps = len(self.grouped_indices)
 
         self._atoms = self.trajectory.atom_names
 
@@ -131,11 +135,10 @@ class AverageStructure(IJob):
         Returns:
             tuple: the result of the step
         """
-
+        atom_index_group = self.grouped_indices[index]
         # get selected atom indices sublist
-        atom_index = self.trajectory.atom_indices[index]
-        series = self.trajectory.read_atomic_trajectory(
-            atom_index,
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=self.configuration["frames"]["first"],
             last=self.configuration["frames"]["last"] + 1,
             step=self.configuration["frames"]["step"],
@@ -143,16 +146,18 @@ class AverageStructure(IJob):
 
         return index, np.mean(series, axis=0) * self._conversion_factor
 
-    def combine(self, index, x):
+    def combine(self, step_index, x):
         # The symbol of the atom.
-        element = self._atoms[self.trajectory.atom_indices[index]]
+        atom_index_group = self.grouped_indices[step_index]
+        for arr_index, at_index in enumerate(atom_index_group):
+            element = self._atoms[self.trajectory.atom_indices[at_index]]
 
-        try:
-            the_atom = Atom(element, x)
-        except KeyError:
-            the_atom = Atom(str(element).strip("0123456789"), x)
+            try:
+                the_atom = Atom(element, x[arr_index])
+            except KeyError:
+                the_atom = Atom(str(element).strip("0123456789"), x[arr_index])
 
-        self._ase_atoms.append(the_atom)
+            self._ase_atoms.append(the_atom)
 
     def finalize(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/AverageStructure.py
@@ -150,7 +150,7 @@ class AverageStructure(IJob):
         # The symbol of the atom.
         atom_index_group = self.grouped_indices[step_index]
         for arr_index, at_index in enumerate(atom_index_group):
-            element = self._atoms[self.trajectory.atom_indices[at_index]]
+            element = self._atoms[at_index]
 
             try:
                 the_atom = Atom(element, x[arr_index])

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CartesianCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CartesianCorrelationFunction.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import abc
 import itertools as it
 
+import numpy as np
+from scipy import fft
 from scipy.signal import correlate
 
 from MDANSE.Framework.AtomGrouping.grouping import (
@@ -25,6 +27,8 @@ from MDANSE.Framework.AtomGrouping.grouping import (
 )
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
+from MDANSE.MolecularDynamics.Analysis import scipy_correlate_2D
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 
 class CartesianCorrelationFunction(IJob):
@@ -92,11 +96,18 @@ class CartesianCorrelationFunction(IJob):
         """
         super().initialize()
 
-        self.numberOfSteps = len(self.trajectory.atom_indices)
+        n_proc = self.configuration["running_mode"].get("slots", 1)
+
+        self.grouped_indices = group_atom_indices(
+            self.trajectory, n_proc=n_proc, memory_scale_factor=8
+        )
+        self.numberOfSteps = len(self.grouped_indices)
 
         self.labels = [
             (element, (element,)) for element in self.trajectory.get_natoms()
         ]
+
+        self.n_frames = self.configuration["frames"]["n_frames"]
 
         selected_weights, all_weights = self.trajectory.get_weights(
             prop=self.configuration["weights"]["property"]
@@ -148,17 +159,21 @@ class CartesianCorrelationFunction(IJob):
     def run_step(self, index):
         series = self.get_series(index)
 
-        u_x = series[:, 0]
-        u_y = series[:, 1]
-        u_z = series[:, 2]
+        u_x = series[:, :, 0]
+        u_y = series[:, :, 1]
+        u_z = series[:, :, 2]
 
         n_configs = self.configuration["frames"]["n_configs"]
         cfs = []
         for u_i, u_j in it.combinations_with_replacement([u_x, u_y, u_z], 2):
-            cfs.append(correlate(u_i, u_j[:n_configs], mode="valid").T / n_configs)
+            fast_len = fft.next_fast_len(len(u_i))
+            v = fft.fft(u_i, n=fast_len, axis=0)
+            w = fft.fft(u_j[:n_configs], n=fast_len, axis=0)
+            single_corr = fft.ifft(v * w.conj(), axis=0)[: self.n_frames] / n_configs
+            cfs.append(single_corr.real)
         return index, cfs
 
-    def combine(self, index, cfs):
+    def combine(self, step_index, cfs):
         """
         Combines returned results of run_step.\n
         :Parameters:
@@ -166,15 +181,22 @@ class CartesianCorrelationFunction(IJob):
             #. x (any): The returned result(s) of run_step
         """
         # The symbol of the atom.
-        element = self.trajectory.atom_names[self.trajectory.atom_indices[index]]
-
+        atom_index_group = self.grouped_indices[step_index]
         isotropic = (cfs[0] + cfs[3] + cfs[5]) / 3
-        self._outputData[f"{self.CF_NAME}/isotropic/{element}"] += isotropic
+        # The symbol of the atom.
+        for arr_index, at_index in enumerate(atom_index_group):
+            element = self.trajectory.atom_names[self.trajectory.atom_indices[at_index]]
 
-        for i, (j, k) in enumerate(
-            it.combinations_with_replacement(["x", "y", "z"], 2)
-        ):
-            self._outputData[f"{self.CF_NAME}/{j}{k}/{element}"] += cfs[i]
+            self._outputData[f"{self.CF_NAME}/isotropic/{element}"] += isotropic[
+                :, arr_index
+            ]
+
+            for i, (j, k) in enumerate(
+                it.combinations_with_replacement(["x", "y", "z"], 2)
+            ):
+                self._outputData[f"{self.CF_NAME}/{j}{k}/{element}"] += cfs[i][
+                    :, arr_index
+                ]
 
     def weight_and_group(self):
         nAtomsPerElement = self.trajectory.get_natoms()

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CartesianCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CartesianCorrelationFunction.py
@@ -99,7 +99,10 @@ class CartesianCorrelationFunction(IJob):
         n_proc = self.configuration["running_mode"].get("slots", 1)
 
         self.grouped_indices = group_atom_indices(
-            self.trajectory, n_proc=n_proc, memory_scale_factor=8
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=8,
         )
         self.numberOfSteps = len(self.grouped_indices)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CartesianCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CartesianCorrelationFunction.py
@@ -185,7 +185,7 @@ class CartesianCorrelationFunction(IJob):
         isotropic = (cfs[0] + cfs[3] + cfs[5]) / 3
         # The symbol of the atom.
         for arr_index, at_index in enumerate(atom_index_group):
-            element = self.trajectory.atom_names[self.trajectory.atom_indices[at_index]]
+            element = self.trajectory.atom_names[at_index]
 
             self._outputData[f"{self.CF_NAME}/isotropic/{element}"] += isotropic[
                 :, arr_index

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CartesianCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CartesianCorrelationFunction.py
@@ -18,16 +18,13 @@ from __future__ import annotations
 import abc
 import itertools as it
 
-import numpy as np
 from scipy import fft
-from scipy.signal import correlate
 
 from MDANSE.Framework.AtomGrouping.grouping import (
     add_grouped_totals,
 )
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
-from MDANSE.MolecularDynamics.Analysis import scipy_correlate_2D
 from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
@@ -33,7 +33,6 @@ from MDANSE.Mathematics.Signal import (
     get_spectrum,
 )
 from MDANSE.MLogging import LOG
-from MDANSE.MolecularDynamics.Analysis import mean_square_displacement_many
 from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 from MDANSE.util_types import ComplexArray

--- a/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CurrentCorrelationFunction.py
@@ -29,10 +29,12 @@ from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.QVectors.IQVectors import IQVectors
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
 from MDANSE.Mathematics.Signal import (
-    differentiate,
+    differentiate_many,
     get_spectrum,
 )
 from MDANSE.MLogging import LOG
+from MDANSE.MolecularDynamics.Analysis import mean_square_displacement_many
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 from MDANSE.MolecularDynamics.UnitCell import UnitCell
 from MDANSE.util_types import ComplexArray
 
@@ -127,6 +129,8 @@ class CurrentCorrelationFunction(IJob):
     def initialize(self):
         """Initialize the input parameters and analysis self variables."""
         super().initialize()
+
+        self.n_proc = self.configuration["running_mode"].get("slots", 1)
 
         self.numberOfSteps = self.configuration["q_vectors"]["n_shells"]
 
@@ -417,10 +421,20 @@ class CurrentCorrelationFunction(IJob):
                 dtype=np.complex64,
             )
 
+        grouped_indices = group_atom_indices(
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=self.n_proc,
+            memory_scale_factor=4 * nQVectors,
+        )
+
         for element, idxs in list(self._indicesPerElement.items()):
-            for idx in idxs:
-                coords = trajectory.read_atomic_trajectory(
-                    idx,
+            for ind_group in grouped_indices:
+                overlap_indices = sorted(set(idxs).intersection(ind_group))
+                if not overlap_indices:
+                    continue
+                coords = trajectory.read_atomic_trajectory_many(
+                    overlap_indices,
                     first=self.configuration["frames"]["first"],
                     last=self.configuration["frames"]["last"] + 1,
                     step=self.configuration["frames"]["step"],
@@ -428,25 +442,23 @@ class CurrentCorrelationFunction(IJob):
 
                 if self.configuration["interpolation_order"]["value"] == 0:
                     veloc = trajectory.read_configuration_trajectory(
-                        idx,
+                        overlap_indices,
                         first=self.configuration["frames"]["first"],
                         last=self.configuration["frames"]["last"] + 1,
                         step=self.configuration["frames"]["step"],
                         variable="velocities",
                     )
                 else:
-                    veloc = np.zeros_like(coords)
-                    for axis in range(3):
-                        veloc[:, axis] = differentiate(
-                            coords[:, axis],
-                            order=self.configuration["interpolation_order"]["value"],
-                            dt=self.configuration["frames"]["time_step"],
-                        )
+                    veloc = differentiate_many(
+                        coords,
+                        order=self.configuration["interpolation_order"]["value"],
+                        dt=self.configuration["frames"]["time_step"],
+                    )
 
                 if qVectors.ndim > 2:
-                    temp_dotprod = np.einsum("ij,jki->ik", coords, qVectors)
+                    temp_dotprod = np.einsum("imj,jki->imk", coords, qVectors)
                     curr = np.einsum(
-                        "ik,ij,j->ikj",
+                        "imk,imj,j->ikj",
                         veloc,
                         np.exp(1j * temp_dotprod),
                         qvec_weights_sqrt,
@@ -460,7 +472,7 @@ class CurrentCorrelationFunction(IJob):
                     trans = curr - long
                 else:
                     curr = np.einsum(
-                        "ik,ij,j->ikj",
+                        "imk,imj,j->ikj",
                         veloc,
                         np.exp(1j * np.dot(coords, qVectors)),
                         qvec_weights_sqrt,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicCoherentStructureFactor.py
@@ -245,6 +245,7 @@ class DynamicCoherentStructureFactor(IJob):
                     axis=0,
                 ),
             )
+        self.unique_names = self.trajectory.unique_names
 
     def run_step(self, index: int) -> tuple[int, dict[str, FloatArray] | None]:
         """Run the analysis for a single Q shell.
@@ -278,7 +279,7 @@ class DynamicCoherentStructureFactor(IJob):
         ]
 
         rho = {}
-        for element in self.trajectory.unique_names:
+        for element in self.unique_names:
             rho[element] = np.zeros(
                 (self.configuration["frames"]["number"], nQVectors),
                 dtype=np.complex64,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -111,7 +111,10 @@ class ElasticIncoherentStructureFactor(IJob):
         n_proc = self.configuration["running_mode"].get("slots", 1)
 
         self.grouped_indices = group_atom_indices(
-            self.trajectory, n_proc=n_proc, memory_scale_factor=self._nQShells
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=self._nQShells,
         )
         self.numberOfSteps = len(self.grouped_indices)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -22,6 +22,7 @@ from MDANSE.Framework.AtomGrouping.grouping import (
 )
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 
 @IJob.register("ElasticIncoherentStructureFactor")
@@ -103,11 +104,16 @@ class ElasticIncoherentStructureFactor(IJob):
         """
         super().initialize()
 
-        self.numberOfSteps = len(self.trajectory.atom_indices)
-
         self._nQShells = self.configuration["q_vectors"]["n_shells"]
 
         self._nFrames = self.configuration["frames"]["number"]
+
+        n_proc = self.configuration["running_mode"].get("slots", 1)
+
+        self.grouped_indices = group_atom_indices(
+            self.trajectory, n_proc=n_proc, memory_scale_factor=self._nQShells
+        )
+        self.numberOfSteps = len(self.grouped_indices)
 
         self.labels = [
             (element, (element,)) for element in self.trajectory.get_natoms()
@@ -154,10 +160,11 @@ class ElasticIncoherentStructureFactor(IJob):
         """
 
         # get atom index
-        atom_index = self.trajectory.atom_indices[index]
+        atom_index_group = self.grouped_indices[index]
+        n_atoms = len(atom_index_group)
 
-        series = self.trajectory.read_atomic_trajectory(
-            atom_index,
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=self.configuration["frames"]["first"],
             last=self.configuration["frames"]["last"] + 1,
             step=self.configuration["frames"]["step"],
@@ -165,24 +172,29 @@ class ElasticIncoherentStructureFactor(IJob):
 
         series = self.configuration["projection"]["projector"](series)
 
-        atomicEISF = np.zeros((self._nQShells,), dtype=np.float64)
+        atomicEISF = np.zeros((self._nQShells, n_atoms), dtype=np.float64)
 
         for i, q in enumerate(self.configuration["q_vectors"]["shells"]):
             if self.configuration["q_vectors"]["value"][q] is None:
-                atomicEISF[i] = np.nan
+                atomicEISF[i, :] = np.nan
                 continue
 
             qVectors = self.configuration["q_vectors"]["value"][q]["q_vectors"]
             qvec_weights = self.configuration["q_vectors"]["value"][q]["weights"]
 
-            a = np.average(np.exp(1j * np.dot(series, qVectors)), axis=0)
+            a = np.average(
+                np.swapaxes(
+                    np.exp(1j * np.dot(qVectors.T, np.swapaxes(series, 1, 2))), 0, 1
+                ),
+                axis=0,
+            )
             a = np.abs(a) ** 2
 
-            atomicEISF[i] = np.average(a, weights=qvec_weights)
+            atomicEISF[i, :] = np.average(a, axis=0, weights=qvec_weights)
 
         return index, atomicEISF
 
-    def combine(self, index, x):
+    def combine(self, step_index, x):
         """
         Combines returned results of run_step.\n
         :Parameters:
@@ -190,10 +202,12 @@ class ElasticIncoherentStructureFactor(IJob):
             #. x (any): The returned result(s) of run_step
         """
 
+        atom_index_group = self.grouped_indices[step_index]
         # The symbol of the atom.
-        element = self._atoms[self.trajectory.atom_indices[index]]
+        for arr_index, at_index in enumerate(atom_index_group):
+            element = self._atoms[self.trajectory.atom_indices[at_index]]
 
-        self._outputData[f"eisf/{element}"] += x
+            self._outputData[f"eisf/{element}"] += x[:, arr_index]
 
     def finalize(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -205,7 +205,7 @@ class ElasticIncoherentStructureFactor(IJob):
         atom_index_group = self.grouped_indices[step_index]
         # The symbol of the atom.
         for arr_index, at_index in enumerate(atom_index_group):
-            element = self._atoms[self.trajectory.atom_indices[at_index]]
+            element = self._atoms[at_index]
 
             self._outputData[f"eisf/{element}"] += x[:, arr_index]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -23,8 +23,9 @@ from MDANSE.Framework.AtomGrouping.grouping import (
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
 from MDANSE.Mathematics.Signal import get_spectrum
-from MDANSE.MolecularDynamics.Analysis import mean_square_displacement
 from MDANSE.util_types import FloatArray
+from MDANSE.MolecularDynamics.Analysis import mean_square_displacement_many
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 
 @IJob.register("GaussianDynamicIncoherentStructureFactor")
@@ -108,9 +109,14 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         """
         super().initialize()
 
-        self.numberOfSteps = len(self.trajectory.atom_indices)
-
         self._nQShells = self.configuration["q_shells"]["number"]
+
+        n_proc = self.configuration["running_mode"].get("slots", 1)
+
+        self.grouped_indices = group_atom_indices(
+            self.trajectory, n_proc=n_proc, memory_scale_factor=self._nQShells
+        )
+        self.numberOfSteps = len(self.grouped_indices)
 
         self._nFrames = self.configuration["frames"]["n_frames"]
 
@@ -247,11 +253,11 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
             GDISF and MSD of an atom.
         """
 
-        # get atom index
-        atom_index = self.trajectory.atom_indices[index]
+        atom_index_group = self.grouped_indices[index]
+        n_atoms = len(atom_index_group)
 
-        series = self.trajectory.read_atomic_trajectory(
-            atom_index,
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=self.configuration["frames"]["first"],
             last=self.configuration["frames"]["last"] + 1,
             step=self.configuration["frames"]["step"],
@@ -259,19 +265,19 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
 
         series = self.configuration["projection"]["projector"](series)
 
-        atomicSF = np.zeros((self._nQShells, self._nFrames), dtype=np.float64)
+        atomicSF = np.zeros((self._nQShells, self._nFrames, n_atoms), dtype=np.float64)
 
-        msd = mean_square_displacement(
+        msd = mean_square_displacement_many(
             series, self.configuration["frames"]["n_configs"]
-        )
+        )[: self._nFrames]
 
         for i, q2 in enumerate(self._kSquare):
             gaussian = np.exp(-msd * q2 / 6.0)
-            atomicSF[i, :] += gaussian
+            atomicSF[i, :, :] += gaussian
 
         return index, (atomicSF, msd)
 
-    def combine(self, index: int, x: tuple[FloatArray, FloatArray]):
+    def combine(self, step_index: int, x: tuple[FloatArray, FloatArray]):
         """Add the results to the output files.
 
         Parameters
@@ -281,10 +287,13 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         x : tuple[FloatArray, FloatArray]
             A tuple of the GDISF and MSD of an atom.
         """
-        element = self._atoms[self.trajectory.atom_indices[index]]
-        atomicSF, msd = x
-        self._outputData[f"gdisf/f(q,t)/{element}"] += atomicSF
-        self._outputData[f"msd/{element}"] += msd
+        atom_index_group = self.grouped_indices[step_index]
+        # The symbol of the atom.
+        for arr_index, at_index in enumerate(atom_index_group):
+            element = self._atoms[self.trajectory.atom_indices[at_index]]
+            atomicSF, msd = x
+            self._outputData[f"gdisf/f(q,t)/{element}"] += atomicSF[:, :, arr_index]
+            self._outputData[f"msd/{element}"] += msd[:, arr_index]
 
     def finalize(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -23,9 +23,9 @@ from MDANSE.Framework.AtomGrouping.grouping import (
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
 from MDANSE.Mathematics.Signal import get_spectrum
-from MDANSE.util_types import FloatArray
 from MDANSE.MolecularDynamics.Analysis import mean_square_displacement_many
 from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
+from MDANSE.util_types import FloatArray
 
 
 @IJob.register("GaussianDynamicIncoherentStructureFactor")

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -290,7 +290,7 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         atom_index_group = self.grouped_indices[step_index]
         # The symbol of the atom.
         for arr_index, at_index in enumerate(atom_index_group):
-            element = self._atoms[self.trajectory.atom_indices[at_index]]
+            element = self._atoms[at_index]
             atomicSF, msd = x
             self._outputData[f"gdisf/f(q,t)/{element}"] += atomicSF[:, :, arr_index]
             self._outputData[f"msd/{element}"] += msd[:, arr_index]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -114,7 +114,10 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         n_proc = self.configuration["running_mode"].get("slots", 1)
 
         self.grouped_indices = group_atom_indices(
-            self.trajectory, n_proc=n_proc, memory_scale_factor=self._nQShells
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=self._nQShells,
         )
         self.numberOfSteps = len(self.grouped_indices)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
-from more_itertools import consumer, first_true
+from more_itertools import consumer
 
 from MDANSE import PLATFORM
 from MDANSE.Core.RegisterFactory import RegisterFactory

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -15,12 +15,14 @@
 #
 from __future__ import annotations
 
+import numpy as np
+
 from MDANSE.Framework.AtomGrouping.grouping import (
     add_grouped_totals,
 )
 from MDANSE.Framework.Jobs.IJob import IJob
-from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
-from MDANSE.MolecularDynamics.Analysis import mean_square_displacement
+from MDANSE.MolecularDynamics.Analysis import mean_square_displacement_many
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 
 @IJob.register("MeanSquareDisplacement")
@@ -100,7 +102,13 @@ class MeanSquareDisplacement(IJob):
         """
         super().initialize()
 
-        self.numberOfSteps = len(self.trajectory.atom_indices)
+        n_proc = self.configuration["running_mode"].get("slots", 1)
+
+        self.grouped_indices = group_atom_indices(
+            self.trajectory, n_proc=n_proc, memory_scale_factor=4
+        )
+        self.numberOfSteps = len(self.grouped_indices)
+        self.n_frames = self.configuration["frames"]["n_frames"]
 
         self.labels = [
             (element, (element,)) for element in self.trajectory.get_natoms()
@@ -148,9 +156,10 @@ class MeanSquareDisplacement(IJob):
         """
 
         # get selected atom indices sublist
-        atom_index = self.trajectory.atom_indices[index]
-        series = self.configuration["trajectory"]["instance"].read_atomic_trajectory(
-            atom_index,
+        atom_index_group = self.grouped_indices[index]
+
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=self.configuration["frames"]["first"],
             last=self.configuration["frames"]["last"] + 1,
             step=self.configuration["frames"]["step"],
@@ -158,25 +167,26 @@ class MeanSquareDisplacement(IJob):
 
         series = self.configuration["projection"]["projector"](series)
 
-        msd = mean_square_displacement(
+        msd = mean_square_displacement_many(
             series, self.configuration["frames"]["n_configs"]
         )
 
-        return index, msd
+        return index, msd[: self.n_frames]
 
-    def combine(self, index, result):
+    def combine(self, step_index, result):
         """
         Combines returned results of run_step.
 
         Args:
             result (tuple): the output of run_step method
         """
-
+        atom_index_group = self.grouped_indices[step_index]
         # The symbol of the atom.
-        element = self._atoms[self.trajectory.atom_indices[index]]
+        for arr_index, at_index in enumerate(atom_index_group):
+            element = self._atoms[self.trajectory.atom_indices[at_index]]
 
-        self._outputData[f"msd/{element}"] += result
-        self._outputData["msd/total"] += result
+            self._outputData[f"msd/{element}"] += result[:, arr_index]
+        self._outputData["msd/total"] += np.sum(result, axis=1)
 
     def finalize(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -183,7 +183,7 @@ class MeanSquareDisplacement(IJob):
         atom_index_group = self.grouped_indices[step_index]
         # The symbol of the atom.
         for arr_index, at_index in enumerate(atom_index_group):
-            element = self._atoms[self.trajectory.atom_indices[at_index]]
+            element = self._atoms[at_index]
 
             self._outputData[f"msd/{element}"] += result[:, arr_index]
         self._outputData["msd/total"] += np.sum(result, axis=1)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -105,7 +105,10 @@ class MeanSquareDisplacement(IJob):
         n_proc = self.configuration["running_mode"].get("slots", 1)
 
         self.grouped_indices = group_atom_indices(
-            self.trajectory, n_proc=n_proc, memory_scale_factor=4
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=4,
         )
         self.numberOfSteps = len(self.grouped_indices)
         self.n_frames = self.configuration["frames"]["n_frames"]

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionCorrelationFunction.py
@@ -39,14 +39,15 @@ class PositionCorrelationFunction(CartesianCorrelationFunction):
     MAIN_RESULTS = "pcf/isotropic/"
 
     def get_series(self, index):
-        atom_index = self.trajectory.atom_indices[index]
+        atom_index_group = self.grouped_indices[index]
 
-        series = self.trajectory.read_atomic_trajectory(
-            atom_index,
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=self.configuration["frames"]["first"],
             last=self.configuration["frames"]["last"] + 1,
             step=self.configuration["frames"]["step"],
         )
+
         series = series - np.average(series, axis=0)
         series = self.configuration["projection"]["projector"](series)
         return series

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
@@ -85,7 +85,10 @@ class RootMeanSquareDeviation(IJob):
         n_proc = self.configuration["running_mode"].get("slots", 1)
 
         self.grouped_indices = group_atom_indices(
-            self.trajectory, n_proc=n_proc, memory_scale_factor=2
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=2,
         )
         self.numberOfSteps = len(self.grouped_indices)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
@@ -152,7 +152,7 @@ class RootMeanSquareDeviation(IJob):
         """
         atom_index_group = self.grouped_indices[step_index]
         for arr_index, at_index in enumerate(atom_index_group):
-            element = self._atoms[self.trajectory.atom_indices[at_index]]
+            element = self._atoms[at_index]
 
             self._outputData[f"rmsd/{element}"] += x[:, arr_index]
         self._outputData["rmsd/total"] += np.sum(x, axis=1)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareDeviation.py
@@ -21,6 +21,7 @@ from MDANSE.Framework.AtomGrouping.grouping import (
     add_grouped_totals,
 )
 from MDANSE.Framework.Jobs.IJob import IJob
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 
 @IJob.register("RootMeanSquareDeviation")
@@ -81,7 +82,12 @@ class RootMeanSquareDeviation(IJob):
     def initialize(self):
         super().initialize()
 
-        self.numberOfSteps = len(self.trajectory.atom_indices)
+        n_proc = self.configuration["running_mode"].get("slots", 1)
+
+        self.grouped_indices = group_atom_indices(
+            self.trajectory, n_proc=n_proc, memory_scale_factor=2
+        )
+        self.numberOfSteps = len(self.grouped_indices)
 
         self._referenceIndex = self.configuration["reference_frame"]["value"]
 
@@ -123,32 +129,33 @@ class RootMeanSquareDeviation(IJob):
         @type index: int.
         """
 
-        atom_index = self.trajectory.atom_indices[index]
+        atom_index_group = self.grouped_indices[index]
 
-        series = self.trajectory.read_atomic_trajectory(
-            atom_index,
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=self.configuration["frames"]["first"],
             last=self.configuration["frames"]["last"] + 1,
             step=self.configuration["frames"]["step"],
         )
 
         # Compute the squared sum of the difference between all the coordinate of atoms i and the reference ones
-        squaredDiff = np.sum((series - series[self._referenceIndex, :]) ** 2, axis=1)
+        squaredDiff = np.sum((series - series[self._referenceIndex, :, :]) ** 2, axis=2)
 
         return index, squaredDiff
 
-    def combine(self, index, x):
+    def combine(self, step_index, x):
         """
         Combines returned results of run_step.\n
         :Parameters:
             #. index (int): The index of the step.\n
             #. x (any): The returned result(s) of run_step
         """
+        atom_index_group = self.grouped_indices[step_index]
+        for arr_index, at_index in enumerate(atom_index_group):
+            element = self._atoms[self.trajectory.atom_indices[at_index]]
 
-        element = self._atoms[self.trajectory.atom_indices[index]]
-
-        self._outputData[f"rmsd/{element}"] += x
-        self._outputData["rmsd/total"] += x
+            self._outputData[f"rmsd/{element}"] += x[:, arr_index]
+        self._outputData["rmsd/total"] += np.sum(x, axis=1)
 
     def finalize(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -73,7 +73,10 @@ class RootMeanSquareFluctuation(IJob):
         n_proc = self.configuration["running_mode"].get("slots", 1)
 
         self.grouped_indices = group_atom_indices(
-            self.trajectory, n_proc=n_proc, memory_scale_factor=2
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=2,
         )
         self.numberOfSteps = len(self.grouped_indices)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -91,7 +91,7 @@ class RootMeanSquareFluctuation(IJob):
         self._outputData.add(
             "rmsf/all",
             "LineOutputVariable",
-            (self.numberOfSteps,),
+            (len(self.trajectory.atom_indices),),
             axis="rmsf/axes/indices/all",
             units="nm",
             main_result=True,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -19,6 +19,7 @@ from itertools import groupby
 
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.MolecularDynamics.Analysis import mean_square_fluctuation
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 
 @IJob.register("RootMeanSquareFluctuation")
@@ -68,7 +69,13 @@ class RootMeanSquareFluctuation(IJob):
     def initialize(self):
         """Initialize the input parameters and analysis self variables"""
         super().initialize()
-        self.numberOfSteps = len(self.trajectory.atom_indices)
+
+        n_proc = self.configuration["running_mode"].get("slots", 1)
+
+        self.grouped_indices = group_atom_indices(
+            self.trajectory, n_proc=n_proc, memory_scale_factor=2
+        )
+        self.numberOfSteps = len(self.grouped_indices)
 
         self.group_molecules = self.configuration["grouping_level"]["value"] != "atom"
         self.ele_idxs = {}
@@ -150,17 +157,18 @@ class RootMeanSquareFluctuation(IJob):
             The atom index and the calculated root mean square
             fluctuation for that atom.
         """
-        atom_index = self.trajectory.atom_indices[index]
-        series = self.trajectory.read_atomic_trajectory(
-            atom_index,
+        atom_index_group = self.grouped_indices[index]
+
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=self.configuration["frames"]["first"],
             last=self.configuration["frames"]["last"] + 1,
             step=self.configuration["frames"]["step"],
         )
-        rmsf = mean_square_fluctuation(series, root=True)
+        rmsf = mean_square_fluctuation(series, root=True, sum_axis=2)
         return index, rmsf
 
-    def combine(self, index, x):
+    def combine(self, step_index, x):
         """Combines returned results of run_step.
 
         Parameters
@@ -170,10 +178,13 @@ class RootMeanSquareFluctuation(IJob):
         x : float
             The RMSF results for the atom.
         """
-        self._outputData["rmsf/all"][index] = x
-        name = self._names[index]
-        self._outputData[f"rmsf/{name}"][self.ele_idxs[name]] = x
-        self.ele_idxs[name] += 1
+        atom_index_group = self.grouped_indices[step_index]
+        # The symbol of the atom.
+        for arr_index, at_index in enumerate(atom_index_group):
+            self._outputData["rmsf/all"][at_index] = x[arr_index]
+            name = self._names[at_index]
+            self._outputData[f"rmsf/{name}"][self.ele_idxs[name]] = x[arr_index]
+            self.ele_idxs[name] += 1
 
     def finalize(self):
         """Finalizes the calculations (e.g. averaging the total term, output

--- a/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/RootMeanSquareFluctuation.py
@@ -15,8 +15,6 @@
 #
 from __future__ import annotations
 
-from itertools import groupby
-
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.MolecularDynamics.Analysis import mean_square_fluctuation
 from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -80,7 +80,10 @@ class Temperature(IJob):
         n_proc = self.configuration["running_mode"].get("slots", 1)
 
         self.grouped_indices = group_atom_indices(
-            self.trajectory, n_proc=n_proc, memory_scale_factor=2
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=2,
         )
         self.numberOfSteps = len(self.grouped_indices)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/Temperature.py
@@ -19,7 +19,8 @@ import numpy as np
 
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Framework.Units import measure
-from MDANSE.Mathematics.Signal import differentiate
+from MDANSE.Mathematics.Signal import differentiate_many
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 KB = measure(1.380649e-23, "kg m2/s2 K").toval("Da nm2/ps2 K")
 
@@ -69,13 +70,19 @@ class Temperature(IJob):
         """
         super().initialize()
 
-        self.indices = [
-            index
-            for index, symbol in enumerate(self.trajectory.atom_types)
-            if symbol in self.trajectory.non_dummy_elements
-        ]
+        self.trajectory.set_selection(
+            [
+                index
+                for index, symbol in enumerate(self.trajectory.atom_types)
+                if symbol in self.trajectory.non_dummy_elements
+            ]
+        )
+        n_proc = self.configuration["running_mode"].get("slots", 1)
 
-        self.numberOfSteps = len(self.indices)
+        self.grouped_indices = group_atom_indices(
+            self.trajectory, n_proc=n_proc, memory_scale_factor=2
+        )
+        self.numberOfSteps = len(self.grouped_indices)
 
         self._nFrames = self.configuration["frames"]["number"]
 
@@ -127,39 +134,43 @@ class Temperature(IJob):
             #. index (int): The index of the step.
             #. kineticEnergy (np.array): The calculated kinetic energy
         """
+        atom_index_group = self.grouped_indices[index]
 
-        real_index = self.indices[index]
-        symbol = self._atoms[real_index]
-
-        mass = self.trajectory.get_atom_property(symbol, "atomic_weight")
+        mass = np.array(
+            [
+                self.trajectory.get_atom_property(
+                    self._atoms[at_index], "atomic_weight"
+                )
+                for at_index in atom_index_group
+            ]
+        )
 
         trajectory = self.trajectory
 
         if self.configuration["interpolation_order"]["value"] == 0:
             series = trajectory.read_configuration_trajectory(
-                real_index,
+                atom_index_group,
                 first=self.configuration["frames"]["first"],
                 last=self.configuration["frames"]["last"] + 1,
                 step=self.configuration["frames"]["step"],
                 variable="velocities",
             )
         else:
-            series = trajectory.read_atomic_trajectory(
-                real_index,
+            series = trajectory.read_atomic_trajectory_many(
+                atom_index_group,
                 first=self.configuration["frames"]["first"],
                 last=self.configuration["frames"]["last"] + 1,
                 step=self.configuration["frames"]["step"],
             )
 
             order = self.configuration["interpolation_order"]["value"]
-            for axis in range(3):
-                series[:, axis] = differentiate(
-                    series[:, axis],
-                    order=order,
-                    dt=self.configuration["frames"]["time_step"],
-                )
+            series = differentiate_many(
+                series,
+                order=order,
+                dt=self.configuration["frames"]["time_step"],
+            )
 
-        kineticEnergy = 0.5 * mass * np.sum(series**2, 1)
+        kineticEnergy = 0.5 * mass[None, :] * np.sum(series**2, axis=2)
 
         return index, kineticEnergy
 
@@ -171,14 +182,14 @@ class Temperature(IJob):
             #. x (any): The returned result(s) of run_step
         """
 
-        self._outputData["temp/kinetic_energy"] += x
+        self._outputData["temp/kinetic_energy"] += np.sum(x, axis=1)
 
     def finalize(self):
         """
         Finalizes the calculations (e.g. averaging the total term, output files creations ...).
         """
 
-        nAtoms = len(self.indices)
+        nAtoms = len(self.trajectory.atom_indices)
         self._outputData["temp/kinetic_energy"] /= nAtoms - 1
 
         norm = np.arange(1, self._outputData["temp/kinetic_energy"].shape[0] + 1)

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -26,7 +26,6 @@ from MDANSE.Framework.Formats.HDFFormat import write_metadata
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.MolecularDynamics.Connectivity import Connectivity
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
-from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 
 @IJob.register("TrajectoryEditor")

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryFilter.py
@@ -15,7 +15,6 @@
 #
 from __future__ import annotations
 
-import copy
 import json
 
 import h5py
@@ -29,7 +28,6 @@ from MDANSE.Chemistry.ChemicalSystem import (
 from MDANSE.Framework.Formats.HDFFormat import write_metadata
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Signal import FILTER_MAP, Filter
-from MDANSE.MLogging import LOG
 from MDANSE.MolecularDynamics.Trajectory import TrajectoryWriter
 from MDANSE.util_types import FloatArray
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionDistinct.py
@@ -19,7 +19,6 @@ import itertools as it
 from collections.abc import Iterator
 
 import numpy as np
-import numpy.typing as npt
 from more_itertools import always_iterable
 
 from MDANSE.Chemistry import ChemicalSystem

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VanHoveFunctionSelf.py
@@ -26,6 +26,7 @@ from MDANSE.Framework.Jobs.VanHoveFunctionDistinct import (
     DETAILED_CELL_MESSAGE,
 )
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 from MDANSE.util_types import FloatArray
 
 
@@ -47,7 +48,7 @@ def van_hove_self(
     Parameters
     ----------
     xyz : FloatArray
-        The trajectory of an atom.
+        The trajectories of multiple atoms.
     histograms : FloatArray
         The histograms to be updated.
     cell_vols : FloatArray
@@ -63,16 +64,20 @@ def van_hove_self(
 
     """
     nbins = histograms.shape[0]
+    n_atoms = histograms.shape[2]
 
     for i in range(n_configs):
         x0 = xyz[i]
-        r_array = xyz[i : i + n_frames] - x0.reshape((1, 3))
-        distance_array = np.sqrt((r_array**2).sum(axis=1))
+        r_array = xyz[i : i + n_frames] - x0.reshape((1, n_atoms, 3))
+        distance_array = np.sqrt((r_array**2).sum(axis=2))
         bins = ((distance_array - rmin) / dr).astype(int)
-        valid_bins = np.logical_and(bins >= 0, bins < nbins)
-        for j in range(n_frames):
-            if valid_bins[j]:
-                histograms[bins[j], j] += cell_vols[i + j]
+        valid_bins = np.logical_and(
+            bins >= 0, bins < nbins
+        )  # atom_index, corr_distance, frame_index
+        for at_ind in range(n_atoms):
+            for j in range(n_frames):
+                if valid_bins[j, at_ind]:
+                    histograms[bins[j, at_ind], j, at_ind] += cell_vols[i + j]
     return histograms
 
 
@@ -153,8 +158,15 @@ class VanHoveFunctionSelf(IJob):
     def initialize(self):
         """Initialize the input parameters and analysis self variables."""
         super().initialize()
+        n_proc = self.configuration["running_mode"].get("slots", 1)
 
-        self.numberOfSteps = len(self.trajectory.atom_indices)
+        self.grouped_indices = group_atom_indices(
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=4,
+        )
+        self.numberOfSteps = len(self.grouped_indices)
         self.n_configs = self.configuration["frames"]["n_configs"]
         self.n_frames = self.configuration["frames"]["n_frames"]
         self._atoms = self.trajectory.atom_names
@@ -256,14 +268,13 @@ class VanHoveFunctionSelf(IJob):
             A tuple containing the atom index and distance histograms.
 
         """
-        histograms = np.zeros((self.n_mid_points, self.n_frames))
         first = self.configuration["frames"]["first"]
         last = self.configuration["frames"]["last"] + 1
         step = self.configuration["frames"]["step"]
 
-        atom_index = self.trajectory.atom_indices[index]
-        series = self.trajectory.read_atomic_trajectory(
-            atom_index,
+        atom_index_group = self.grouped_indices[index]
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=first,
             last=last,
             step=step,
@@ -275,6 +286,7 @@ class VanHoveFunctionSelf(IJob):
             ],
         )
 
+        histograms = np.zeros((self.n_mid_points, self.n_frames, len(atom_index_group)))
         histograms = van_hove_self(
             series,
             histograms,
@@ -287,7 +299,7 @@ class VanHoveFunctionSelf(IJob):
 
         return index, histograms
 
-    def combine(self, index: int, histogram: FloatArray):
+    def combine(self, step_index: int, histogram: FloatArray):
         """Add the results into the histograms for the input time difference.
 
         Parameters
@@ -299,9 +311,14 @@ class VanHoveFunctionSelf(IJob):
             time t0 and t0 + t.
 
         """
-        element = self._atoms[self.trajectory.atom_indices[index]]
-        self._outputData[f"vh/g(r,t)/{element}"][:] += histogram
-        self._outputData[f"vh/4_pi_r2_g(r,t)/{element}"][:] += histogram
+        atom_index_group = self.grouped_indices[step_index]
+        # The symbol of the atom.
+        for arr_index, at_index in enumerate(atom_index_group):
+            element = self._atoms[self.trajectory.atom_indices[at_index]]
+            self._outputData[f"vh/g(r,t)/{element}"][:] += histogram[:, :, arr_index]
+            self._outputData[f"vh/4_pi_r2_g(r,t)/{element}"][:] += histogram[
+                :, :, arr_index
+            ]
 
     def finalize(self):
         """Apply scaling to the summed up results.

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityCorrelationFunction.py
@@ -59,7 +59,7 @@ class VelocityCorrelationFunction(CartesianCorrelationFunction):
         atom_index_group = self.grouped_indices[index]
 
         if self.configuration["interpolation_order"]["value"] == 0:
-            series = trajectory.read_configuration_trajectory_many(
+            series = trajectory.read_configuration_trajectory(
                 atom_index_group,
                 first=self.configuration["frames"]["first"],
                 last=self.configuration["frames"]["last"] + 1,

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityCorrelationFunction.py
@@ -19,7 +19,7 @@ from MDANSE.Framework.Jobs.CartesianCorrelationFunction import (
     CartesianCorrelationFunction,
 )
 from MDANSE.Framework.Jobs.IJob import IJob
-from MDANSE.Mathematics.Signal import differentiate
+from MDANSE.Mathematics.Signal import differentiate_many
 
 
 @IJob.register("VelocityCorrelationFunction")
@@ -56,31 +56,28 @@ class VelocityCorrelationFunction(CartesianCorrelationFunction):
 
     def get_series(self, index):
         trajectory = self.trajectory
-        atom_index = self.trajectory.atom_indices[index]
+        atom_index_group = self.grouped_indices[index]
 
         if self.configuration["interpolation_order"]["value"] == 0:
-            series = trajectory.read_configuration_trajectory(
-                atom_index,
+            series = trajectory.read_configuration_trajectory_many(
+                atom_index_group,
                 first=self.configuration["frames"]["first"],
                 last=self.configuration["frames"]["last"] + 1,
                 step=self.configuration["frames"]["step"],
                 variable="velocities",
             )
         else:
-            series = trajectory.read_atomic_trajectory(
-                atom_index,
+            series = self.trajectory.read_atomic_trajectory_many(
+                atom_index_group,
                 first=self.configuration["frames"]["first"],
                 last=self.configuration["frames"]["last"] + 1,
                 step=self.configuration["frames"]["step"],
             )
 
             order = self.configuration["interpolation_order"]["value"]
-            for axis in range(3):
-                series[:, axis] = differentiate(
-                    series[:, axis],
-                    order=order,
-                    dt=self.configuration["frames"]["time_step"],
-                )
+            series = differentiate_many(
+                series, dt=self.configuration["frames"]["time_step"], order=order
+            )
 
         series = self.configuration["projection"]["projector"](series)
         return series

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, NamedTuple
 import numpy as np
 import numpy.typing as npt
 from scipy import fftpack, signal
+from scipy.interpolate import make_interp_spline
 
 from MDANSE.Framework.OutputVariables.IOutputVariable import OutputData
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
@@ -85,31 +86,6 @@ INTERPOLATION_ORDER[5] = np.array(
     ],
     dtype=np.float64,
 )
-
-
-def normalisation_factor(x: IOutputVariable, axis: int = 0) -> FloatArray:
-    """Normalizes the signal by dividing x by the zeroth elements
-    along the input axis.
-
-    Parameters
-    ----------
-    x : FloatArray
-        The input array to normalize.
-    axis : int
-        The axis to normalize the array along.
-
-    Returns
-    -------
-    FloatArray
-        The normalization factors.
-    """
-    s = [slice(None)] * x.ndim
-    s[axis] = slice(0, 1, 1)
-
-    s = tuple(s)
-    scaling_factor = x.scaling_factor
-
-    return 1 / (scaling_factor * x[s])
 
 
 def differentiate(a, dt=1.0, order=1):
@@ -202,6 +178,17 @@ def differentiate(a, dt=1.0, order=1):
     ts *= fact
 
     return ts
+
+
+def differentiate_many(input_array, dt: float = 1.0, order: int = 1):
+    time_axis = np.arange(len(input_array)) * dt
+    if order == 1:
+        spline = make_interp_spline(time_axis, input_array, k=order, axis=0)
+    else:
+        spline = make_interp_spline(
+            time_axis, input_array, k=order, axis=0, bc_type=None
+        )
+    return spline(time_axis, nu=1)
 
 
 def symmetrize(signal, axis=0):

--- a/MDANSE/Src/MDANSE/Mathematics/Signal.py
+++ b/MDANSE/Src/MDANSE/Mathematics/Signal.py
@@ -27,11 +27,7 @@ import numpy.typing as npt
 from scipy import fftpack, signal
 from scipy.interpolate import make_interp_spline
 
-from MDANSE.Framework.OutputVariables.IOutputVariable import OutputData
-from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
-
 if TYPE_CHECKING:
-    from MDANSE.Framework.OutputVariables.IOutputVariable import IOutputVariable
     from MDANSE.util_types import FloatArray
 
 
@@ -180,7 +176,91 @@ def differentiate(a, dt=1.0, order=1):
     return ts
 
 
-def differentiate_many(input_array, dt: float = 1.0, order: int = 1):
+def differentiate_verlet(a: FloatArray, dt: float = 1.0) -> FloatArray:
+    coeffs = np.array(
+        [[-3.0, 4.0, -1.0], [-1.0, 0.0, 1.0], [1.0, -4.0, 3.0]], dtype=np.float64
+    )
+
+    # outputSeries is the output resulting from the differentiation
+    ts = np.zeros(a.shape, dtype=np.float64)
+
+    fact = 1.0 / dt
+
+    ts[0] = np.sum(a[:3] * coeffs[0].reshape((3, 1, 1)), axis=0)
+    ts[-1] = np.sum(a[-3:] * coeffs[2].reshape((3, 1, 1)), axis=0)
+
+    ts[1:-1] = a[2:] - a[:-2]
+
+    fact /= 2.0
+
+    ts *= fact
+
+    return ts
+
+
+def differentiate_many(a, dt=1.0, order=1):
+    if order not in INTERPOLATION_ORDER:
+        raise SignalError("Invalid differentiation order")
+
+    coeffs = INTERPOLATION_ORDER[order]
+
+    ts = np.empty_like(a)
+
+    fact = 1.0 / dt
+
+    if order == 1:
+        ts[-1] = np.sum(coeffs[1].reshape((2, 1, 1)) * a[-2:], axis=0)
+
+        gj = a[1:] - a[:-1]
+        ts[:-1] = gj
+
+    elif order == 2:
+        ts[0] = np.sum(a[:3] * coeffs[0].reshape((3, 1, 1)), axis=0)
+        ts[-1] = np.sum(a[-3:] * coeffs[2].reshape((3, 1, 1)), axis=0)
+
+        ts[1:-1] = a[2:] - a[:-2]
+
+        fact /= 2.0
+
+    elif order == 3:
+        ts[0] = np.sum(a[:4] * coeffs[0].reshape((4, 1, 1)), axis=0)
+        ts[1] = np.sum(a[:4] * coeffs[1].reshape((4, 1, 1)), axis=0)
+        ts[-1] = np.sum(a[-4:] * coeffs[3].reshape((4, 1, 1)), axis=0)
+        ts[2:-1] = 1 * a[:-3] - 6 * a[1:-2] + 3 * a[2:-1] + 2 * a[3:]
+        fact /= 6.0
+
+    elif order == 4:
+        ts[0] = np.sum(a[:5] * coeffs[0].reshape((5, 1, 1)), axis=0)
+        ts[1] = np.sum(a[:5] * coeffs[1].reshape((5, 1, 1)), axis=0)
+        ts[-2] = np.sum(a[-5:] * coeffs[3].reshape((5, 1, 1)), axis=0)
+        ts[-1] = np.sum(a[-5:] * coeffs[4].reshape((5, 1, 1)), axis=0)
+        ts[2:-2] = 2 * a[:-4] - 16 * a[1:-3] + 16 * a[3:-1] - 2 * a[4:]
+        fact /= 24.0
+
+    elif order == 5:
+        # Special case for the first and last elements
+        ts[0] = np.sum(a[:6] * coeffs[0].reshape((6, 1, 1)), axis=0)
+        ts[1] = np.sum(a[:6] * coeffs[1].reshape((6, 1, 1)), axis=0)
+        ts[2] = np.sum(a[:6] * coeffs[2].reshape((6, 1, 1)), axis=0)
+        ts[-2] = np.sum(a[-6:] * coeffs[3].reshape((6, 1, 1)), axis=0)
+        ts[-1] = np.sum(a[-6:] * coeffs[4].reshape((6, 1, 1)), axis=0)
+        ts[3:-2] = (
+            -4 * a[:-5]
+            + 30 * a[1:-4]
+            - 120 * a[2:-3]
+            + 40 * a[3:-2]
+            + 60 * a[4:-1]
+            - 6 * a[5:]
+        )
+
+        fact /= 120.0
+
+    ts *= fact
+
+    return ts
+
+
+def differentiate_spline(input_array, dt: float = 1.0, order: int = 1):
     time_axis = np.arange(len(input_array)) * dt
     if order == 1:
         spline = make_interp_spline(time_axis, input_array, k=order, axis=0)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
@@ -120,7 +120,9 @@ def mean_square_fluctuation(
         the mean-square fluctuation
 
     """
-    msf = np.average(np.sum((coords - np.average(coords, axis=0)) ** 2, axis=sum_axis))
+    msf = np.average(
+        np.sum((coords - np.average(coords, axis=0)) ** 2, axis=sum_axis), axis=0
+    )
 
     if root:
         msf = np.sqrt(msf)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
@@ -44,30 +44,6 @@ def scipy_correlate_2D(
     return fft.ifft(np.sum(v * w.conj(), axis=sum_axis), axis=0)[:n_frames] / n_configs
 
 
-def mean_square_displacement(coords: FloatArray, n_configs: int) -> FloatArray:
-    """Computes the mean square displacement of a set of coordinates
-    using the MSD algorithm described in Kneller et al., Com. Phys. Com., 1995.
-
-    Parameters
-    ----------
-    coords : FloatArray
-        Coordinates used to calculate MSD.
-    n_configs : int
-        Size of the window used to correlated positions.
-
-    Returns
-    -------
-    FloatArray
-        An array of the MSD.
-    """
-    r2 = coords * coords
-    window = np.ones((n_configs, 3))
-    r2t = correlate(r2, window, mode="valid").T[0] / n_configs
-    rtr0 = correlate(coords, coords[:n_configs], mode="valid").T[0] / n_configs
-    msd = r2t[0] + r2t - 2 * rtr0
-    return msd
-
-
 def mean_square_displacement_many(coords: FloatArray, n_configs: int) -> FloatArray:
     """Computes the mean square displacement of a set of coordinates
     using the MSD algorithm described in Kneller et al., Com. Phys. Com., 1995.

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
@@ -44,9 +44,7 @@ def scipy_correlate_2D(
     return fft.ifft(np.sum(v * w.conj(), axis=sum_axis), axis=0)[:n_frames] / n_configs
 
 
-def mean_square_displacement(
-    coords: FloatArray, n_configs: int
-) -> FloatArray:
+def mean_square_displacement(coords: FloatArray, n_configs: int) -> FloatArray:
     """Computes the mean square displacement of a set of coordinates
     using the MSD algorithm described in Kneller et al., Com. Phys. Com., 1995.
 
@@ -70,22 +68,20 @@ def mean_square_displacement(
     return msd
 
 
-def mean_square_displacement_many(
-    coords: FloatArray, n_configs: int
-) -> FloatArray:
+def mean_square_displacement_many(coords: FloatArray, n_configs: int) -> FloatArray:
     """Computes the mean square displacement of a set of coordinates
     using the MSD algorithm described in Kneller et al., Com. Phys. Com., 1995.
 
     Parameters
     ----------
-    coords : np.ndarray
+    coords : FloatArray
         Atom coordinate array with shape (N_FRAMES, N_ATOMS, 3)
     n_configs : int
         Size of the window used to correlated positions.
 
     Returns
     -------
-    np.ndarray
+    FloatArray
         An array of the MSD.
     """
     n_frames = coords.shape[0]

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+from scipy import fft
 from scipy.signal import correlate
 
 from MDANSE.Mathematics.Geometry import center_of_mass
@@ -30,7 +31,22 @@ class AnalysisError(Exception):
     pass
 
 
-def mean_square_displacement(coords: FloatArray, n_configs: int) -> FloatArray:
+def scipy_correlate_2D(
+    input_array_1: FloatArray,
+    input_array_2: FloatArray,
+    n_frames: int,
+    n_configs: int,
+    sum_axis: int = 1,
+):
+    fast_len = fft.next_fast_len(n_frames)
+    v = fft.fft(input_array_1, n=fast_len, axis=0)
+    w = fft.fft(input_array_2[:n_configs], n=fast_len, axis=0)
+    return fft.ifft(np.sum(v * w.conj(), axis=sum_axis), axis=0)[:n_frames] / n_configs
+
+
+def mean_square_displacement(
+    coords: FloatArray, n_configs: int
+) -> FloatArray:
     """Computes the mean square displacement of a set of coordinates
     using the MSD algorithm described in Kneller et al., Com. Phys. Com., 1995.
 
@@ -54,7 +70,38 @@ def mean_square_displacement(coords: FloatArray, n_configs: int) -> FloatArray:
     return msd
 
 
-def mean_square_fluctuation(coords: FloatArray, root: bool = False) -> float:
+def mean_square_displacement_many(
+    coords: FloatArray, n_configs: int
+) -> FloatArray:
+    """Computes the mean square displacement of a set of coordinates
+    using the MSD algorithm described in Kneller et al., Com. Phys. Com., 1995.
+
+    Parameters
+    ----------
+    coords : np.ndarray
+        Atom coordinate array with shape (N_FRAMES, N_ATOMS, 3)
+    n_configs : int
+        Size of the window used to correlated positions.
+
+    Returns
+    -------
+    np.ndarray
+        An array of the MSD.
+    """
+    n_frames = coords.shape[0]
+    n_atoms = coords.shape[1]
+    r2 = coords * coords
+    window = np.ones((n_configs, n_atoms, 3))
+    # correlate the coordinates
+    rtr0 = scipy_correlate_2D(coords, coords, n_frames, n_configs, sum_axis=2)
+    # correlate the squares
+    r2t = scipy_correlate_2D(r2, window, n_frames, n_configs, sum_axis=2)
+    return (r2t[0, :] + r2t - 2 * rtr0).real
+
+
+def mean_square_fluctuation(
+    coords: FloatArray, root: bool = False, sum_axis: int = 1
+) -> float:
     """Computes the mean-square fluctuation, or the root-mean-square fluctuation if root is set to True. The following
     equation is used:
     .. math:: MSF = \\frac{\\sum_{i=0} ^{n} \\sum_{x=1} ^{3}(coords_{i,x} - \\frac{\\sum_{j=0} ^{n}coords_{j,x}}{n})^2}{n}
@@ -73,12 +120,12 @@ def mean_square_fluctuation(coords: FloatArray, root: bool = False) -> float:
         the mean-square fluctuation
 
     """
-    msf = np.average(np.sum((coords - np.average(coords, axis=0)) ** 2, axis=1))
+    msf = np.average(np.sum((coords - np.average(coords, axis=0)) ** 2, axis=sum_axis))
 
     if root:
         msf = np.sqrt(msf)
 
-    return float(msf)
+    return msf.astype(float)
 
 
 def radius_of_gyration(

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -640,17 +640,17 @@ class Trajectory:
 
     def to_absolute_coordinates(
         self,
-        box_coordinates: FloatArray,
+        fractional_coordinates: FloatArray,
         first: int = 0,
         last: int | None = None,
         step: int | None = None,
     ) -> FloatArray:
-        """Convert box coordinates to real coordinates for a set of frames.
+        """Convert fractional coordinates to absolute coordinates for a set of frames.
 
         Parameters
         ----------
-        box_coordinates : ndarray
-            A 2D array containing the box coordinates.
+        fractional_coordinates : ndarray
+            A 2D array containing the fractional coordinates.
         first : int
             The index of the first frame.
         last : int or None
@@ -664,7 +664,7 @@ class Trajectory:
             2D array containing the absolute coordinates converted from fractionals.
 
         """
-        return self._trajectory.to_absolute_coordinates(box_coordinates, first, last, step)
+        return self._trajectory.to_absolute_coordinates(fractional_coordinates, first, last, step)
 
     def read_atomic_trajectory(
         self,
@@ -673,9 +673,9 @@ class Trajectory:
         last: int | None = None,
         step: int | None = 1,
         *,
-        box_coordinates: bool = False,
+        fractional_coordinates: bool = False,
     ) -> FloatArray:
-        """Read an atomic trajectory. The trajectory is corrected from box jumps.
+        """Read a continuous trajectory of a single atom.
 
         Parameters
         ----------
@@ -685,10 +685,10 @@ class Trajectory:
             The index of the first frame. (Default value = 0)
         last : int
             The index of the last frame. (Default value = None)
-        step : int
-            The step in frame. (Default value = 1)
-        box_coordinates : bool
-            If True, the coordiniates are returned in box coordinates (Default value = False).
+        step : int, default 1.
+            The step in frame.
+        fractional_coordinates : bool, default False
+            If True, the coordinates are returned in fractional coordinates.
 
         Returns
         -------
@@ -701,7 +701,7 @@ class Trajectory:
             first=first,
             last=last,
             step=step,
-            box_coordinates=box_coordinates,
+            fractional_coordinates=fractional_coordinates,
         )
 
     def read_atomic_trajectory_many(
@@ -709,25 +709,25 @@ class Trajectory:
         index_list: list[int],
         first: int = 0,
         last: int | None = None,
-        step: int | None = 1,
+        step: int = 1,
         *,
-        box_coordinates: bool = False,
+        fractional_coordinates: bool = False,
         reference: FloatArray | None = None,
     ) -> FloatArray:
-        """Read an atomic trajectory. The trajectory is corrected from box jumps.
+        """Read continuous trajectories of multiple atoms.
 
         Parameters
         ----------
-        index : int
+        index_list : list[int]
             The index of the atom.
         first : int
-            The index of the first frame. (Default value = 0)
-        last : int
-            The index of the last frame. (Default value = None)
-        step : int
-            The step in frame. (Default value = 1)
-        box_coordinates : bool
-            If True, the coordiniates are returned in box coordinates (Default value = False).
+            The index of the first frame.
+        last : int | None, default None
+            The index of the last frame.
+        step : int, default 1
+            The step in frame.
+        fractional_coordinates : bool
+            If True, the coordiniates are returned in fractional coordinates.
 
         Returns
         -------
@@ -740,33 +740,35 @@ class Trajectory:
             first=first,
             last=last,
             step=step,
-            box_coordinates=box_coordinates,
+            fractional_coordinates=fractional_coordinates,
             reference = reference,
         )
 
     def read_configuration_trajectory(
         self,
-        index: int,
+        index: int | list[int],
         first: int = 0,
         last: int | None = None,
         step: int = 1,
         slc: slice | None = None,
         variable: str = "velocities",
     ) -> FloatArray:
-        """Return trajectory values for one atom for a subset of frames.
+        """Return trajectory values for one or more atoms for a subset of frames.
 
         Parameters
         ----------
-        index : int
-            Atom index.
-        first : int, optional
-            First frame index, by default 0
-        last : int | None, optional
-            Last frame index, by default None
-        step : int, optional
-            Step in time frames, by default 1
-        variable : str, optional
-            Value to be read from trajectory, by default "velocities"
+        index : int | list[int]
+            Atom index or a list of atom indices.
+        first : int, default 0
+            First frame index.
+        last : int | None, default None
+            Last frame index.
+        step : int, default 1
+            Step in time frames.
+        slc: slice | None, default None
+            Slice defining the frame selection, optional.
+        variable : str, default "velocities"
+            Value to be read from trajectory.
 
         Returns
         -------

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -666,44 +666,6 @@ class Trajectory:
         """
         return self._trajectory.to_absolute_coordinates(fractional_coordinates, first, last, step)
 
-    def read_atomic_trajectory(
-        self,
-        index: int,
-        first: int = 0,
-        last: int | None = None,
-        step: int | None = 1,
-        *,
-        fractional_coordinates: bool = False,
-    ) -> FloatArray:
-        """Read a continuous trajectory of a single atom.
-
-        Parameters
-        ----------
-        index : int
-            The index of the atom.
-        first : int
-            The index of the first frame. (Default value = 0)
-        last : int
-            The index of the last frame. (Default value = None)
-        step : int, default 1.
-            The step in frame.
-        fractional_coordinates : bool, default False
-            If True, the coordinates are returned in fractional coordinates.
-
-        Returns
-        -------
-        ndarray
-            2D array containing the atomic trajectory for the selected frames
-
-        """
-        return self._trajectory.read_atomic_trajectory(
-            index,
-            first=first,
-            last=last,
-            step=step,
-            fractional_coordinates=fractional_coordinates,
-        )
-
     def read_atomic_trajectory_many(
         self,
         index_list: list[int],

--- a/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
@@ -34,6 +34,11 @@ CHUNK_SIZE_LIMIT = (
     int(mb_ram_per_process) * 2**20
 )  # 512 MB memory limit per process for now
 
+if TYPE_CHECKING:
+    from MDANSE.MolecularDynamics.Trajectory import Trajectory
+
+CHUNK_SIZE_LIMIT = 2**29  # 512 MB memory limit per process for now
+
 
 class MolecularDynamicsError(Exception):
     pass

--- a/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
@@ -48,7 +48,7 @@ def atomic_trajectory(
     cell: FloatArray,
     rcell: FloatArray,
     *,
-    box_coordinates: bool = False,
+    fractional_coordinates: bool = False,
 ) -> FloatArray:
     """For the coordinates of a specific atom, remove all unit cell jumps.
 
@@ -60,7 +60,7 @@ def atomic_trajectory(
         The direct matrices.
     rcell : FloatArray
         The inverse matrices.
-    box_coordinates : bool
+    fractional_coordinates : bool
         Returns the coordinates in fractional coordinates if true.
 
     Returns
@@ -73,7 +73,7 @@ def atomic_trajectory(
     sdxyz = trajectory[1:, :] - trajectory[:-1, :]
     sdxyz -= np.cumsum(np.round(sdxyz), axis=0)
     trajectory[1:, :] = trajectory[:-1, :] + sdxyz
-    if not box_coordinates:
+    if not fractional_coordinates:
         trajectory = np.einsum("ij,ijk->ik", trajectory, cell)
     return trajectory
 
@@ -83,10 +83,10 @@ def atomic_trajectory_many(
     cell: FloatArray,
     rcell: FloatArray,
     *,
-    box_coordinates: bool = False,
+    fractional_coordinates: bool = False,
     reference: FloatArray | None = None,
 ) -> FloatArray:
-    """For the coordinates of a specific atom, remove all unit cell jumps.
+    """Make atom trajectories continuous by removing jumps.
 
     Parameters
     ----------
@@ -96,7 +96,7 @@ def atomic_trajectory_many(
         The direct matrices.
     rcell : FloatArray
         The inverse matrices.
-    box_coordinates : bool
+    fractional_coordinates : bool
         Returns the coordinates in fractional coordinates if true.
 
     Returns
@@ -115,7 +115,7 @@ def atomic_trajectory_many(
         sdxyz = trajectory[:, :] - reference
         sdxyz -= np.cumsum(np.round(sdxyz), axis=0)
         trajectory[:, :] = reference + sdxyz
-    if not box_coordinates:
+    if not fractional_coordinates:
         trajectory = np.einsum("inj,ijk->ink", trajectory, cell)
     return trajectory
 

--- a/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
+++ b/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
@@ -256,6 +256,8 @@ class TrajectoryFile(ABC):
             Last frame index, by default None
         step : int, optional
             Step in time frames, by default 1
+        slc : slice | None, default None
+            Slice of time frames to be used, optional.
         variable : str, optional
             Value to be read from trajectory, by default "velocities"
 
@@ -283,17 +285,17 @@ class TrajectoryFile(ABC):
 
     def to_absolute_coordinates(
         self,
-        box_coordinates: FloatArray,
+        fractional_coordinates: FloatArray,
         first: int = 0,
         last: int | None = None,
         step: int | None = None,
     ) -> FloatArray:
-        """Convert box coordinates to real coordinates for a set of frames.
+        """Convert fractional coordinates to absolute coordinates for a set of frames.
 
         Parameters
         ----------
-        box_coordinates : ndarray
-            A 2D array containing the box coordinates.
+        fractional_coordinates : ndarray
+            A 2D array containing the fractional coordinates.
         first : int
             The index of the first frame.
         last : int or None
@@ -304,12 +306,12 @@ class TrajectoryFile(ABC):
         Returns
         -------
         ndarray
-            2D array containing the real coordinates converted from box coordinates.
+            2D array containing the absolute coordinates converted from fractional coordinates.
 
         """
         if self.unit_cell_warning == NO_CELL:
-            return box_coordinates
-        return box_coordinates @ self.unit_cells_raw[first:last:step]
+            return fractional_coordinates
+        return fractional_coordinates @ self.unit_cells_raw[first:last:step]
 
     def read_atomic_trajectory(
         self,
@@ -318,7 +320,7 @@ class TrajectoryFile(ABC):
         last: int | None = None,
         step: int | None = 1,
         *,
-        box_coordinates: bool = False,
+        fractional_coordinates: bool = False,
     ) -> FloatArray:
         """Read an atomic trajectory. The trajectory is corrected from box jumps.
 
@@ -332,8 +334,8 @@ class TrajectoryFile(ABC):
             The index of the last frame. (Default value = None)
         step : int
             The step in frame. (Default value = 1)
-        box_coordinates : bool
-            If True, the coordiniates are returned in box coordinates (Default value = False).
+        fractional_coordinates : bool
+            If True, the coordiniates are returned in fractional coordinates (Default value = False).
 
         Returns
         -------
@@ -354,7 +356,7 @@ class TrajectoryFile(ABC):
             coords,
             direct_cells,
             inverse_cells,
-            box_coordinates=box_coordinates,
+            fractional_coordinates=fractional_coordinates,
         )
 
     def read_atomic_trajectory_many(
@@ -362,30 +364,30 @@ class TrajectoryFile(ABC):
         index_list: list[int],
         first: int = 0,
         last: int | None = None,
-        step: int | None = 1,
+        step: int = 1,
         *,
-        box_coordinates: bool = False,
+        fractional_coordinates: bool = False,
         reference: FloatArray | None = None,
     ) -> FloatArray:
-        """Read an atomic trajectory. The trajectory is corrected from box jumps.
+        """Read continuous trajectories of multiple atoms.
 
         Parameters
         ----------
-        index : int
-            The index of the atom.
-        first : int
-            The index of the first frame. (Default value = 0)
-        last : int
-            The index of the last frame. (Default value = None)
-        step : int
-            The step in frame. (Default value = 1)
-        box_coordinates : bool
-            If True, the coordiniates are returned in box coordinates (Default value = False).
+        index : list[int]
+            Indices of atoms to be read.
+        first : int, default 0
+            The index of the first frame.
+        last : int | None, default None
+            The index of the last frame.
+        step : int, default 1
+            The step in frame.
+        fractional_coordinates : bool, default False.
+            If True, the coordinates are returned in fractional coordinates.
 
         Returns
         -------
         ndarray
-            2D array containing the atomic trajectory for the selected frames
+            (N_FRAMES, N_ATOMS, 3) array of coordinates.
 
         """
         slc = np.s_[first:last:step]
@@ -401,7 +403,7 @@ class TrajectoryFile(ABC):
             coords,
             direct_cells,
             inverse_cells,
-            box_coordinates=box_coordinates,
+            fractional_coordinates=fractional_coordinates,
             reference=reference,
         )
 

--- a/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
+++ b/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
@@ -313,52 +313,6 @@ class TrajectoryFile(ABC):
             return fractional_coordinates
         return fractional_coordinates @ self.unit_cells_raw[first:last:step]
 
-    def read_atomic_trajectory(
-        self,
-        index: int,
-        first: int = 0,
-        last: int | None = None,
-        step: int | None = 1,
-        *,
-        fractional_coordinates: bool = False,
-    ) -> FloatArray:
-        """Read an atomic trajectory. The trajectory is corrected from box jumps.
-
-        Parameters
-        ----------
-        index : int
-            The index of the atom.
-        first : int
-            The index of the first frame. (Default value = 0)
-        last : int
-            The index of the last frame. (Default value = None)
-        step : int
-            The step in frame. (Default value = 1)
-        fractional_coordinates : bool
-            If True, the coordiniates are returned in fractional coordinates (Default value = False).
-
-        Returns
-        -------
-        ndarray
-            2D array containing the atomic trajectory for the selected frames
-
-        """
-        slc = np.s_[first:last:step]
-
-        coords = self.coordinates(slc, index)
-
-        if self.unit_cell_warning == NO_CELL:
-            return coords
-
-        direct_cells = self.unit_cells_raw[slc]
-        inverse_cells = np.linalg.pinv(direct_cells)
-        return atomic_trajectory(
-            coords,
-            direct_cells,
-            inverse_cells,
-            fractional_coordinates=fractional_coordinates,
-        )
-
     def read_atomic_trajectory_many(
         self,
         index_list: list[int],

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 from collections import ChainMap
 from enum import Enum
-from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING
 

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections import ChainMap
 from enum import Enum
+from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING
 

--- a/MDANSE/Tests/UnitTests/test_analysis.py
+++ b/MDANSE/Tests/UnitTests/test_analysis.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from MDANSE.MolecularDynamics.Analysis import (AnalysisError,
-                                               mean_square_displacement,
+                                               mean_square_displacement_many,
                                                mean_square_fluctuation,
                                                radius_of_gyration)
 
@@ -21,8 +21,8 @@ COORDS = [
     (COORDS[1], 1, [0., 1., 4.])
 ])
 def test_mean_square_displacement(coords, n_configs, expected):
-    msd = mean_square_displacement(coords, n_configs)
-    assert np.allclose(msd, expected)
+    msd = mean_square_displacement_many(coords.reshape((3, 1, 3)), n_configs)
+    assert np.allclose(msd.ravel(), expected)
 
 @pytest.mark.parametrize("coords, root, expected", [
     (COORDS[3], False, 19.625),

--- a/MDANSE/Tests/UnitTests/test_atomic_trajectory.py
+++ b/MDANSE/Tests/UnitTests/test_atomic_trajectory.py
@@ -8,14 +8,14 @@ cells = np.array([np.eye(3)] * 5)
 
 def test_constant():
     coords = np.zeros((5, 3)) + 0.5
-    atomic_traj = atomic_trajectory(coords, cells, cells, box_coordinates=False)
+    atomic_traj = atomic_trajectory(coords, cells, cells, fractional_coordinates=False)
     assert np.allclose(atomic_traj, 0.5)
 
 
 def test_one_big_jump():
     coords = np.zeros((5, 3)) + 3.2
     coords[0, 0] = 0.1
-    atomic_traj = atomic_trajectory(coords, cells, cells, box_coordinates=False)
+    atomic_traj = atomic_trajectory(coords, cells, cells, fractional_coordinates=False)
     result = np.zeros((5, 3)) + 3.2
     result[0, 0] = 0.1
     result[1:, 0] = 0.2
@@ -23,14 +23,14 @@ def test_one_big_jump():
 
 def test_constant_many():
     coords = np.zeros((5, 3)) + 0.5
-    atomic_traj = atomic_trajectory_many(coords[:,:,None], cells, cells, box_coordinates=False)
+    atomic_traj = atomic_trajectory_many(coords[:,:,None], cells, cells, fractional_coordinates=False)
     assert np.allclose(atomic_traj, 0.5)
 
 
 def test_one_big_jump_many():
     coords = np.zeros((5, 3)) + 3.2
     coords[0, 0] = 0.1
-    atomic_traj = atomic_trajectory_many(coords[:,None,:], cells, cells, box_coordinates=False)
+    atomic_traj = atomic_trajectory_many(coords[:,None,:], cells, cells, fractional_coordinates=False)
     result = np.zeros((5, 3)) + 3.2
     result[0, 0] = 0.1
     result[1:, 0] = 0.2
@@ -39,7 +39,7 @@ def test_one_big_jump_many():
 def test_two_atoms_many():
     coords = np.zeros((5, 2, 3)) + 3.2
     coords[0, 0, 0] = 0.1
-    atomic_traj = atomic_trajectory_many(coords, cells, cells, box_coordinates=False)
+    atomic_traj = atomic_trajectory_many(coords, cells, cells, fractional_coordinates=False)
     result = np.zeros((5, 2, 3)) + 3.2
     result[0, 0, 0] = 0.1
     result[1:, 0, 0] = 0.2

--- a/MDANSE/Tests/UnitTests/test_signal.py
+++ b/MDANSE/Tests/UnitTests/test_signal.py
@@ -1,0 +1,38 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+from MDANSE.Mathematics.Signal import differentiate, differentiate_many
+
+mock_trajectory = np.vstack([
+    np.sin(np.arange(30)), np.cos(np.arange(30)), np.sin(np.arange(30)/2.1)
+]).T
+
+mock_3D_trajectory = np.arange(1,5).reshape((1,4,1)) * mock_trajectory.reshape((30,1,3))
+
+
+@pytest.fixture(scope="module")
+def diff_result():
+    result = np.empty_like(mock_3D_trajectory)
+    for j in range(mock_3D_trajectory.shape[1]):
+        for k in range(mock_3D_trajectory.shape[2]):
+            result[:, j, k] = differentiate(mock_3D_trajectory[:, j ,k], order=3)
+    return result
+
+
+def test_result_shape(diff_result):
+    new_result = differentiate_many(mock_3D_trajectory, order=3)
+    assert diff_result.shape == new_result.shape
+
+
+def test_result_values(diff_result, output_plots: bool = False):
+    new_result = differentiate_many(mock_3D_trajectory, order=3)
+    if output_plots:
+        import matplotlib.pyplot as mpl
+        for j in range(mock_3D_trajectory.shape[1]):
+            for k in range(mock_3D_trajectory.shape[2]):
+                mpl.plot(np.arange(30), diff_result[:, j,k], label="old MDANSE")
+                mpl.plot(np.arange(30), new_result[:, j,k], label = "new scipy")
+                mpl.legend(loc=0)
+                mpl.savefig(f"derivative_comparison_{j}_{k}.png")
+                mpl.close()
+    npt.assert_allclose(diff_result, new_result)

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/readers/i_reader.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/readers/i_reader.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import abc
 
+import numpy as np
+
 from MDANSE.Chemistry import ATOMS_DATABASE
 
 
@@ -169,4 +171,4 @@ class IReader(abc.ABC):
         if index < 0 or index >= self._n_atoms:
             raise InvalidAtomError("Invalid atom index")
 
-        return self._trajectory.read_atomic_trajectory(index)
+        return np.squeeze(self._trajectory.read_atomic_trajectory_many([index]))


### PR DESCRIPTION
**Description of work**
The main goal of this PR is to speed up MDANSE analysis runs.

This work is based on the changes from #1240 

**Fixes**
So far, the following changes have been implemented:

1. Grouping atom indices into batches belonging to the same chunk in the underlying trajectory file. This reduces the number of read operations performed on the file.
2. Use [scipy.interpolate.make_interp_spline](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.make_interp_spline.html#make-interp-spline) to calculate the velocity by interpolating the atom positions. **This change has been removed in order not to reduce the precision in the case of order=2 and all the frames being present in the trajectory.**
3. All the analysis types which used `read_atomic_trajectory` have been modified to use `read_atomic_trajectory_many`.

**To test**
All analysis types must be checked, given the extent of the changes. Ideally we should be comparing both the results and the performance before and after the changes.
