### PR TITLE
Include memory limit in the job inputs

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -109,7 +109,7 @@ def guess_hdf5_trajectory_parameters(
     trajectory_instance = Trajectory(fname, fast_load=True)
     traj_length = len(trajectory_instance)
     chunk_size = trajectory_instance.chunk_size()
-    bytes_per_num = trajectory_instance.dtype_size()
+    bytes_per_num = trajectory_instance.bytes_per_num()
     if chunk_size < 0 or bytes_per_num < 0:
         return None, None
     cache_size = 200 * traj_length * chunk_size * 3 * bytes_per_num

--- a/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/IConfigurator.py
@@ -334,6 +334,14 @@ class IConfigurator(dict, RegisterFactory, abc.ABC):
         if hasattr(self, "prediction_keys"):
             for key in self.prediction_keys:
                 yield (key, self[key], self.prediction.unit)
+        elif hasattr(self, "prediction_list"):
+            for prediction in self.prediction_list:
+                if prediction.key in self:
+                    yield (
+                        prediction.label,
+                        self[prediction.key],
+                        prediction.unit,
+                    )
         elif self.prediction.key in self:
             yield (
                 self.prediction.label,

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MemoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MemoryConfigurator.py
@@ -1,0 +1,72 @@
+#    This file is part of MDANSE.
+#
+#    MDANSE is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from __future__ import annotations
+
+import os
+
+from MDANSE.Framework.Configurators.IConfigurator import (
+    IConfigurator,
+    PredictionSettings,
+)
+
+MAX_MEMORY_PER_PROCESS = int(os.environ.get("MDANSE_MAX_RAM_PER_PROCESS", "512"))
+
+
+@IConfigurator.register("MemoryConfigurator")
+class MemoryConfigurator(IConfigurator):
+    """Specified the upper limit of memory used by a single process.
+
+    MDANSE will adjust the number of atoms or frames processed in a single
+    analysis step to lower the memory requirements. However, this will not
+    always be possible, as for large trajectories the memory limit may
+    be exceeded already for a single atom or a single frame.
+    """
+
+    _default = MAX_MEMORY_PER_PROCESS
+
+    label = "Memory options"
+    tooltip = "Set the upper limit of memory per process (MB) that you want MDANSE to use."
+
+    def __init__(self, name, **kwargs):
+        self.memory_function = kwargs.pop("mem_function", None)
+        super().__init__(name, **kwargs)
+        self.prediction = PredictionSettings(key="mem_per_proc", label="RAM per process (MB)")
+
+    def configure(self, value):
+        """
+        Configure the memory limit in MB.
+        """
+        if not self.update_needed(value):
+            return
+
+        self._original_input = value
+
+        try:
+            num_value = int(value)
+        except (TypeError, ValueError):
+            self.error_status = f"Input {num_value} cannot be converted to a number of MB."
+            return
+
+        if value <= 0:
+            self.error_status = f"Upper limit of {value} MB cannot be used. Use a positive number."
+            return
+
+        if self.memory_function is not None:
+            predicted_memory = self.memory_function(self)
+            self["memory_per_atom"] = predicted_memory
+
+        self["value"] = value
+        self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MemoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MemoryConfigurator.py
@@ -48,9 +48,15 @@ class MemoryConfigurator(IntegerConfigurator):
     def __init__(self, name, **kwargs):
         self.memory_function = kwargs.pop("mem_function", None)
         super().__init__(name, **kwargs)
-        self.prediction = PredictionSettings(
-            key="memory_per_process", label="RAM per process (MB)"
-        )
+        self.prediction_list = [
+            PredictionSettings(
+                key="memory_per_process",
+                label="RAM per process (MB)",
+            ),
+            PredictionSettings(
+                key="atoms_per_step", label="Atoms processed in a single step"
+            ),
+        ]
         self["memory_per_process"] = [1]
 
     def find_group_size(self) -> int:
@@ -81,13 +87,19 @@ class MemoryConfigurator(IntegerConfigurator):
             )
             return
 
+        atoms_per_chunk = self.configurable[self.dependencies["trajectory"]][
+            "instance"
+        ].chunk_size(array_name="position")
+
         if self.memory_function is not None:
             predicted_memory = self.memory_function(self)
-            self["memory_per_atom"] = predicted_memory[0] / 2**20
-            self["memory_per_chunk"] = predicted_memory[1] / 2**20
-            self["memory_per_step"] = (
-                num_value // predicted_memory[0]
-            ) * predicted_memory[0]
+            self["memory_per_atom"] = predicted_memory[0]
+            self["memory_per_chunk"] = predicted_memory[1]
+            atoms_per_step = max(
+                1, min(num_value // predicted_memory[0], atoms_per_chunk)
+            )
+            self["memory_per_step"] = atoms_per_step * predicted_memory[0]
+            self["atoms_per_step"] = [atoms_per_step]
             if self["memory_per_step"] > num_value:
                 self.warning_status = (
                     f"Expected memory per step ({self['memory_per_step']} MB) "

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MemoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MemoryConfigurator.py
@@ -21,12 +21,13 @@ from MDANSE.Framework.Configurators.IConfigurator import (
     IConfigurator,
     PredictionSettings,
 )
+from MDANSE.Framework.Configurators.IntegerConfigurator import IntegerConfigurator
 
 MAX_MEMORY_PER_PROCESS = int(os.environ.get("MDANSE_MAX_RAM_PER_PROCESS", "512"))
 
 
 @IConfigurator.register("MemoryConfigurator")
-class MemoryConfigurator(IConfigurator):
+class MemoryConfigurator(IntegerConfigurator):
     """Specified the upper limit of memory used by a single process.
 
     MDANSE will adjust the number of atoms or frames processed in a single
@@ -37,13 +38,23 @@ class MemoryConfigurator(IConfigurator):
 
     _default = MAX_MEMORY_PER_PROCESS
 
+    choices = None
+
     label = "Memory options"
-    tooltip = "Set the upper limit of memory per process (MB) that you want MDANSE to use."
+    tooltip = (
+        "Set the upper limit of memory per process (MB) that you want MDANSE to use."
+    )
 
     def __init__(self, name, **kwargs):
         self.memory_function = kwargs.pop("mem_function", None)
         super().__init__(name, **kwargs)
-        self.prediction = PredictionSettings(key="mem_per_proc", label="RAM per process (MB)")
+        self.prediction = PredictionSettings(
+            key="memory_per_process", label="RAM per process (MB)"
+        )
+        self["memory_per_process"] = [1]
+
+    def find_group_size(self) -> int:
+        return 5
 
     def configure(self, value):
         """
@@ -53,20 +64,36 @@ class MemoryConfigurator(IConfigurator):
             return
 
         self._original_input = value
+        self.error_status = "OK"
+        self.warning_status = ""
 
         try:
             num_value = int(value)
         except (TypeError, ValueError):
-            self.error_status = f"Input {num_value} cannot be converted to a number of MB."
+            self.error_status = (
+                f"Input {num_value} cannot be converted to a number of MB."
+            )
             return
 
-        if value <= 0:
-            self.error_status = f"Upper limit of {value} MB cannot be used. Use a positive number."
+        if num_value <= 0:
+            self.error_status = (
+                f"Upper limit of {num_value} MB cannot be used. Use a positive number."
+            )
             return
 
         if self.memory_function is not None:
             predicted_memory = self.memory_function(self)
-            self["memory_per_atom"] = predicted_memory
+            self["memory_per_atom"] = predicted_memory[0] / 2**20
+            self["memory_per_chunk"] = predicted_memory[1] / 2**20
+            self["memory_per_step"] = (
+                num_value // predicted_memory[0]
+            ) * predicted_memory[0]
+            if self["memory_per_step"] > num_value:
+                self.warning_status = (
+                    f"Expected memory per step ({self['memory_per_step']} MB) "
+                    f"is larger than the requested upper limit ({num_value} MB)."
+                )
+            self["memory_per_process"] = [self["memory_per_step"]]
 
-        self["value"] = value
+        self["value"] = num_value
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/MemoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/MemoryConfigurator.py
@@ -50,11 +50,11 @@ class MemoryConfigurator(IntegerConfigurator):
         super().__init__(name, **kwargs)
         self.prediction_list = [
             PredictionSettings(
-                key="memory_per_process",
-                label="RAM per process (MB)",
+                key="memory_per_process", label="RAM per process", unit="MB"
             ),
             PredictionSettings(
-                key="atoms_per_step", label="Atoms processed in a single step"
+                key="atoms_per_step",
+                label="Atoms processed in a single step",
             ),
         ]
         self["memory_per_process"] = [1]
@@ -106,6 +106,12 @@ class MemoryConfigurator(IntegerConfigurator):
                     f"is larger than the requested upper limit ({num_value} MB)."
                 )
             self["memory_per_process"] = [self["memory_per_step"]]
+        else:
+            self.warning_status = (
+                "There is no valid function for memory use calculations"
+            )
+            self["atoms_per_step"] = [1]
+            self["memory_per_step"] = [-1]
 
         self["value"] = num_value
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/RunningModeConfigurator.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 
 import multiprocessing
 
-from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
+from MDANSE.Framework.Configurators.IConfigurator import (
+    IConfigurator,
+    PredictionSettings,
+)
 
 
 @IConfigurator.register("RunningModeConfigurator")
@@ -34,6 +37,13 @@ class RunningModeConfigurator(IConfigurator):
     _default = ("single-core", 1)
     label = "Parallelisation options"
     tooltip = "Run the job on a single core or parallelise over multiple cores."
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.prediction = PredictionSettings(
+            key="total_ram", label="Expected total RAM", unit="MB"
+        )
+        self["total_ram"] = "?"
 
     def configure(self, value):
         """
@@ -70,4 +80,14 @@ class RunningModeConfigurator(IConfigurator):
         self["mode"] = mode
 
         self["slots"] = slots
+        if "memory" in self.dependencies:
+            ram_per_process = self.configurable[self.dependencies["memory"]][
+                "memory_per_step"
+            ]
+            try:
+                self["total_ram"] = [slots * ram_per_process]
+            except Exception:
+                self.warning_status = (
+                    "Could not calculate the expected memory requirements."
+                )
         self.error_status = "OK"

--- a/MDANSE/Src/MDANSE/Framework/Configurators/__init__.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/__init__.py
@@ -83,6 +83,7 @@ from .MDTrajTopologyFileConfigurator import (
 from .MDTrajTrajectoryFileConfigurator import (
     MDTrajTrajectoryFileConfigurator as MDTrajTrajectoryFileConfigurator,
 )
+from .MemoryConfigurator import MemoryConfigurator as MemoryConfigurator
 from .MoleculeSelectionConfigurator import (
     MoleculeSelectionConfigurator as MoleculeSelectionConfigurator,
 )

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -27,6 +27,22 @@ from MDANSE.Mathematics.Signal import get_spectrum
 from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 
+def disf_memory_per_atom(mem_conf, n_atoms: int = 1) -> int:
+    """Calculate RAM (in bytes) needed by a single process.
+
+    """
+    trajectory = mem_conf.configurable[mem_conf.dependencies["trajectory"]]["instance"]
+    frame_config = mem_conf.configurable[mem_conf.dependencies["frames"]]
+    vector_config = mem_conf.configurable[mem_conf.dependencies["q_vectors"]]
+    n_dimensions = 3
+    n_frames = frame_config["number"]
+    n_vectors = vector_config["parameters"].get(
+        "n_vectors", 1
+    )
+    data_size = trajectory.bytes_per_num(array_name="position")
+    return 8 * n_frames * n_atoms * n_vectors * n_dimensions * data_size
+
+
 @IJob.register("DynamicIncoherentStructureFactor")
 class DynamicIncoherentStructureFactor(IJob):
     r"""Computes the dynamic incoherent structure factor :math:`S_{\text{inc}}(\mathbf{q},\omega)` for a set of atoms.
@@ -104,6 +120,27 @@ class DynamicIncoherentStructureFactor(IJob):
     )
     settings["output_files"] = ("OutputFilesConfigurator", {})
     settings["running_mode"] = ("RunningModeConfigurator", {})
+    settings["memory"] = ("MemoryConfigurator", {
+                     "dependencies": {
+                "trajectory": "trajectory",
+                "frames": "frames",
+                "q_vectors": "q_vectors",
+            },
+            "mem_function": disf_memory_per_atom
+    })
+
+    def predict_memory(self, n_atoms: int = 1) -> int:
+        """Calculate RAM (in bytes) needed by a single process.
+
+        """
+        4000 * 64 * 3 * 100 * 8 * 4
+        n_dimensions = 3
+        n_frames = self.configuration["frames"]["number"]
+        n_vectors = self.configuration["q_vectors"]["parameters"].get(
+            "n_vectors", 1
+        )
+        data_size = self.trajectory.bytes_per_num(array_name="position")
+        return 8 * n_frames * n_atoms * n_vectors * n_dimensions * data_size
 
     def initialize(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -15,6 +15,8 @@
 #
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from scipy import fft
 
@@ -26,21 +28,41 @@ from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_
 from MDANSE.Mathematics.Signal import get_spectrum
 from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
+if TYPE_CHECKING:
+    from MDANSE.Framework.Configurators.MemoryConfigurator import MemoryConfigurator
 
-def disf_memory_per_atom(mem_conf, n_atoms: int = 1) -> int:
-    """Calculate RAM (in bytes) needed by a single process.
 
+def disf_memory_per_atom(
+    mem_conf: MemoryConfigurator, n_atoms: int = 1
+) -> tuple[int, int, int]:
+    """Calculate the memory requirements of a DISF calculation.
+
+    The data size is fixed as 8 bytes per number, since the arrays allocated
+    by numpy in this analysis are most likely going to be float64, even
+    if the coordinates in the input trajectory are float32.
+
+    Parameters
+    ----------
+    mem_conf : MemoryConfigurator
+        The configurator instance which contains the needed inputs
+    n_atoms : int, optional
+        Use a specific number of atoms in the calculation, by default 1
+
+    Returns
+    -------
+    tuple[int, int int]
+        Bytes per atom, per chunk and per n_atoms from input, respectively
     """
     trajectory = mem_conf.configurable[mem_conf.dependencies["trajectory"]]["instance"]
     frame_config = mem_conf.configurable[mem_conf.dependencies["frames"]]
     vector_config = mem_conf.configurable[mem_conf.dependencies["q_vectors"]]
     n_dimensions = 3
     n_frames = frame_config["number"]
-    n_vectors = vector_config["parameters"].get(
-        "n_vectors", 1
-    )
-    data_size = trajectory.bytes_per_num(array_name="position")
-    return 8 * n_frames * n_atoms * n_vectors * n_dimensions * data_size
+    n_vectors = vector_config["parameters"].get("n_vectors", 1)
+    data_size = 8
+    chunk_size = trajectory.chunk_size(array_name="position")
+    prefactor = 4 * n_frames * n_vectors * n_dimensions * data_size
+    return (prefactor, chunk_size * prefactor, n_atoms * prefactor)
 
 
 @IJob.register("DynamicIncoherentStructureFactor")
@@ -63,7 +85,7 @@ class DynamicIncoherentStructureFactor(IJob):
         "Analysis",
         "Scattering",
     )
-    PREDICTORS = ("instrument_resolution", "q_vectors")
+    PREDICTORS = ("instrument_resolution", "q_vectors", "memory")
 
     ancestor = ["hdf_trajectory", "molecular_viewer"]
 
@@ -120,27 +142,17 @@ class DynamicIncoherentStructureFactor(IJob):
     )
     settings["output_files"] = ("OutputFilesConfigurator", {})
     settings["running_mode"] = ("RunningModeConfigurator", {})
-    settings["memory"] = ("MemoryConfigurator", {
-                     "dependencies": {
+    settings["memory"] = (
+        "MemoryConfigurator",
+        {
+            "dependencies": {
                 "trajectory": "trajectory",
                 "frames": "frames",
                 "q_vectors": "q_vectors",
             },
-            "mem_function": disf_memory_per_atom
-    })
-
-    def predict_memory(self, n_atoms: int = 1) -> int:
-        """Calculate RAM (in bytes) needed by a single process.
-
-        """
-        4000 * 64 * 3 * 100 * 8 * 4
-        n_dimensions = 3
-        n_frames = self.configuration["frames"]["number"]
-        n_vectors = self.configuration["q_vectors"]["parameters"].get(
-            "n_vectors", 1
-        )
-        data_size = self.trajectory.bytes_per_num(array_name="position")
-        return 8 * n_frames * n_atoms * n_vectors * n_dimensions * data_size
+            "mem_function": disf_memory_per_atom,
+        },
+    )
 
     def initialize(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -51,7 +51,7 @@ def disf_memory_per_atom(
     Returns
     -------
     tuple[int, int int]
-        Bytes per atom, per chunk and per n_atoms from input, respectively
+        MB per atom, per chunk and per n_atoms from input, respectively
     """
     trajectory = mem_conf.configurable[mem_conf.dependencies["trajectory"]]["instance"]
     frame_config = mem_conf.configurable[mem_conf.dependencies["frames"]]
@@ -61,7 +61,7 @@ def disf_memory_per_atom(
     n_vectors = vector_config["parameters"].get("n_vectors", 1)
     data_size = 8
     chunk_size = trajectory.chunk_size(array_name="position")
-    prefactor = 4 * n_frames * n_vectors * n_dimensions * data_size
+    prefactor = 4 * n_frames * n_vectors * n_dimensions * data_size / 2**20
     return (prefactor, chunk_size * prefactor, n_atoms * prefactor)
 
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/DynamicIncoherentStructureFactor.py
@@ -26,7 +26,7 @@ from MDANSE.Framework.AtomGrouping.grouping import (
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
 from MDANSE.Mathematics.Signal import get_spectrum
-from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices_precalculated
 
 if TYPE_CHECKING:
     from MDANSE.Framework.Configurators.MemoryConfigurator import MemoryConfigurator
@@ -85,7 +85,7 @@ class DynamicIncoherentStructureFactor(IJob):
         "Analysis",
         "Scattering",
     )
-    PREDICTORS = ("instrument_resolution", "q_vectors", "memory")
+    PREDICTORS = ("instrument_resolution", "q_vectors", "memory", "running_mode")
 
     ancestor = ["hdf_trajectory", "molecular_viewer"]
 
@@ -140,8 +140,6 @@ class DynamicIncoherentStructureFactor(IJob):
             },
         },
     )
-    settings["output_files"] = ("OutputFilesConfigurator", {})
-    settings["running_mode"] = ("RunningModeConfigurator", {})
     settings["memory"] = (
         "MemoryConfigurator",
         {
@@ -153,6 +151,15 @@ class DynamicIncoherentStructureFactor(IJob):
             "mem_function": disf_memory_per_atom,
         },
     )
+    settings["output_files"] = ("OutputFilesConfigurator", {})
+    settings["running_mode"] = (
+        "RunningModeConfigurator",
+        {
+            "dependencies": {
+                "memory": "memory",
+            }
+        },
+    )
 
     def initialize(self):
         """
@@ -160,18 +167,15 @@ class DynamicIncoherentStructureFactor(IJob):
         """
         super().initialize()
 
-        vectors_per_shell = self.configuration["q_vectors"]["parameters"].get(
-            "n_vectors", 1
-        )
         n_proc = self.configuration["running_mode"].get("slots", 1)
 
         self._nFrames = self.configuration["frames"]["n_frames"]
 
-        self.grouped_indices = group_atom_indices(
+        self.grouped_indices = group_atom_indices_precalculated(
             self.trajectory,
             self.configuration["frames"]["number"],
             n_proc=n_proc,
-            memory_scale_factor=6 * vectors_per_shell,
+            max_group_size=self.configuration["memory"]["atoms_per_step"][0],
         )
         self.numberOfSteps = len(self.grouped_indices)
 

--- a/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/IJob.py
@@ -261,6 +261,16 @@ class IJob(Configurable, RegisterFactory, ABC):
     def results(self):
         return self._in_memory_result
 
+    def predict_memory(self) -> int:
+        """Calculate RAM (in bytes) needed by a single process.
+
+        This is just a placeholder function, and the correct form
+        should be implemented and calibrated for each job."""
+        axis1 = self.trajectory.chunk_size(array_name="position")
+        axis2 = self.configuration["frames"]["number"]
+        data_size = self.trajectory.bytes_per_num(array_name="position")
+        return axis1 * axis2 * data_size
+
     def initialize(self):
         try:
             if (

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -264,10 +264,10 @@ class Trajectory:
         dataset_type = TrajDataArray[array_name.upper()]
         return self._trajectory.chunk_size(dataset_type)
 
-    def dtype_size(self, array_name: str = "position") -> int:
+    def bytes_per_num(self, array_name: str = "position") -> int:
         """Return the number of atoms in a single chunk of the HDF5 dataset."""
         dataset_type = TrajDataArray[array_name.upper()]
-        return self._trajectory.dtype_size(dataset_type)
+        return self._trajectory.bytes_per_num(dataset_type)
 
     def group_elements(self, grp_name):
         """The elements in the group with the name grp_name.

--- a/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/TrajectoryUtils.py
@@ -252,6 +252,51 @@ def group_atom_indices(
     )
 
 
+def group_atom_indices_precalculated(
+    traj_instance: Trajectory,
+    n_frames: int,
+    *,
+    n_proc: int = 1,
+    max_group_size: int = 1,
+) -> list[list[int]]:
+    """Create groups of atom indices coaligned with the chunk size in the input file.
+
+    This function is meant to group indices so that a single process loads data
+    from a single chunk per frame. Additionally, indices will be split into smaller
+    sets if a process is expected to use more memory than the specified limits, or
+    if there are less index sets than there are worker processes.
+
+    Typically, the memory requirements will be proportional to the size of the
+    input array, but larger. For example, DISF analysis allocates an array
+    of the size of N_ATOMSxN_VECTORS, which means that the worker process
+    will need significantly more memory that the size of the input coordinate
+    array.
+
+    Parameters
+    ----------
+    traj_instance : Trajectory
+        The current input trajectory.
+    n_proc : int, optional
+        Number of available CPU cores or worker processes, by default 1
+    memory_scale_factor : int, optional
+        Multiplier of the expected memory requirements of the job, by default 10
+    size_limit : int, optional
+        Limit of memory per worker process, by default CHUNK_SIZE_LIMIT
+
+    Returns
+    -------
+    list[set[int]]
+        List of atom index set, each set containing indices from a single HDF5 chunk
+    """
+    selected_indices = set(traj_instance.atom_indices)
+    total_dimensions = (n_frames, traj_instance.variable("position").shape[1])
+    chunk_size = traj_instance.chunk_size(array_name="position")
+    min_group_count = min(n_proc, len(selected_indices))
+    return split_selected_atoms(
+        selected_indices, chunk_size, total_dimensions, max_group_size, min_group_count
+    )
+
+
 def split_index_sets(index_sets: list[set[int]], max_size: int) -> list[set[int]]:
     """Check the size of each atom index set and split those exceeding the size limit.
 

--- a/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
+++ b/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
@@ -396,3 +396,20 @@ class TrajectoryFile(ABC):
 
         """
         return str(self._h5_filename)
+
+    def bytes_per_num(self, dataset_type=TrajDataArray.POSITION) -> int:
+        data_key = self.KEYS[dataset_type.name.lower()]
+        dataset = self._h5_file[data_key]
+        data_type = dataset.dtype
+        if data_type in (np.int16, np.float16):
+            return 2
+        elif data_type in (np.int32, np.float32):
+            return 4
+        elif data_type in (np.int64, np.float64, np.complex64):
+            return 8
+        elif data_type in (np.float128, np.complex128):
+            return 16
+        elif data_type in (np.complex256):
+            return 32
+        else:
+            return 1

--- a/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/RunningModeWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/InputWidgets/RunningModeWidget.py
@@ -67,6 +67,7 @@ class RunningModeWidget(WidgetBase):
         else:
             self._field.setEnabled(True)
             self._field.setValue(nextval)
+        self.updateValue()
 
     @Slot()
     def numproc_changed(self):
@@ -75,6 +76,7 @@ class RunningModeWidget(WidgetBase):
         if mode == "single-core":
             return
         self._last_numproc = numproc
+        self.updateValue()
 
     def get_widget_value(self):
         mode = self.mode_box.currentText()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -129,6 +129,7 @@ widget_lookup = {  # these all come from MDANSE_GUI.InputWidgets
     "MDTrajTimeStepConfigurator": MDAnalysisMDTrajTimeStepWidget,
     "MDTrajTrajectoryFileConfigurator": MultiInputFileWidget,
     "MDTrajTopologyFileConfigurator": MDTrajTopologyFileWidget,
+    "MemoryConfigurator": IntegerWidget,
 }
 
 


### PR DESCRIPTION
**Description of work**
In principle, we _could_ add an input to our jobs letting the user specify their preferred amount of memory that the job should use.

This prototype applies the new approach only to the Dynamic Incoherent Structure Factor calculations.

**Fixes**
1. Introduced `MemoryConfigurator`,
2. Added new prediction outputs for RAM per process and number of atoms per step.
3. Connected `RunningModeConfigurator` to `MemoryConfigurator` to calculate the total expected RAM use.
4. Changed the `group_per_index` function to use a pre-calculated number of atoms per index group.
5. Created a memory prediction function that is meant to be called by `MemoryConfigurator`.

**To test**
Load a trajectory and run DISF on it. Check how the memory requirements on your computer compare to the MDANSE prediction.

