### PR TITLE
Prevent InstrumentInfo from using an empty vector type

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/InstrumentInfo.py
@@ -15,6 +15,8 @@
 #
 from __future__ import annotations
 
+import traceback
+
 from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtGui import QStandardItem
 from qtpy.QtWidgets import QTextBrowser
@@ -236,12 +238,14 @@ class InstrumentInfo(QTextBrowser):
 
     @Slot(object)
     def update_panel(self, incoming: SimpleInstrument):
-        if incoming is None:
+        if incoming is None or not incoming._qvector_type:
             return
         try:
             filtered = self.filter(incoming)
         except Exception as e:
-            LOG.error(f"Error in InstrumentInfo: {e}")
+            LOG.error(
+                f"Error in InstrumentInfo: {e}. Traceback: {traceback.format_exc()}"
+            )
             self.setHtml("")
         else:
             self.setHtml(filtered)


### PR DESCRIPTION
**Description of work**
This PR stops InstrumentInfo from logging errors every time a new instrument is picked.

It seems that an instance of SimpleInstrument is passed to the visualiser before it has been fully configured, and the q vector type is set to `''`.  This PR adds a check for this.

**Fixes**
1. Ignore `SimpleInstrument` in `InstrumentInfo` if the q vector type has not been set.

**To test**
Run the GUI and go to the Instrument tab. Change the current instrument. There should be no error in the log.
