### PR TITLE
Extend plot creator

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -161,6 +161,18 @@ class TabbedWindow(QMainWindow):
         self._tabs["Instruments"]._visualiser.instrument_details_changed.connect(
             self._tabs["Actions"].update_action_after_instrument_change
         )
+        self._tabs["Plot Holder"]._visualiser.current_tab_index.connect(
+            self._tabs["Plot Creator"]._visualiser.new_target_plot_index
+        )
+        self._tabs["Plot Holder"]._visualiser.current_tab_count.connect(
+            self._tabs["Plot Creator"]._visualiser.new_target_plot_count
+        )
+        self._tabs["Plot Holder"]._visualiser.datasets_in_plot.connect(
+            self._tabs["Plot Creator"]._visualiser.new_dataset_count_in_target
+        )
+        self._tabs["Plot Holder"]._visualiser.plot_widget_type.connect(
+            self._tabs["Plot Creator"]._visualiser.new_plot_widget_type
+        )
         # connect signal to the tab
         self.signal_recent_trajectory_file.connect(
             self._tabs["Trajectories"].load_trajectory

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -164,6 +164,9 @@ class TabbedWindow(QMainWindow):
         self._tabs["Plot Holder"]._visualiser.current_tab_index.connect(
             self._tabs["Plot Creator"]._visualiser.new_target_plot_index
         )
+        self._tabs["Plot Holder"]._visualiser.current_tab_name.connect(
+            self._tabs["Plot Creator"]._visualiser.new_target_plot_name
+        )
         self._tabs["Plot Holder"]._visualiser.current_tab_count.connect(
             self._tabs["Plot Creator"]._visualiser.new_target_plot_count
         )

--- a/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/TabbedWindow.py
@@ -173,6 +173,9 @@ class TabbedWindow(QMainWindow):
         self._tabs["Plot Holder"]._visualiser.plot_widget_type.connect(
             self._tabs["Plot Creator"]._visualiser.new_plot_widget_type
         )
+        self._tabs["Plot Holder"].connect_external_view(
+            self._tabs["Plot Creator"]._visualiser.preview_table
+        )
         # connect signal to the tab
         self.signal_recent_trajectory_file.connect(
             self._tabs["Trajectories"].load_trajectory

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
@@ -29,7 +29,7 @@ from MDANSE_GUI.Tabs.Visualisers.PlotSettings import PlotSettings
 from MDANSE_GUI.Widgets.PlotSettingsDialog import PlotSettingsEditor
 
 if TYPE_CHECKING:
-    from qtpy.QtWidgets import QDialog, QWidget
+    from qtpy.QtWidgets import QAbstractItemView, QDialog, QWidget
 
     from MDANSE_GUI.Session.Session import Session
 
@@ -66,6 +66,12 @@ class PlotTab(GeneralTab):
         )
         self.matplotlib_dialog.values_changed.connect(self._visualiser.update_plots)
         self._core.add_button("Change matplotlib settings", self.edit_matplotlib)
+        self.connected_views = [self._view]
+
+    def connect_external_view(self, new_view: QAbstractItemView):
+        if new_view not in self.connected_views:
+            self.connected_views.append(new_view)
+            new_view.setModel(self.model)
 
     def launch_dialog(self, dialog: QDialog) -> None:
         if dialog.isVisible():
@@ -131,5 +137,6 @@ class PlotTab(GeneralTab):
 
     @Slot(int)
     def switch_model(self, tab_id):
-        self._view.setModel(self.model)
+        for view in self.connected_views:
+            view.setModel(self.model)
         self._visualiser.send_plot_info()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/PlotTab.py
@@ -127,7 +127,9 @@ class PlotTab(GeneralTab):
                 LOG.error(f"Visualiser failed to plot data: {e2}")
             else:
                 self.tab_notification()
+        self._visualiser.send_plot_info()
 
     @Slot(int)
     def switch_model(self, tab_id):
         self._view.setModel(self.model)
+        self._visualiser.send_plot_info()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
@@ -48,7 +48,9 @@ class DataPlotter(QWidget):
 
     def __init__(self, *args, unit_lookup=None, **kwargs):
         super().__init__(*args, **kwargs)
-        self.tab_index, self.tab_count = 1, 1
+        self.tab_index, self.tab_count = 0, 1
+        self.dataset_count = 0
+        self.plotter_type = "PlotWidget"
         self._unit_lookup = unit_lookup
         layout = QVBoxLayout(self)
         control_bar = QWidget(self)
@@ -85,11 +87,38 @@ class DataPlotter(QWidget):
     def create_preview(self) -> QWidget:
         previewer = QWidget(self)
         previewer_layout = QVBoxLayout(previewer)
-        self.target_label = QLabel(
-            f"Datasets will be sent to plotter tab {self.tab_index} out of {self.tab_count}"
-        )
+        self.target_label = QLabel("Target plot in next tab.")
         self.target_label.setWordWrap(True)
         previewer_layout.addWidget(self.target_label)
+        self.update_target_plot_label()
+        return previewer
+
+    def update_target_plot_label(self):
+        self.target_label.setText(
+            "Datasets will be sent to the <b>Plot Holder</b> tab.<br>"
+            f"They will appear in tab {self.tab_index + 1} out of {self.tab_count}.<br>"
+            f"It is a {self.plotter_type}, currently containing {self.dataset_count} datasets."
+        )
+
+    @Slot(int)
+    def new_target_plot_index(self, new_index: int):
+        self.tab_index = new_index
+        self.update_target_plot_label()
+
+    @Slot(int)
+    def new_target_plot_count(self, new_count: int):
+        self.tab_count = new_count
+        self.update_target_plot_label()
+
+    @Slot(int)
+    def new_dataset_count_in_target(self, new_dataset_count: int):
+        self.dataset_count = new_dataset_count
+        self.update_target_plot_label()
+
+    @Slot(str)
+    def new_plot_widget_type(self, new_plot_widget_type: str):
+        self.plotter_type = new_plot_widget_type
+        self.update_target_plot_label()
 
     @Slot(object)
     def add_dataset(self, dataset: SingleDataset):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
@@ -179,45 +179,11 @@ class DataPlotter(QWidget):
     def new_plot(self):
         """Trigger the creation of a new plot in the plotting tab."""
         self.create_new_plot.emit("")
-        group = self._settings.group("dialogs")
-        try:
-            show_it = group.get("new_plot")
-        except KeyError:
-            show_it = group.get_default("dialogs", "new_plot")
-        if show_it != "False":
-            plot_added_box = QMessageBox.information(
-                self,
-                "Plot created",
-                "A new plot has been created in the next tab (called 'Plot Holder').\n"
-                "Should this message be shown every time this happens?",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                QMessageBox.StandardButton.Yes,
-            )
-            if plot_added_box == QMessageBox.StandardButton.No:
-                group = self._settings.group("dialogs")
-                group.set("new_plot", "False")
 
     @Slot()
     def new_text(self):
         """Trigger the creation of a new text view in the plotting tab."""
         self.create_new_text.emit("Text view")
-        group = self._settings.group("dialogs")
-        try:
-            show_it = group.get("new_text")
-        except KeyError:
-            show_it = group.get_default("dialogs", "new_text")
-        if show_it != "False":
-            plot_added_box = QMessageBox.information(
-                self,
-                "Plot created",
-                "A new text view has been created in the next tab (called 'Plot Holder').\n"
-                "Should this message be shown every time this happens?",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                QMessageBox.StandardButton.Yes,
-            )
-            if plot_added_box == QMessageBox.StandardButton.No:
-                group = self._settings.group("dialogs")
-                group.set("new_text", "False")
 
     @Slot()
     def plot_data(self):
@@ -225,23 +191,6 @@ class DataPlotter(QWidget):
         if len(self._model.datasets()) == 0:
             return
         self.data_for_plotting.emit(self._model)
-        group = self._settings.group("dialogs")
-        try:
-            show_it = group.get("data_plotted")
-        except KeyError:
-            show_it = group.get_default("dialogs", "data_plotted")
-        if show_it != "False":
-            data_plotted_box = QMessageBox.information(
-                self,
-                "Datasets plotted!",
-                "Your results have been plotted in the currently active plot in the next tab (called 'Plot Holder').\n"
-                "Should this message be shown every time this happens?",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                QMessageBox.StandardButton.Yes,
-            )
-            if data_plotted_box == QMessageBox.StandardButton.No:
-                group = self._settings.group("dialogs")
-                group.set("data_plotted", "False")
 
     @Slot(object)
     def accept_data(self, data_set):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
+    QGroupBox,
     QHBoxLayout,
     QLabel,
     QMessageBox,
@@ -71,17 +72,25 @@ class DataPlotter(QWidget):
     def create_buttons(self) -> QWidget:
         button_bar = QWidget(self)
         button_layout = QVBoxLayout(button_bar)
-        buttons = [
-            ("New empty plot", self.new_plot),
-            ("New empty text view", self.new_text),
-            ("Send data to plotter", self.plot_data),
-            ("Clear data selection", self.clear),
-        ]
-        for name, function in buttons:
-            button = QPushButton(name, button_bar)
-            button_layout.addWidget(button)
-            if function is not None:
-                button.clicked.connect(function)
+        button_groups = {
+            "Empty plot creation": [
+                ("New empty plot", self.new_plot),
+                ("New empty text view", self.new_text),
+            ],
+            "Current data selection": [
+                ("Send data to plotter", self.plot_data),
+                ("Clear data selection", self.clear),
+            ],
+        }
+        for group_name, buttons in button_groups.items():
+            subgroup = QGroupBox(group_name, button_bar)
+            sublayout = QVBoxLayout(subgroup)
+            for name, function in buttons:
+                button = QPushButton(name, button_bar)
+                sublayout.addWidget(button)
+                if function is not None:
+                    button.clicked.connect(function)
+            button_layout.addWidget(subgroup)
         return button_bar
 
     def create_preview(self) -> QWidget:
@@ -90,15 +99,24 @@ class DataPlotter(QWidget):
         self.target_label = QLabel("Target plot in next tab.")
         self.target_label.setWordWrap(True)
         previewer_layout.addWidget(self.target_label)
+        info_label = QLabel(
+            f"Contents of the currently selected {self.plotter_type} in the next tab:"
+        )
+        previewer_layout.addWidget(info_label)
+        self.preview_table = QTableView(previewer)
+        previewer_layout.addWidget(self.preview_table)
         self.update_target_plot_label()
         return previewer
 
     def update_target_plot_label(self):
         self.target_label.setText(
-            "Datasets will be sent to the <b>Plot Holder</b> tab.<br>"
+            "Datasets listed above will be sent to the <b>Plot Holder</b> tab.<br>"
             f"They will appear in tab {self.tab_index + 1} out of {self.tab_count}.<br>"
             f"It is a {self.plotter_type}, currently containing {self.dataset_count} datasets."
         )
+        for col_num in range(4, 10):
+            self.preview_table.hideColumn(col_num)
+        self.preview_table.resizeColumnsToContents()
 
     @Slot(int)
     def new_target_plot_index(self, new_index: int):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
@@ -33,7 +33,7 @@ from MDANSE_GUI.Tabs.Models.PlottingContext import (
     SingleDataset,
 )
 
-WIDGET_DESCRIPTIONS = {"DataWidget": "text viewer", "PlotWidget": "plotter"}
+WIDGET_DESCRIPTIONS = {"DataWidget": "text view", "PlotWidget": "plot view"}
 
 
 class DataPlotter(QWidget):
@@ -52,19 +52,24 @@ class DataPlotter(QWidget):
     def __init__(self, *args, unit_lookup=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.tab_index, self.tab_count = 0, 1
+        self.tab_name = "Preview"
         self.dataset_count = 0
         self.plotter_type = "PlotWidget"
         self._unit_lookup = unit_lookup
         layout = QVBoxLayout(self)
         control_bar = QWidget(self)
-        bar_layout = QHBoxLayout(control_bar)
+        lower_bar_layout = QHBoxLayout(control_bar)
+        selection_bar = QWidget(self)
+        upper_bar_layout = QHBoxLayout(selection_bar)
         self._selection_viewer = QTableView(self)
-        layout.addWidget(self._selection_viewer)
-        layout.addWidget(control_bar)
-        button_bar = self.create_buttons()
-        bar_layout.addWidget(button_bar)
+        button_bar1, button_bar2 = self.create_buttons()
         plotter_preview = self.create_preview()
-        bar_layout.addWidget(plotter_preview)
+        layout.addWidget(selection_bar)
+        layout.addWidget(control_bar)
+        upper_bar_layout.addWidget(button_bar2)
+        upper_bar_layout.addWidget(self._selection_viewer)
+        lower_bar_layout.addWidget(button_bar1)
+        lower_bar_layout.addWidget(plotter_preview)
         self._model = PlottingContext(
             unit_lookup=self._unit_lookup,
         )
@@ -73,8 +78,6 @@ class DataPlotter(QWidget):
 
     def create_buttons(self) -> QWidget:
         self._plotting_button_reference = None
-        button_bar = QWidget(self)
-        button_layout = QVBoxLayout(button_bar)
         button_groups = {
             "Empty plot creation": [
                 ("New empty plot", self.new_plot),
@@ -85,7 +88,10 @@ class DataPlotter(QWidget):
                 ("Clear data selection", self.clear),
             ],
         }
+        bars = []
         for group_name, buttons in button_groups.items():
+            button_bar = QWidget(self)
+            button_layout = QVBoxLayout(button_bar)
             subgroup = QGroupBox(group_name, button_bar)
             sublayout = QVBoxLayout(subgroup)
             for name, function in buttons:
@@ -96,7 +102,8 @@ class DataPlotter(QWidget):
                 if name == "Send data to plotter":
                     self._plotting_button_reference = button
             button_layout.addWidget(subgroup)
-        return button_bar
+            bars.append(button_bar)
+        return bars
 
     def create_preview(self) -> QWidget:
         previewer = QWidget(self)
@@ -120,8 +127,8 @@ class DataPlotter(QWidget):
         )
         self.target_label.setText(
             "Datasets listed above will be sent to the <b>Plot Holder</b> tab.<br>"
-            f"They will appear in tab {self.tab_index + 1} out of {self.tab_count}.<br>"
-            f"It is a {output_widget}, "
+            f"They will appear in '{self.tab_name}' in the Plot Holder tab.<br>"
+            f"'{self.tab_name}' is a {output_widget}, "
             f"currently containing {self.dataset_count} datasets."
         )
         self._plotting_button_reference.setText(f"Send data to {output_widget}")
@@ -132,6 +139,11 @@ class DataPlotter(QWidget):
     @Slot(int)
     def new_target_plot_index(self, new_index: int):
         self.tab_index = new_index
+        self.update_target_plot_label()
+
+    @Slot(str)
+    def new_target_plot_name(self, new_name: str):
+        self.tab_name = new_name
         self.update_target_plot_label()
 
     @Slot(int)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QHBoxLayout,
+    QLabel,
     QMessageBox,
     QPushButton,
     QTableView,
@@ -47,30 +48,48 @@ class DataPlotter(QWidget):
 
     def __init__(self, *args, unit_lookup=None, **kwargs):
         super().__init__(*args, **kwargs)
-
+        self.tab_index, self.tab_count = 1, 1
         self._unit_lookup = unit_lookup
         layout = QVBoxLayout(self)
-        button_bar = QWidget(self)
-        button_layout = QHBoxLayout(button_bar)
+        control_bar = QWidget(self)
+        bar_layout = QHBoxLayout(control_bar)
         self._selection_viewer = QTableView(self)
         layout.addWidget(self._selection_viewer)
-        layout.addWidget(button_bar)
+        layout.addWidget(control_bar)
+        button_bar = self.create_buttons()
+        bar_layout.addWidget(button_bar)
+        plotter_preview = self.create_preview()
+        bar_layout.addWidget(plotter_preview)
+        self._model = PlottingContext(
+            unit_lookup=self._unit_lookup,
+        )
+        self._selection_viewer.setModel(self._model)
+        self.hide_columns()
+
+    def create_buttons(self) -> QWidget:
+        button_bar = QWidget(self)
+        button_layout = QVBoxLayout(button_bar)
         buttons = [
-            ("Plot Data", self.plot_data),
-            ("Clear", self.clear),
-            ("New Plot", self.new_plot),
-            ("New Data View (Text)", self.new_text),
+            ("New empty plot", self.new_plot),
+            ("New empty text view", self.new_text),
+            ("Send data to plotter", self.plot_data),
+            ("Clear data selection", self.clear),
         ]
         for name, function in buttons:
             button = QPushButton(name, button_bar)
             button_layout.addWidget(button)
             if function is not None:
                 button.clicked.connect(function)
-        self._model = PlottingContext(
-            unit_lookup=self._unit_lookup,
+        return button_bar
+
+    def create_preview(self) -> QWidget:
+        previewer = QWidget(self)
+        previewer_layout = QVBoxLayout(previewer)
+        self.target_label = QLabel(
+            f"Datasets will be sent to plotter tab {self.tab_index} out of {self.tab_count}"
         )
-        self._selection_viewer.setModel(self._model)
-        self.hide_columns()
+        self.target_label.setWordWrap(True)
+        previewer_layout.addWidget(self.target_label)
 
     @Slot(object)
     def add_dataset(self, dataset: SingleDataset):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/DataPlotter.py
@@ -33,6 +33,8 @@ from MDANSE_GUI.Tabs.Models.PlottingContext import (
     SingleDataset,
 )
 
+WIDGET_DESCRIPTIONS = {"DataWidget": "text viewer", "PlotWidget": "plotter"}
+
 
 class DataPlotter(QWidget):
     """Part of PlotCreator which sends datasets to the plotter.
@@ -70,6 +72,7 @@ class DataPlotter(QWidget):
         self.hide_columns()
 
     def create_buttons(self) -> QWidget:
+        self._plotting_button_reference = None
         button_bar = QWidget(self)
         button_layout = QVBoxLayout(button_bar)
         button_groups = {
@@ -90,6 +93,8 @@ class DataPlotter(QWidget):
                 sublayout.addWidget(button)
                 if function is not None:
                     button.clicked.connect(function)
+                if name == "Send data to plotter":
+                    self._plotting_button_reference = button
             button_layout.addWidget(subgroup)
         return button_bar
 
@@ -99,21 +104,27 @@ class DataPlotter(QWidget):
         self.target_label = QLabel("Target plot in next tab.")
         self.target_label.setWordWrap(True)
         previewer_layout.addWidget(self.target_label)
-        info_label = QLabel(
+        self.info_label = QLabel(
             f"Contents of the currently selected {self.plotter_type} in the next tab:"
         )
-        previewer_layout.addWidget(info_label)
+        previewer_layout.addWidget(self.info_label)
         self.preview_table = QTableView(previewer)
         previewer_layout.addWidget(self.preview_table)
         self.update_target_plot_label()
         return previewer
 
     def update_target_plot_label(self):
+        output_widget = WIDGET_DESCRIPTIONS.get(self.plotter_type, "data visualiser")
+        self.info_label.setText(
+            f"Contents of the currently selected {output_widget} in the next tab:"
+        )
         self.target_label.setText(
             "Datasets listed above will be sent to the <b>Plot Holder</b> tab.<br>"
             f"They will appear in tab {self.tab_index + 1} out of {self.tab_count}.<br>"
-            f"It is a {self.plotter_type}, currently containing {self.dataset_count} datasets."
+            f"It is a {output_widget}, "
+            f"currently containing {self.dataset_count} datasets."
         )
+        self._plotting_button_reference.setText(f"Send data to {output_widget}")
         for col_num in range(4, 10):
             self.preview_table.hideColumn(col_num)
         self.preview_table.resizeColumnsToContents()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
@@ -34,6 +34,10 @@ class PlotHolder(QTabWidget):
 
     error = Signal(str)
     new_entry = Signal()
+    current_tab_index = Signal(int)
+    current_tab_count = Signal(int)
+    datasets_in_plot = Signal(int)
+    plot_widget_type = Signal(str)
 
     def __init__(self, *args, unit_lookup=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -75,6 +79,7 @@ class PlotHolder(QTabWidget):
         self._plotter.append(plotter)
         self.setCurrentIndex(tab_id)
         self.new_entry.emit()
+        self.send_plot_info()
         return tab_id
 
     @Slot(str)
@@ -91,6 +96,7 @@ class PlotHolder(QTabWidget):
         self._plotter.append(plotter)
         self.setCurrentIndex(tab_id)
         self.new_entry.emit()
+        self.send_plot_info()
         return tab_id
 
     @Slot(int)
@@ -108,9 +114,10 @@ class PlotHolder(QTabWidget):
             self._current_id = valid_id_values[0]
             self.setCurrentIndex(self._current_id)
         self.removeTab(tab_id)
+        self.send_plot_info()
 
     @property
-    def model(self):
+    def model(self) -> PlottingContext:
         tab_id = self.currentIndex()
         try:
             pc = self._context[tab_id]
@@ -122,7 +129,7 @@ class PlotHolder(QTabWidget):
             return pc
 
     @property
-    def plotter(self):
+    def plotter(self) -> DataWidget:
         tab_id = self.currentIndex()
         try:
             return self._plotter[tab_id]
@@ -164,3 +171,11 @@ class PlotHolder(QTabWidget):
         except Exception:
             LOG.error("Plotting failed: %s", traceback.format_exc())
             plotter.plot_blank()
+        else:
+            self.send_plot_info()
+
+    def send_plot_info(self):
+        self.current_tab_count.emit(len(self._plotter))
+        self.current_tab_index.emit(self.currentIndex())
+        self.datasets_in_plot.emit(self.model.rowCount())
+        self.plot_widget_type.emit(type(self.plotter).__name__)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/PlotHolder.py
@@ -35,6 +35,7 @@ class PlotHolder(QTabWidget):
     error = Signal(str)
     new_entry = Signal()
     current_tab_index = Signal(int)
+    current_tab_name = Signal(str)
     current_tab_count = Signal(int)
     datasets_in_plot = Signal(int)
     plot_widget_type = Signal(str)
@@ -65,7 +66,7 @@ class PlotHolder(QTabWidget):
     @Slot(str)
     def new_plot(self, tab_name: str) -> int:
         if not tab_name:
-            tab_name = f"New plot {self._last_number}"
+            tab_name = f"Plot {self._last_number}"
             self._last_number += 1
         plotting_context = PlottingContext(
             unit_lookup=self._unit_lookup,
@@ -83,8 +84,8 @@ class PlotHolder(QTabWidget):
         return tab_id
 
     @Slot(str)
-    def new_text(self, ignored_name: str) -> int:
-        tab_name = f"New text view {self._last_number}"
+    def new_text(self, _: str) -> int:
+        tab_name = f"Text view {self._last_number}"
         self._last_number += 1
         plotting_context = PlottingContext(unit_lookup=self._unit_lookup)
         plotting_context.needs_an_update.connect(self.update_plot)
@@ -177,5 +178,6 @@ class PlotHolder(QTabWidget):
     def send_plot_info(self):
         self.current_tab_count.emit(len(self._plotter))
         self.current_tab_index.emit(self.currentIndex())
+        self.current_tab_name.emit(self.tabBar().tabText(self.currentIndex()))
         self.datasets_in_plot.emit(self.model.rowCount())
         self.plot_widget_type.emit(type(self.plotter).__name__)


### PR DESCRIPTION
**Description of work**
One of the weakest spots of the current plotting workflow in MDANSE_GUI is the one-way communication between "Plot Creator" and "Plot Holder". This PR is meant to give the users a chance to see that their actions in "Plot Creator" tab had some effect on "Plot Holder", without the need to switch between the two.

**Fixes**
1. Plot creator buttons have more accurate labels,
2. Plot creator contains text informing the user about the current plotting tab in "Plot Holder".
3. Plot creator contains a preview of the datasets in the current plot in "Plot Holder".

**To test**
Try to create some plots and text views out of .mda files. Check if you find that the information shown in "Plot Creator" helps you understand what is happening in the "Plot Holder" tab.
