### PR TITLE
Unit test fixes

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -30,11 +30,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from logging import FileHandler
 from logging.handlers import QueueHandler, QueueListener
-from multiprocessing import Queue
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from more_itertools import consumer, first_true
+from more_itertools import consumer
 
 from MDANSE import PLATFORM
 from MDANSE.Core.RegisterFactory import RegisterFactory

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -225,9 +225,10 @@ class IJob(Configurable, RegisterFactory, ABC):
         self._log_filename = None
         self._in_memory_result = None
 
-        self.inputQueue = Queue()
-        self.outputQueue = Queue()
-        self.log_queue = Queue()
+        ctx = multiprocessing.get_context("spawn")
+        self.inputQueue = ctx.Queue()
+        self.outputQueue = ctx.Queue()
+        self.log_queue = ctx.Queue()
 
     def __getstate__(self):
         d = self.__dict__.copy()
@@ -424,9 +425,10 @@ class IJob(Configurable, RegisterFactory, ABC):
         for i in range(self.numberOfSteps):
             inputQueue.put(i)
 
+        ctx = multiprocessing.get_context("spawn")
         for _ in range(self.configuration["running_mode"]["slots"]):
             self._run_multicore_check_terminate(listener)
-            p = multiprocessing.Process(
+            p = ctx.Process(
                 target=self.process_tasks_queue,
                 args=(inputQueue, outputQueue, log_queues),
             )

--- a/MDANSE/Src/MDANSE/__init__.py
+++ b/MDANSE/Src/MDANSE/__init__.py
@@ -15,7 +15,6 @@
 #
 from __future__ import annotations
 
-import multiprocessing
 import os
 import warnings
 
@@ -35,8 +34,6 @@ os.environ.update(
         "NUMEXPR_NUM_THREADS": "1",
     }
 )
-
-multiprocessing.set_start_method("spawn")
 
 __version__ = str(get_version())
 

--- a/MDANSE/Src/MDANSE/__init__.py
+++ b/MDANSE/Src/MDANSE/__init__.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+import multiprocessing
 import os
 import warnings
 
@@ -34,6 +35,8 @@ os.environ.update(
         "NUMEXPR_NUM_THREADS": "1",
     }
 )
+
+multiprocessing.set_start_method("spawn")
 
 __version__ = str(get_version())
 

--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    "scipy",
+    "scipy<=1.17.1",
     "h5py>=3.13",
     "ase",
     "rdkit>=2025.3.3",

--- a/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/Subprocess.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/Subprocess.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import time
 from logging.handlers import QueueHandler
-from multiprocessing import Event, Process, Queue
+from multiprocessing import Event, Process, Queue, get_context
 from multiprocessing.connection import Connection
 
 from MDANSE.Framework.Jobs.IJob import IJob
@@ -27,12 +27,14 @@ from MDANSE_GUI.Subprocess.JobStatusProcess import JobStatusProcess
 
 class Subprocess(Process):
     def __init__(self, *args, **kwargs):
+        self._default_context = get_context("spawn")
         super().__init__()
         job_name = kwargs.get("job_name")
         self._job_parameters = kwargs.get("job_parameters")
         sending_pipe = kwargs.get("pipe")
-        self.queue_0 = Queue()
-        self.queue_1 = Queue()
+        ctx = get_context("spawn")
+        self.queue_0 = ctx.Queue()
+        self.queue_1 = ctx.Queue()
         pause_event = kwargs.get("pause_event")
         self.log_queue = kwargs.get("log_queue")
         self.construct_job(

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -20,7 +20,7 @@ import traceback
 from itertools import count
 from logging import Handler
 from logging.handlers import QueueListener
-from multiprocessing import Event, Pipe, Process, Queue
+from multiprocessing import Event, Process, get_context
 from typing import Any, NamedTuple
 
 from qtpy.QtCore import QMutex, QObject, Qt, QThread, QTimer, Signal, Slot
@@ -320,10 +320,11 @@ class JobHolder(QStandardItemModel):
     def startProcess(
         self, job_vars: tuple[str, dict[str, Any]], load_afterwards: bool = False
     ):
-        log_queue = Queue()
+        ctx = get_context("spawn")
+        log_queue = ctx.Queue()
 
-        main_pipe, child_pipe = Pipe()
-        pause_event = Event()
+        main_pipe, child_pipe = ctx.Pipe()
+        pause_event = ctx.Event()
         entry_number = next(self.job_number)
 
         job_name, job_params = job_vars


### PR DESCRIPTION
**Description of work**
Unit tests were all passing with scipy 1.17.1, but now one test fails with Python>=3.12 and scipy==1.18.0. This should be investigated, but for now let's use the last version that did not trigger errors.

**Fixes**
1. Limits scipy version to 1.17.1.
2. Makes all platforms use "spawn" method of creating processes. (Hoping to fix random timeout on Linux.)

**To test**
All tests must pass.

