### PR TITLE
Improve the plot metadata preview.

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -656,10 +656,12 @@ class PlotDataView(QTreeView):
             )
         else:
             try:
-                text += "\n"
+                text = html.escape(f"{text}\n")
                 for attr in mda_data_structure.attrs:
-                    text += f"<b>{attr}</b>: {mda_data_structure.attrs[attr]}\n"
-                self.item_details.emit(html.escape(text))
+                    text += f"<b>{attr}</b>: " + html.escape(
+                        f"{mda_data_structure.attrs[attr]}\n"
+                    )
+                self.item_details.emit(text)
             except Exception:
                 self.item_details.emit("No additional information included.")
 
@@ -748,7 +750,7 @@ class PlotDataView(QTreeView):
         Parameters
         ----------
         index : QModelIndex
-            _description_
+            Index of the selected data set in the GUI model.
 
         """
         model = self.model()
@@ -762,13 +764,17 @@ class PlotDataView(QTreeView):
                 description = f"File {mda_data._file.filename}, no further information"
         elif item_type in {"dataset", "group"}:
             dataset = model.inner_object(index)
-            description = f"{dataset}{model_item.data(role=Qt.ItemDataRole.UserRole)}\n"
+            description = html.escape(
+                f"{dataset}{model_item.data(role=Qt.ItemDataRole.UserRole)}\n"
+            )
             for key in dataset.attrs:
-                description += f"{key}: {dataset.attrs[key]}\n"
+                description += f"<b>{key}</b>: " + html.escape(
+                    f"{dataset.attrs[key]}\n"
+                )
         else:
             description = "generic item"
         self.item_details.emit(
-            html.escape(description),
+            description,
         )  # this should emit the job name
 
     def connect_to_visualiser(


### PR DESCRIPTION
**Description of work**
The dataset path in plot preview is sometimes not displayed correctly. We get
<img width="619" height="167" alt="Screenshot 2026-07-22 at 15 41 54" src="https://github.com/user-attachments/assets/562ad599-8725-4d91-91a6-2f6572c9f967" />
while the correct preview should be
<img width="619" height="167" alt="Screenshot 2026-07-22 at 16 01 37" src="https://github.com/user-attachments/assets/4efc832a-2412-40f7-a90d-0752426b7d77" />


**Fixes**
`html.escape` is applied to the dataset path, as well as the values of the `attrs` dictionary. At the same time it is **not** applied to keys, allowing us to keep the formatting that displays each key in **bold** typeface.

**To test**
Generate analysis results using molecule grouping. Select the datasets in the plot creator and check if the dataset path is displayed correctly.
