### PR TITLE
Set visibility to true on jobs with invisible parents

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/CoordinationNumber.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CoordinationNumber.py
@@ -46,6 +46,7 @@ class CoordinationNumber(DistanceHistogram):
     label = "Coordination Number"
 
     enabled = True
+    visible = True
     PREDICTORS = ("r_values",)
 
     category = (

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PairDistributionFunction.py
@@ -50,6 +50,7 @@ class PairDistributionFunction(DistanceHistogram):
     label = "Pair Distribution Function"
 
     enabled = True
+    visible = True
 
     category = (
         "Analysis",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/PositionCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/PositionCorrelationFunction.py
@@ -32,6 +32,7 @@ class PositionCorrelationFunction(CartesianCorrelationFunction):
     """
 
     enabled = True
+    visible = True
     label = "Position Correlation Function"
     CF_NAME = "pcf"
     CF_UNITS = "nm2"

--- a/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/StaticStructureFactor.py
@@ -40,6 +40,7 @@ class StaticStructureFactor(DistanceHistogram):
     label = "Static Structure Factor"
 
     enabled = True
+    visible = True
 
     category = (
         "Analysis",

--- a/MDANSE/Src/MDANSE/Framework/Jobs/VelocityCorrelationFunction.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/VelocityCorrelationFunction.py
@@ -33,6 +33,7 @@ class VelocityCorrelationFunction(CartesianCorrelationFunction):
     """
 
     enabled = True
+    visible = True
     label = "Velocity Correlation Function"
     CF_NAME = "vcf"
     CF_UNITS = "nm2/ps2"

--- a/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/XRayStaticStructureFactor.py
@@ -63,6 +63,7 @@ class XRayStaticStructureFactor(DistanceHistogram):
     label = "XRay Static Structure Factor"
 
     enabled = True
+    visible = True
 
     category = (
         "Analysis",


### PR DESCRIPTION
**Description of work**
Some jobs like PairDistributionFunction are not visible in the GUI because they inherit `visible = False` from their parent class. This PR makes them visible.

**Fixes**
1. Set `visible = True` on PDF, VACF, PACF, DOS, PPS and coordination number jobs.

**To test**
Run the GUI. Check if any jobs are missing.
