### PR TITLE
Add extra information to output files

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
@@ -100,6 +100,17 @@ def check_metadata(hdf5_file: h5py.File) -> dict[str, str]:
 
 
 def create_metadata_datasets(job: IJob, meta: h5py.Group):
+    """Put information from the input job into the input HDF5 data group.
+
+    This function is used both by converters and analysis tasks.
+
+    Parameters
+    ----------
+    job : IJob
+        An instance of an MDANSE analysis job or converter.
+    meta : h5py.Group
+        The HDF5 data group where the datasets will be created.
+    """
     string_dt = h5py.special_dtype(vlen=str)
     meta.create_dataset("task_name", (1,), data=type(job).__name__, dtype=string_dt)
     meta.create_dataset(

--- a/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
@@ -128,7 +128,7 @@ def create_metadata_datasets(job: IJob, meta: h5py.Group):
             "job_state",
             (1,),
             dtype=string_dt,
-            data=job_status_text_summary(job._status._state),
+            data=job_status_text_summary(job._status._state, for_output_file=True),
         )
 
 
@@ -196,8 +196,6 @@ class HDFFormat(IFormat):
         """
         if extension is None:
             extension = cls.extensions[0]
-
-        string_dt = h5py.special_dtype(vlen=str)
 
         if in_memory:
             outputFile = h5py.File.in_memory()

--- a/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
+++ b/MDANSE/Src/MDANSE/Framework/Formats/HDFFormat.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -23,7 +24,9 @@ import h5py
 
 import MDANSE
 from MDANSE import PLATFORM
+from MDANSE.Core.Platform import version_summary
 from MDANSE.Framework.Formats.IFormat import IFormat
+from MDANSE.IO.IOUtils import job_status_text_summary
 from MDANSE.MLogging import LOG
 
 if TYPE_CHECKING:
@@ -96,6 +99,39 @@ def check_metadata(hdf5_file: h5py.File) -> dict[str, str]:
     return meta_dict
 
 
+def create_metadata_datasets(job: IJob, meta: h5py.Group):
+    string_dt = h5py.special_dtype(vlen=str)
+    meta.create_dataset("task_name", (1,), data=type(job).__name__, dtype=string_dt)
+    meta.create_dataset(
+        "MDANSE_version",
+        (1,),
+        data=MDANSE.__version__,
+        dtype=string_dt,
+    )
+    meta.create_dataset(
+        "version_summary",
+        (1,),
+        data=version_summary(),
+        dtype=string_dt,
+    )
+
+    inputs = job.output_configuration()
+
+    if inputs is not None:
+        LOG.info(inputs)
+        dgroup = meta.create_group("inputs")
+        for key, value in inputs.items():
+            dgroup.create_dataset(key, (1,), data=value, dtype=string_dt)
+
+    with suppress(AttributeError):
+        meta.create_dataset(
+            "job_state",
+            (1,),
+            dtype=string_dt,
+            data=job_status_text_summary(job._status._state),
+        )
+
+
 def write_metadata(job: IJob, output_file: h5py.File):
     """Save parameters of IJob in the output file.
 
@@ -107,23 +143,8 @@ def write_metadata(job: IJob, output_file: h5py.File):
         an open HDF5 file, typically .mdt
 
     """
-    string_dt = h5py.special_dtype(vlen=str)
     meta = output_file.create_group("metadata")
-    meta.create_dataset("task_name", (1,), data=type(job).__name__, dtype=string_dt)
-    meta.create_dataset(
-        "MDANSE_version",
-        (1,),
-        data=MDANSE.__version__,
-        dtype=string_dt,
-    )
-
-    inputs = job.output_configuration()
-
-    if inputs is not None:
-        LOG.info(inputs)
-        dgroup = meta.create_group("inputs")
-        for key, value in inputs.items():
-            dgroup.create_dataset(key, (1,), data=value, dtype=string_dt)
+    create_metadata_datasets(job, meta)
 
 
 @IFormat.register("HDFFormat")
@@ -201,25 +222,7 @@ class HDFFormat(IFormat):
             outputFile.attrs["header"] = header
 
         meta = outputFile.create_group("metadata")
-        if run_instance is not None:
-            meta.create_dataset(
-                "task_name",
-                (1,),
-                data=type(run_instance).__name__,
-                dtype=string_dt,
-            )
-            meta.create_dataset(
-                "MDANSE_version",
-                (1,),
-                data=MDANSE.__version__,
-                dtype=string_dt,
-            )
-
-            if inputs := run_instance.output_configuration():
-                LOG.info(inputs)
-                dgroup = meta.create_group("inputs")
-                for key, value in inputs.items():
-                    dgroup.create_dataset(key, (1,), data=value, dtype=string_dt)
+        create_metadata_datasets(run_instance, meta)
 
         # Loop over the OutputVariable instances to write.
 

--- a/MDANSE/Src/MDANSE/IO/IOUtils.py
+++ b/MDANSE/Src/MDANSE/IO/IOUtils.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from collections import UserDict
 from collections.abc import Callable, Collection, Iterable, Iterator, Sequence
 from enum import Enum
@@ -508,3 +509,39 @@ def unused_standard_output_filename(
     )
 
     return Path(name) if name else None
+
+
+def sec_fmt(time: float) -> str:
+    """Format a time in seconds sensibly."""
+    if not isinstance(time, float):
+        return "N/A"
+
+    hr, min = divmod(time, 3600)
+    min, sec = divmod(min, 60)
+
+    if hr:
+        return f"{hr:.0f}hr {min:.0f}m {sec:.0f}s"
+    if min:
+        return f"{min:.0f}m {sec:.0f}s"
+
+    return f"{sec:.0f}s"
+
+
+def job_status_text_summary(job) -> str:
+    try:
+        comp_time = (job.n_steps - job.current_step) / job.rate
+    except (TypeError, ZeroDivisionError):
+        comp_time = "N/A"
+
+    elapsed_time = job.end - job.start if job.end else time.time() - job.start
+
+    return f"""
+Status:
+  Current state: {job.state.name.title()}
+  Percent complete: {job.progress}
+  Percent rate: {job.pct_rate} %/s
+  Steps: {job.current_step}/{job.n_steps}
+  Step rate: {job.rate} steps/s
+  Elapsed time: {sec_fmt(elapsed_time)}
+  Estimated remaining time: {sec_fmt(comp_time)}
+"""

--- a/MDANSE/Src/MDANSE/IO/IOUtils.py
+++ b/MDANSE/Src/MDANSE/IO/IOUtils.py
@@ -527,15 +527,24 @@ def sec_fmt(time: float) -> str:
     return f"{sec:.0f}s"
 
 
-def job_status_text_summary(job) -> str:
+def job_status_text_summary(job, *, for_output_file: bool = False) -> str:
     try:
         comp_time = (job.n_steps - job.current_step) / job.rate
     except (TypeError, ZeroDivisionError):
         comp_time = "N/A"
 
     elapsed_time = job.end - job.start if job.end else time.time() - job.start
-
-    return f"""
+    if for_output_file:
+        return f"""
+Status:
+  Percent complete: {job.progress}
+  Percent rate: {job.pct_rate} %/s
+  Steps: {job.current_step}/{job.n_steps}
+  Step rate: {job.rate} steps/s
+  Elapsed time: {sec_fmt(elapsed_time)}
+"""
+    else:
+        return f"""
 Status:
   Current state: {job.state.name.title()}
   Percent complete: {job.progress}

--- a/MDANSE/Src/MDANSE/IO/IOUtils.py
+++ b/MDANSE/Src/MDANSE/IO/IOUtils.py
@@ -31,6 +31,9 @@ from more_itertools import first_true, last, take, value_chain
 
 from MDANSE.MLogging import LOG
 
+if TYPE_CHECKING:
+    from MDANSE.Framework.Jobs.JobStatus import JobInfo
+
 K = TypeVar("K", str, bytes)
 V = TypeVar("V")
 
@@ -527,30 +530,37 @@ def sec_fmt(time: float) -> str:
     return f"{sec:.0f}s"
 
 
-def job_status_text_summary(job, *, for_output_file: bool = False) -> str:
+def job_status_text_summary(jobinf: JobInfo, *, for_output_file: bool = False) -> str:
+    """Return run details as a formatted string.
+
+    When writing the run information into an output file, the for_output_file
+    can be used to skip the parts of the output that are not relevant
+    to a completed task (e.g. estimated remaining time.)"""
     try:
-        comp_time = (job.n_steps - job.current_step) / job.rate
+        comp_time = (jobinf.n_steps - jobinf.current_step) / jobinf.rate
     except (TypeError, ZeroDivisionError):
         comp_time = "N/A"
 
-    elapsed_time = job.end - job.start if job.end else time.time() - job.start
+    elapsed_time = (
+        jobinf.end - jobinf.start if jobinf.end else time.time() - jobinf.start
+    )
     if for_output_file:
         return f"""
 Status:
-  Percent complete: {job.progress}
-  Percent rate: {job.pct_rate} %/s
-  Steps: {job.current_step}/{job.n_steps}
-  Step rate: {job.rate} steps/s
+  Percent complete: {jobinf.progress}
+  Percent rate: {jobinf.pct_rate} %/s
+  Steps: {jobinf.current_step}/{jobinf.n_steps}
+  Step rate: {jobinf.rate} steps/s
   Elapsed time: {sec_fmt(elapsed_time)}
 """
     else:
         return f"""
 Status:
-  Current state: {job.state.name.title()}
-  Percent complete: {job.progress}
-  Percent rate: {job.pct_rate} %/s
-  Steps: {job.current_step}/{job.n_steps}
-  Step rate: {job.rate} steps/s
+  Current state: {jobinf.state.name.title()}
+  Percent complete: {jobinf.progress}
+  Percent rate: {jobinf.pct_rate} %/s
+  Steps: {jobinf.current_step}/{jobinf.n_steps}
+  Step rate: {jobinf.rate} steps/s
   Elapsed time: {sec_fmt(elapsed_time)}
   Estimated remaining time: {sec_fmt(comp_time)}
 """

--- a/MDANSE/Src/MDANSE/IO/IOUtils.py
+++ b/MDANSE/Src/MDANSE/IO/IOUtils.py
@@ -544,6 +544,9 @@ def job_status_text_summary(jobinf: JobInfo, *, for_output_file: bool = False) -
     elapsed_time = (
         jobinf.end - jobinf.start if jobinf.end else time.time() - jobinf.start
     )
+    start_time_str = time.asctime(time.localtime(jobinf.start))
+    end_time_str = time.asctime(time.localtime(jobinf.end or time.time()))
+
     if for_output_file:
         return f"""
 Status:
@@ -552,6 +555,8 @@ Status:
   Steps: {jobinf.current_step}/{jobinf.n_steps}
   Step rate: {jobinf.rate} steps/s
   Elapsed time: {sec_fmt(elapsed_time)}
+  Started on: {start_time_str}
+  Finished on: {end_time_str}
 """
     else:
         return f"""
@@ -562,5 +567,6 @@ Status:
   Steps: {jobinf.current_step}/{jobinf.n_steps}
   Step rate: {jobinf.rate} steps/s
   Elapsed time: {sec_fmt(elapsed_time)}
+  Started on: {start_time_str}
   Estimated remaining time: {sec_fmt(comp_time)}
 """

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -27,7 +27,11 @@ from qtpy.QtCore import QMutex, QObject, Qt, QThread, QTimer, Signal, Slot
 from qtpy.QtGui import QStandardItem, QStandardItemModel
 
 from MDANSE.Framework.Converters import Converter
-from MDANSE.Framework.Jobs.JobStatus import JobInfo, JobStates
+from MDANSE.Framework.Jobs.JobStatus import (
+    JobInfo,
+    JobStates,
+)
+from MDANSE.IO.IOUtils import job_status_text_summary
 from MDANSE.MLogging import FMT, LOG
 from MDANSE_GUI.Subprocess.JobStatusProcess import JobCommunicator
 from MDANSE_GUI.Subprocess.Subprocess import Connection, Subprocess
@@ -143,47 +147,14 @@ class JobEntry(QObject):
         self._prog_item.setData(100, role=ProgressDelegate.progress_role + 1)
         self.handler = JobLogHandler()
 
-    @staticmethod
-    def _sec_fmt(time: float) -> str:
-        """Format a time in seconds sensibly."""
-        if not isinstance(time, float):
-            return "N/A"
-
-        hr, min = divmod(time, 3600)
-        min, sec = divmod(min, 60)
-
-        if hr:
-            return f"{hr:.0f}hr {min:.0f}m {sec:.0f}s"
-        if min:
-            return f"{min:.0f}m {sec:.0f}s"
-
-        return f"{sec:.0f}s"
-
     def text_summary(self) -> str:
         nl = "\n"
-
-        try:
-            comp_time = (self.job.n_steps - self.job.current_step) / self.job.rate
-        except (TypeError, ZeroDivisionError):
-            comp_time = "N/A"
-
-        if self.job.end:
-            elapsed_time = self.job.end - self.job.start
-        else:
-            elapsed_time = time.time() - self.job.start
 
         return f"""\
 Job type: {self._command}
 Parameters:
 {nl.join(" - {} = {}".format(*kv) for kv in self.parameters.items())}
-Status:
-  Current state: {self.job.state.name.title()}
-  Percent complete: {self.job.progress}
-  Percent rate: {self.job.pct_rate} %/s
-  Steps: {self.job.current_step}/{self.job.n_steps}
-  Step rate: {self.job.rate} steps/s
-  Elapsed time: {self._sec_fmt(elapsed_time)}
-  Estimated remaining time: {self._sec_fmt(comp_time)}
+{job_status_text_summary(self.job)}
 """
 
     def update_fields(self):

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -649,18 +649,16 @@ class PlotDataView(QTreeView):
         self.dataset_selected.emit(packet)
         if hasattr(mda_data_structure, "_metadata"):
             self.item_details.emit(
-                html.escape(
-                    "\n".join(
-                        f"{key}: {item}"
-                        for key, item in mda_data_structure._metadata.items()
-                    ),
+                "\n".join(
+                    f"<b>{key}</b>: " + html.escape(f"{item}")
+                    for key, item in mda_data_structure._metadata.items()
                 ),
             )
         else:
             try:
                 text += "\n"
                 for attr in mda_data_structure.attrs:
-                    text += f"{attr}: {mda_data_structure.attrs[attr]}\n"
+                    text += f"<b>{attr}</b>: {mda_data_structure.attrs[attr]}\n"
                 self.item_details.emit(html.escape(text))
             except Exception:
                 self.item_details.emit("No additional information included.")


### PR DESCRIPTION
**Description of work**
This PR adds platform information and job status summary to the metadata written into the output files (both .mdt and .mda).

closes #1262

**Fixes**
1. Write the output of version information (platform string, Python version) to the output files.
2. Write most of the job status (number of steps, elapsed time) to the output files.
3. Highlight entry names in file content preview.

**To test**
Run a trajectory converter. Check if platform information and run summary can be seen in the trajectory tab.
Run an analysis on the trajectory. Check if platform information and run summary can be seen in the plot creator tab.

Is any other important information missing in the output files?
