### PR TITLE
Limit scipy version to 1.17.1, use spawn in tests

### DIFF
--- a/MDANSE/Tests/UnitTests/__init__.py
+++ b/MDANSE/Tests/UnitTests/__init__.py
@@ -1,0 +1,3 @@
+import multiprocessing
+
+multiprocessing.set_start_method("spawn")

--- a/MDANSE/pyproject.toml
+++ b/MDANSE/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    "scipy",
+    "scipy<=1.17.1",
     "h5py>=3.13",
     "ase",
     "rdkit>=2025.3.3",


### PR DESCRIPTION
**Description of work**
This PR replaces #1247 and implements minimum changes meant to eliminate spurious test fails.

**Fixes**
1. Limits the scipy version to 1.17.1
2. Uses "spawn" to for creating subprocesses in unit tests (replacing "fork" on Linux).

**To test**
All tests should pass.
