### PR TITLE
Improve index grouping to prevent zero-size groups

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -116,15 +116,18 @@ class DynamicIncoherentStructureFactor(IJob):
         )
         n_proc = self.configuration["running_mode"].get("slots", 1)
 
+        self._nFrames = self.configuration["frames"]["n_frames"]
+
         self.grouped_indices = group_atom_indices(
-            self.trajectory, n_proc=n_proc, memory_scale_factor=vectors_per_shell
+            self.trajectory,
+            self._nFrames,
+            n_proc=n_proc,
+            memory_scale_factor=8 * vectors_per_shell,
         )
         self.numberOfSteps = len(self.grouped_indices)
 
         self._using_lattice_vectors = self.configuration["q_vectors"]["is_lattice"]
         self._nQShells = self.configuration["q_vectors"]["n_shells"]
-
-        self._nFrames = self.configuration["frames"]["n_frames"]
 
         self._instrResolution = self.configuration["instrument_resolution"]
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -120,9 +120,9 @@ class DynamicIncoherentStructureFactor(IJob):
 
         self.grouped_indices = group_atom_indices(
             self.trajectory,
-            self._nFrames,
+            self.configuration["frames"]["number"],
             n_proc=n_proc,
-            memory_scale_factor=8 * vectors_per_shell,
+            memory_scale_factor=6 * vectors_per_shell,
         )
         self.numberOfSteps = len(self.grouped_indices)
 

--- a/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+import os
 from itertools import pairwise
 from typing import TYPE_CHECKING
 
@@ -24,7 +25,10 @@ from more_itertools import chunked_even
 if TYPE_CHECKING:
     from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
-CHUNK_SIZE_LIMIT = 2**29  # 512 MB memory limit per process for now
+mb_ram_per_process = os.environ.get("MDANSE_RAM_PER_PROCESS", "512")
+CHUNK_SIZE_LIMIT = (
+    int(mb_ram_per_process) * 2**20
+)  # 512 MB memory limit per process for now
 
 from MDANSE.util_types import FloatArray
 
@@ -108,6 +112,84 @@ def atomic_trajectory_many(
     return trajectory
 
 
+def get_natoms_per_step(
+    chunk_size: int,
+    trajectory_size: tuple[int, int],
+    scale_factor: float,
+    upper_limit: int,
+) -> int:
+    """Determine how many atom indices should be used in a single analysis run step.
+
+    This considers trajectory size, trajectory chunking, and expected memory requirements.
+
+    Parameters
+    ----------
+    chunk_size : int
+        Number of atoms per chunk in the trajectory file.
+    trajectory_size : tuple[int, int]
+        Total trajectory dimensions in the form of (n_frames, n_atoms).
+    scale_factor : float
+        A job-dependent scaling factor estimating the memory needs per atom.
+    upper_limit : int
+        Total allowed memory per process.
+
+    Returns
+    -------
+    int
+        Number of atom indices in a single group used by an analysis step.
+    """
+    if chunk_size < 0:
+        max_chunk_size = upper_limit // (trajectory_size[0] * 3 * 8 * scale_factor)
+    else:
+        predicted_memory = trajectory_size[0] * chunk_size * 3 * 8 * scale_factor
+        downscale_factor = np.ceil(predicted_memory / upper_limit)
+        max_chunk_size = chunk_size // downscale_factor
+    return max(max_chunk_size, 1)
+
+
+def split_selected_atoms(
+    selected_atoms: set[int],
+    traj_chunk_size: int,
+    traj_size: tuple[int, int],
+    max_atoms_per_group: int,
+    min_group_count: int,
+) -> list[set[int]]:
+    """Group atom indices into sets, each set contained in a single trajectory chunk.
+
+    Parameters
+    ----------
+    selected_atoms : set[int]
+        All atom indices included in the current selection.
+    traj_chunk_size : int
+        Number of atoms per chunk in the trajectory.
+    traj_size : tuple[int, int]
+        Total trajectory size as (n_frames, n_atoms).
+    max_atoms_per_group : int
+        Limit on number of atoms per group, based on memory requirements.
+    min_group_count : int
+        Minimum number of index groups, based on number of processes.
+
+    Returns
+    -------
+    list[set[int]]
+        List of atom index sets, grouped to belong to a single chunk.
+    """
+    if traj_chunk_size < 0:
+        chunk_limits = np.array([0, traj_size[1]])
+    else:
+        chunk_limits = np.concatenate(
+            [np.arange(0, traj_size[1], traj_chunk_size), [traj_size[1]]]
+        )
+    initial_sets = [
+        sorted(selected_atoms.intersection(range(*chunk_block)))
+        for chunk_block in pairwise(chunk_limits)
+    ]
+    initial_sets = [index_set for index_set in initial_sets if len(index_set)]
+    return balance_index_groups(
+        initial_sets, max_size=int(max_atoms_per_group), min_count=min_group_count
+    )
+
+
 def group_atom_indices(
     traj_instance: Trajectory,
     n_proc: int = 1,
@@ -146,28 +228,12 @@ def group_atom_indices(
     selected_indices = set(traj_instance.atom_indices)
     total_dimensions = traj_instance.variable("position").shape
     chunk_size = traj_instance.chunk_size(array_name="position")
-    if chunk_size < 0:
-        max_chunk_size = size_limit // (
-            total_dimensions[0] * 3 * 8 * memory_scale_factor
-        )
-        chunk_limits = np.array([0, total_dimensions[1]])
-    else:
-        predicted_memory = (
-            total_dimensions[0] * chunk_size * 3 * 8 * memory_scale_factor
-        )
-        downscale_factor = np.ceil(predicted_memory / size_limit)
-        max_chunk_size = chunk_size // downscale_factor
-        chunk_limits = np.concatenate(
-            [np.arange(0, total_dimensions[1], chunk_size), [total_dimensions[1]]]
-        )
-    min_chunk_count = n_proc
-    initial_sets = [
-        sorted(selected_indices.intersection(range(*chunk_block)))
-        for chunk_block in pairwise(chunk_limits)
-    ]
-    initial_sets = [index_set for index_set in initial_sets if len(index_set)]
-    return balance_index_groups(
-        initial_sets, max_size=int(max_chunk_size), min_count=min_chunk_count
+    max_group_size = get_natoms_per_step(
+        chunk_size, total_dimensions, memory_scale_factor, size_limit
+    )
+    min_group_count = min(n_proc, len(selected_indices))
+    return split_selected_atoms(
+        selected_indices, chunk_size, total_dimensions, max_group_size, min_group_count
     )
 
 
@@ -210,8 +276,13 @@ def balance_index_groups(
     list[set[int]]
         List of index sets after splitting into smaller sets.
     """
-    while any(len(ind_set) > max_size for ind_set in index_sets):
+    while (
+        any(len(ind_set) > max_size for ind_set in index_sets)
+        or len(index_sets) < min_count
+    ):
         index_sets = split_index_sets(index_sets, max_size)
+        if max_size == 1:
+            break
         if len(index_sets) < min_count:
-            max_size = 3 * max_size // 4
+            max_size = max(3 * max_size // 4, 1)
     return index_sets

--- a/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
@@ -25,7 +25,7 @@ from more_itertools import chunked_even
 if TYPE_CHECKING:
     from MDANSE.MolecularDynamics.Trajectory import Trajectory
 
-mb_ram_per_process = os.environ.get("MDANSE_RAM_PER_PROCESS", "512")
+mb_ram_per_process = os.environ.get("MDANSE_MAX_RAM_PER_PROCESS", "512")
 CHUNK_SIZE_LIMIT = (
     int(mb_ram_per_process) * 2**20
 )  # 512 MB memory limit per process for now
@@ -192,6 +192,8 @@ def split_selected_atoms(
 
 def group_atom_indices(
     traj_instance: Trajectory,
+    n_frames: int,
+    *,
     n_proc: int = 1,
     memory_scale_factor: int = 10,
     size_limit: int = CHUNK_SIZE_LIMIT,
@@ -226,7 +228,7 @@ def group_atom_indices(
         List of atom index set, each set containing indices from a single HDF5 chunk
     """
     selected_indices = set(traj_instance.atom_indices)
-    total_dimensions = traj_instance.variable("position").shape
+    total_dimensions = (n_frames, traj_instance.variable("position").shape[1])
     chunk_size = traj_instance.chunk_size(array_name="position")
     max_group_size = get_natoms_per_step(
         chunk_size, total_dimensions, memory_scale_factor, size_limit

--- a/MDANSE/Tests/UnitTests/test_index_grouping.py
+++ b/MDANSE/Tests/UnitTests/test_index_grouping.py
@@ -1,0 +1,77 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import numpy as np
+import pytest
+
+from MDANSE.MolecularDynamics.TrajectoryUtils import (
+    balance_index_groups,
+    get_natoms_per_step,
+    split_index_sets,
+    split_selected_atoms,
+)
+
+
+@pytest.fixture(scope="module")
+def selected_indices():
+    all_indices = set(range(20000))
+    all_indices -= set(range(400, 600))
+    all_indices -= set(range(10000, 20000, 7))
+    return all_indices
+
+
+@pytest.mark.parametrize("chunk_size", [-1, 128, 2000])
+@pytest.mark.parametrize(
+    "trajectory_size", [(500, 20000), (10000, 20000), (100000, 20000)]
+)
+@pytest.mark.parametrize("scale_factor", [1, 10, 1000])
+@pytest.mark.parametrize("size_limit", [2**24, 2**28, 2**32])
+def test_natoms_per_step_is_not_zero(
+    chunk_size, trajectory_size, scale_factor, size_limit
+):
+    n_atoms_per_step = get_natoms_per_step(
+        chunk_size, trajectory_size, scale_factor, size_limit
+    )
+    assert n_atoms_per_step > 0
+
+
+@pytest.mark.parametrize("chunk_size", [-1, 128, 2000])
+@pytest.mark.parametrize(
+    "trajectory_size", [(500, 20000), (10000, 20000), (100000, 20000)]
+)
+@pytest.mark.parametrize("scale_factor", [1, 10, 1000])
+@pytest.mark.parametrize("size_limit", [2**24, 2**28, 2**32])
+def test_groups_are_not_empty(
+    selected_indices, chunk_size, trajectory_size, scale_factor, size_limit
+):
+    n_atoms_per_step = get_natoms_per_step(
+        chunk_size, trajectory_size, scale_factor, size_limit
+    )
+    grouped_indices = split_selected_atoms(
+        selected_indices, chunk_size, trajectory_size, n_atoms_per_step, 8
+    )
+    assert all(len(grp) for grp in grouped_indices)
+    assert all(len(grp) <= n_atoms_per_step for grp in grouped_indices)
+
+
+@pytest.mark.parametrize("max_size", [1000, 100, 10, 1])
+@pytest.mark.parametrize("min_count", [1, 10, 100, 1000])
+def test_group_balancing_reaches_target(selected_indices, max_size, min_count):
+    total_index_count = len(np.ravel(selected_indices))
+    final_groups = balance_index_groups([selected_indices], max_size, min_count)
+    assert all(len(grp) for grp in final_groups)
+    assert all(len(grp) <= max_size for grp in final_groups)
+    assert len(final_groups) >= min(total_index_count, min_count)


### PR DESCRIPTION
**Description of work**
The `group_atom_indices` function is split into smaller functions that can be tested better in the unit tests.

Additional checks are introduces to make sure that a usable grouping is returned also for large trajectories.

closes #1257

**Fixes**
1. Unit tests added for `group_atom_indices` and related functions.
2. An environment variable 'MDANSE_RAM_PER_PROCESS` can be used to increase the amount of memory per process that we aim for when grouping atoms. The default value is 512 (give in MB). **Note** there is no mechanism to guarantee that the right amount of memory will be used in the end. Also, it requires us to set the memory scaling factor correctly in the code of each analysis job, based on how much additional memory will be allocated by the job per atom.

**To test**
All tests should pass.
Try running the DISF analysis for a large trajectory. Check if memory use can be tuned using the `MDANSE_RAM_PER_PROCESS` environment variable.
