### PR TITLE
Use platform.platform output in version summary

### DIFF
--- a/MDANSE/Src/MDANSE/Core/Platform.py
+++ b/MDANSE/Src/MDANSE/Core/Platform.py
@@ -31,8 +31,7 @@ def version_summary(show_backend: bool = True, show_gui: bool = True) -> str:
     else:
         GUI_VERSION = MDANSE_GUI.__version__
     BACKEND_VERSION = MDANSE.__version__
-    sys_info = platform.uname()
-    version = f"Platform: {sys_info.system} {sys_info.release} on {sys_info.machine}\n"
+    version = f"Platform string: {platform.platform()}\n"
     version += (
         f"Python {platform.python_version()} ({platform.python_implementation()}),"
         f" {platform.python_build()[1]}\n"


### PR DESCRIPTION
**Description of work**
Instead of trying to put OS version information together, we just use a string generated by `platform.platform()`.

Hopefully this output will cause less confusion in respect to the OS version running on the user's computer.

closes #1256

**Fixes**
1. Use `platform.platform` in `version_summary`.

**To test**
Run `mdanse --version`.
Run `mdanse_gui` and open "Help -> Version information".
They should both show the same string containing OS version and CPU architecture information.