### PR TITLE
Optimise GUI interaction with very long trajectories 

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
@@ -20,6 +20,7 @@ from math import floor
 import numpy as np
 
 from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
+from MDANSE.MolecularDynamics.UnitCell import NO_CELL
 
 from .IConfigurator import PredictionSettings
 from .RangeConfigurator import RangeConfigurator
@@ -73,37 +74,31 @@ class DistHistCutoffConfigurator(RangeConfigurator):
             The maximum cutoff for the distance histogram job.
         """
         traj_config = self.configurable[self.dependencies["trajectory"]]["instance"]
-        try:
-            trajectory_array = np.array(
-                [
-                    traj_config.unit_cell(frame)._unit_cell
-                    for frame in range(len(traj_config))
-                ]
-            )
-        except Exception:
+        if traj_config.unit_cell_warning == NO_CELL:
+            return np.linalg.norm(traj_config.min_span)
+
+        unit_cells = traj_config.unit_cells_raw
+        if np.allclose(unit_cells, 0.0):
             return np.linalg.norm(traj_config.min_span)
         else:
-            if np.allclose(trajectory_array, 0.0):
-                return np.linalg.norm(traj_config.min_span)
-            else:
-                # calculated the radius of the largest sphere that can
-                # fit into the unit cell
-                min_d = np.min(trajectory_array, axis=0)
-                vec_a, vec_b, vec_c = min_d
+            # calculated the radius of the largest sphere that can
+            # fit into the unit cell
+            min_d = np.min(unit_cells, axis=0)
+            vec_a, vec_b, vec_c = min_d
 
-                cross_bc = np.cross(vec_b, vec_c)
-                cross_ca = np.cross(vec_c, vec_a)
-                cross_ab = np.cross(vec_a, vec_b)
+            cross_bc = np.cross(vec_b, vec_c)
+            cross_ca = np.cross(vec_c, vec_a)
+            cross_ab = np.cross(vec_a, vec_b)
 
-                if (
-                    np.allclose(cross_bc, 0.0)
-                    or np.allclose(cross_ca, 0.0)
-                    or np.allclose(cross_ab, 0.0)
-                ):
-                    raise ValueError("Trajectory contains invalid unit cell.")
+            if (
+                np.allclose(cross_bc, 0.0)
+                or np.allclose(cross_ca, 0.0)
+                or np.allclose(cross_ab, 0.0)
+            ):
+                raise ValueError("Trajectory contains invalid unit cell.")
 
-                h_1 = abs(np.dot(vec_a, cross_bc)) / np.linalg.norm(cross_bc)
-                h_2 = abs(np.dot(vec_b, cross_ca)) / np.linalg.norm(cross_ca)
-                h_3 = abs(np.dot(vec_c, cross_ab)) / np.linalg.norm(cross_ab)
+            h_1 = abs(np.dot(vec_a, cross_bc)) / np.linalg.norm(cross_bc)
+            h_2 = abs(np.dot(vec_b, cross_ca)) / np.linalg.norm(cross_ca)
+            h_3 = abs(np.dot(vec_c, cross_ab)) / np.linalg.norm(cross_ab)
 
-                return 0.5 * min(h_1, h_2, h_3)
+            return 0.5 * min(h_1, h_2, h_3)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/DistHistCutoffConfigurator.py
@@ -80,25 +80,25 @@ class DistHistCutoffConfigurator(RangeConfigurator):
         unit_cells = traj_config.unit_cells_raw
         if np.allclose(unit_cells, 0.0):
             return np.linalg.norm(traj_config.min_span)
-        else:
-            # calculated the radius of the largest sphere that can
-            # fit into the unit cell
-            min_d = np.min(unit_cells, axis=0)
-            vec_a, vec_b, vec_c = min_d
 
-            cross_bc = np.cross(vec_b, vec_c)
-            cross_ca = np.cross(vec_c, vec_a)
-            cross_ab = np.cross(vec_a, vec_b)
+        # calculated the radius of the largest sphere that can
+        # fit into the unit cell
+        min_d = np.min(unit_cells, axis=0)
+        vec_a, vec_b, vec_c = min_d
 
-            if (
-                np.allclose(cross_bc, 0.0)
-                or np.allclose(cross_ca, 0.0)
-                or np.allclose(cross_ab, 0.0)
-            ):
-                raise ValueError("Trajectory contains invalid unit cell.")
+        cross_bc = np.cross(vec_b, vec_c)
+        cross_ca = np.cross(vec_c, vec_a)
+        cross_ab = np.cross(vec_a, vec_b)
 
-            h_1 = abs(np.dot(vec_a, cross_bc)) / np.linalg.norm(cross_bc)
-            h_2 = abs(np.dot(vec_b, cross_ca)) / np.linalg.norm(cross_ca)
-            h_3 = abs(np.dot(vec_c, cross_ab)) / np.linalg.norm(cross_ab)
+        if (
+            np.allclose(cross_bc, 0.0)
+            or np.allclose(cross_ca, 0.0)
+            or np.allclose(cross_ab, 0.0)
+        ):
+            raise ValueError("Trajectory contains invalid unit cell.")
 
-            return 0.5 * min(h_1, h_2, h_3)
+        h_1 = abs(np.dot(vec_a, cross_bc)) / np.linalg.norm(cross_bc)
+        h_2 = abs(np.dot(vec_b, cross_ca)) / np.linalg.norm(cross_ca)
+        h_3 = abs(np.dot(vec_c, cross_ab)) / np.linalg.norm(cross_ab)
+
+        return 0.5 * min(h_1, h_2, h_3)

--- a/MDANSE/Src/MDANSE/Framework/Configurators/GridStepConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/GridStepConfigurator.py
@@ -22,6 +22,7 @@ import numpy as np
 from MDANSE.Framework.Configurators.FloatConfigurator import FloatConfigurator
 from MDANSE.Framework.Configurators.IConfigurator import IConfigurator
 from MDANSE.MolecularDynamics.Trajectory import Trajectory
+from MDANSE.MolecularDynamics.UnitCell import NO_CELL
 
 from .IConfigurator import PredictionSettings
 
@@ -82,12 +83,10 @@ class GridStepConfigurator(FloatConfigurator):
         trajectory: Trajectory = self.configurable[self.dependencies["trajectory"]][
             "instance"
         ]
-        if any(trajectory.unit_cell(frame) is None for frame in frames):
+        if trajectory.unit_cell_warning == NO_CELL:
             self._avg_cell = trajectory.max_span
         else:
-            self._avg_cell = np.array(
-                [trajectory.unit_cell(frame)._unit_cell for frame in frames]
-            ).mean(axis=0)
+            self._avg_cell = trajectory.unit_cells_raw.mean(axis=0)
         return self._avg_cell
 
     def configure(self, value):

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -140,12 +140,10 @@ class TrajectoryEditor(IJob):
         )
 
         if self.configuration["unit_cell"]["apply"]:
-            self._new_unit_cell = UnitCell(
-                np.array(self.configuration["unit_cell"]["value"])
+            self._new_unit_cell = np.array(self.configuration["unit_cell"]["value"])
+            self._input_trajectory._trajectory.unit_cells_raw = np.tile(
+                self._new_unit_cell, (len(self._input_trajectory), 1, 1)
             )
-            self._input_trajectory._trajectory._unit_cells = [
-                self._new_unit_cell for _ in range(len(self._input_trajectory))
-            ]
 
         # The collection of atoms corresponding to the atoms selected for output.
         indices = self.trajectory.atom_indices

--- a/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/TrajectoryEditor.py
@@ -144,6 +144,7 @@ class TrajectoryEditor(IJob):
             self._input_trajectory._trajectory.unit_cells_raw = np.tile(
                 self._new_unit_cell, (len(self._input_trajectory), 1, 1)
             )
+            self._input_trajectory._trajectory.check_unit_cells()
 
         # The collection of atoms corresponding to the atoms selected for output.
         indices = self.trajectory.atom_indices

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -1378,7 +1378,6 @@ class TrajectoryWriter:
             dset = self._h5_file.create_dataset(
                     dataset,
                     shape=(self._n_steps,) if dataset != "unit_cell" else (self._n_steps, 3, 3),
-                    chunks=True,
                     dtype=self._dtype,)
         dset.attrs["units"] = units.get(dataset, "")
         dset[frame_indices] = data
@@ -1461,7 +1460,6 @@ class TrajectoryWriter:
                 unit_cell_dset = self._h5_file.create_dataset(
                     "unit_cell",
                     shape=(self._n_steps, 3, 3),
-                    chunks=True,
                     dtype=np.float64,
                 )
                 unit_cell_dset.attrs["units"] = units.get("unit_cell", "")
@@ -1473,7 +1471,6 @@ class TrajectoryWriter:
             time_dset = self._h5_file.create_dataset(
                 "time",
                 shape=(self._n_steps,),
-                chunks=True,
                 dtype=np.float64,
             )
             time_dset.attrs["units"] = units.get("time", "")

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -1297,14 +1297,6 @@ class TrajectoryWriter:
             for k, v in self._last_configuration.variables.items():
                 dset = configuration_grp.get(k, None)
                 dset.resize((self._current_index, n_atoms, 3))
-            try:
-                unit_cell_dataset = self._h5_file["/unit_cell"]
-            except KeyError:
-                pass
-            else:
-                unit_cell_dataset.resize((self._current_index, 3, 3))
-            time_dataset = self._h5_file["/time"]
-            time_dataset.resize((self._current_index,))
         self._h5_file.close()
 
     def write_charges(self, charges: FloatArray, index: int, atom_indices: list[int] | None = None):

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -611,6 +611,10 @@ class Trajectory:
     def unit_cell_warning(self) -> str:
         return self._trajectory.unit_cell_warning
 
+    @property
+    def unit_cells_raw(self):
+        return self._trajectory.unit_cells_raw
+
     def calculate_coordinate_span(self) -> None:
         min_span = np.array(3 * [1e11])
         max_span = np.zeros(3)

--- a/MDANSE/Src/MDANSE/MolecularDynamics/UnitCell.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/UnitCell.py
@@ -30,12 +30,6 @@ BAD_CELL = "Unit cell definition is invalid. Correct it using TrajectoryEditor."
 CHANGING_CELL = "Unit cell definition changes during the simulation. MANY ANALYSIS TYPES WILL PRODUCE WRONG RESULTS."
 
 
-CELL_SIZE_LIMIT = 1e-9
-NO_CELL = "Unit cell definition is missing. Add it using TrajectoryEditor."
-BAD_CELL = "Unit cell definition is invalid. Correct it using TrajectoryEditor."
-CHANGING_CELL = "Unit cell definition changes during the simulation. MANY ANALYSIS TYPES WILL PRODUCE WRONG RESULTS."
-
-
 class UnitCell:
     """
     This class stores a unit cell, which is stored row-wise i.e. the a, b and c vectors are

--- a/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
+++ b/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
@@ -30,6 +30,9 @@ from MDANSE.MolecularDynamics.TrajectoryUtils import (
     atomic_trajectory_many,
 )
 from MDANSE.MolecularDynamics.UnitCell import (
+    BAD_CELL,
+    CELL_SIZE_LIMIT,
+    CHANGING_CELL,
     NO_CELL,
     UnitCell,
 )
@@ -188,6 +191,27 @@ class TrajectoryFile(ABC):
             return None
         self._check_frame(frame)
         return UnitCell(self.unit_cells_raw[frame].astype(np.float64))
+
+    def check_unit_cells(self):
+        """Checks the unit cells and updates the warning."""
+        self.unit_cell_warning = ""
+
+        if self.unit_cells_raw is None:
+            self.unit_cell_warning = NO_CELL
+            return
+
+        if not self.unit_cell_warning:
+            if self.unit_cell(0).volume < CELL_SIZE_LIMIT:
+                self.unit_cell_warning = BAD_CELL
+                return
+
+            reference_array = self.unit_cells_raw[0]
+
+            if self.unit_cells_raw.shape[0] > 1:
+                directs = self.unit_cells_raw[1:]
+                if not np.allclose(directs, reference_array):
+                    self.unit_cell_warning = CHANGING_CELL
+                    return
 
     @abstractmethod
     def masses(self) -> FloatArray: ...

--- a/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
+++ b/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
@@ -29,6 +29,10 @@ from MDANSE.MolecularDynamics.TrajectoryUtils import (
     atomic_trajectory,
     atomic_trajectory_many,
 )
+from MDANSE.MolecularDynamics.UnitCell import (
+    NO_CELL,
+    UnitCell,
+)
 from MDANSE.util_types import FloatArray
 
 if TYPE_CHECKING:
@@ -39,7 +43,6 @@ if TYPE_CHECKING:
     from MDANSE.MolecularDynamics.Configuration import (
         _Configuration,
     )
-    from MDANSE.MolecularDynamics.UnitCell import UnitCell
 
 
 class TrajDataArray(Enum):
@@ -162,8 +165,29 @@ class TrajectoryFile(ABC):
             case _:
                 return 8
 
-    @abstractmethod
-    def unit_cell(self, frame: int) -> UnitCell | None: ...
+    def unit_cell(self, frame: int) -> UnitCell | None:
+        """Return the unit cell at a given frame.
+
+        Parameters
+        ----------
+        frame : int
+            Index of the selected trajectory frame.
+
+        Returns
+        -------
+        UnitCell | None
+            Unit cell definition. None if no cell is defined in the trajectory.
+
+        Raises
+        ------
+        IndexError
+            If frame index is out of the range covered by the trajectory.
+
+        """
+        if self.unit_cell_warning == NO_CELL:
+            return None
+        self._check_frame(frame)
+        return UnitCell(self.unit_cells_raw[frame].astype(np.float64))
 
     @abstractmethod
     def masses(self) -> FloatArray: ...
@@ -259,14 +283,9 @@ class TrajectoryFile(ABC):
             2D array containing the real coordinates converted from box coordinates.
 
         """
-        if self._unit_cells is not None:
-            real_coordinates = np.empty_like(box_coordinates)
-
-            for comp, cell in enumerate(self._unit_cells[first:last:step]):
-                real_coordinates[comp, :] = box_coordinates[comp, :] @ cell.direct
-            return real_coordinates
-
-        return box_coordinates
+        if self.unit_cell_warning == NO_CELL:
+            return box_coordinates
+        return box_coordinates @ self.unit_cells_raw[first:last:step]
 
     def read_atomic_trajectory(
         self,
@@ -302,11 +321,11 @@ class TrajectoryFile(ABC):
 
         coords = self.coordinates(slc, index)
 
-        if self._unit_cells is None:
+        if self.unit_cell_warning == NO_CELL:
             return coords
 
-        direct_cells = np.array([cell.direct for cell in self._unit_cells[slc]])
-        inverse_cells = np.array([cell.inverse for cell in self._unit_cells[slc]])
+        direct_cells = self.unit_cells_raw[slc]
+        inverse_cells = np.linalg.pinv(direct_cells)
         return atomic_trajectory(
             coords,
             direct_cells,
@@ -349,11 +368,11 @@ class TrajectoryFile(ABC):
 
         coords = self.coordinates(slc, index_list)
 
-        if self._unit_cells is None:
+        if self.unit_cell_warning == NO_CELL:
             return coords
 
-        direct_cells = np.array([cell.direct for cell in self._unit_cells[slc]])
-        inverse_cells = np.array([cell.inverse for cell in self._unit_cells[slc]])
+        direct_cells = self.unit_cells_raw[slc]
+        inverse_cells = np.linalg.pinv(direct_cells)
         return atomic_trajectory_many(
             coords,
             direct_cells,

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -299,11 +299,11 @@ class H5MDTrajectory(TrajectoryFile):
                 self.velocities[frame, :, :] * self.unit_conv["velocity"]
             )
 
-        if self._unit_cells is not None:
+        if self.unit_cell_warning != NO_CELL:
             try:
-                configuration["unit_cell"] = self._unit_cells[frame]
+                configuration["unit_cell"] = self.unit_cells(frame)
             except IndexError:
-                configuration["unit_cell"] = self._unit_cells[0]
+                configuration["unit_cell"] = self.unit_cells(0)
 
         return configuration
 
@@ -384,7 +384,7 @@ class H5MDTrajectory(TrajectoryFile):
         """
         self._check_frame(frame)
 
-        unit_cell = self.unit_cell(frame) if self._unit_cells is not None else None
+        unit_cell = self.unit_cell(frame)
 
         variables = {}
         for k in self.variables():
@@ -410,32 +410,31 @@ class H5MDTrajectory(TrajectoryFile):
         try:
             cells = self._h5_file[self.box_key][:] * self.unit_conv["box"]
         except KeyError:
-            self._unit_cells = None
+            self.unit_cells_raw = None
             self.unit_cell_warning = NO_CELL
             return
 
-        if cells.ndim > 1:
-            for cell in cells:
-                if cell.shape == (3, 3):
-                    temp_array = np.array(cell)
-                elif cell.shape == (3,):
-                    temp_array = np.diag(cell)
-                else:
-                    raise ValueError(
-                        f"Cell array {cell} has a wrong shape {cell.shape}"
-                    )
-                uc = UnitCell(temp_array)
-                self._unit_cells.append(uc)
-                if not self.unit_cell_warning and uc.volume < CELL_SIZE_LIMIT:
-                    self.unit_cell_warning = BAD_CELL
+        if cells.ndim == 3 and cells.shape[1:] == (3, 3):
+            self.unit_cells_raw = cells
+        elif cells.ndim == 2 and cells.shape[1:] == (3,):
+            self.unit_cells_raw = np.eye(3) * cells[:, :, None]
+        elif cells.ndim == 1 and cells.shape[0] == 3:
+            self.unit_cells_raw = np.tile(
+                np.diag(cells), (self.positions.shape[0], 1, 1)
+            )
         else:
-            temp_array = np.diag(cells)
-            self._unit_cells.append(UnitCell(temp_array))
+            raise ValueError(f"Cell array {cells} has a wrong shape {cells.shape}")
 
         if not self.unit_cell_warning:
-            reference_array = self._unit_cells[0].direct
-            for uc in self._unit_cells[1:]:
-                if not np.allclose(reference_array, uc.direct):
+            if self.unit_cell(0).volume < CELL_SIZE_LIMIT:
+                self.unit_cell_warning = BAD_CELL
+                return
+
+            reference_array = self.unit_cells_raw[0]
+
+            if self.unit_cells_raw.shape[0] > 1:
+                directs = self.unit_cells_raw[1:]
+                if not np.allclose(directs, reference_array):
                     self.unit_cell_warning = CHANGING_CELL
                     return
 
@@ -452,31 +451,6 @@ class H5MDTrajectory(TrajectoryFile):
             ) * self.unit_conv["time"]
 
         return time
-
-    def unit_cell(self, frame: int) -> UnitCell | None:
-        """Return the unit cell at a given frame. If no unit cell is defined, returns None.
-
-        Parameters
-        ----------
-        frame : int
-            The frame number.
-
-        Returns
-        -------
-        UnitCell or None
-            The unit cell or None if no unit cells found.
-
-        """
-        self._check_frame(frame)
-
-        if self._unit_cells is not None:
-            try:
-                uc = self._unit_cells[frame]
-            except IndexError:
-                uc = self._unit_cells[0]
-            return uc
-
-        return None
 
     def __len__(self) -> int:
         """Returns the length of the trajectory.

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -33,16 +33,10 @@ from MDANSE.MolecularDynamics.Configuration import (
     PeriodicAbsoluteConfiguration,
     _Configuration,
 )
-from MDANSE.MolecularDynamics.UnitCell import (
-    BAD_CELL,
-    CELL_SIZE_LIMIT,
-    CHANGING_CELL,
-    NO_CELL,
-    UnitCell,
-)
+from MDANSE.MolecularDynamics.UnitCell import NO_CELL
 from MDANSE.util_types import FloatArray
 
-from .FileTrajBase import TrajDataArray, TrajectoryFile
+from .FileTrajBase import TrajectoryFile
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -425,18 +419,7 @@ class H5MDTrajectory(TrajectoryFile):
         else:
             raise ValueError(f"Cell array {cells} has a wrong shape {cells.shape}")
 
-        if not self.unit_cell_warning:
-            if self.unit_cell(0).volume < CELL_SIZE_LIMIT:
-                self.unit_cell_warning = BAD_CELL
-                return
-
-            reference_array = self.unit_cells_raw[0]
-
-            if self.unit_cells_raw.shape[0] > 1:
-                directs = self.unit_cells_raw[1:]
-                if not np.allclose(directs, reference_array):
-                    self.unit_cell_warning = CHANGING_CELL
-                    return
+        self.check_unit_cells()
 
     def time(self) -> FloatArray:
         """Time timesteps from file."""

--- a/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/H5MDTrajectory.py
@@ -294,10 +294,7 @@ class H5MDTrajectory(TrajectoryFile):
             )
 
         if self.unit_cell_warning != NO_CELL:
-            try:
-                configuration["unit_cell"] = self.unit_cells(frame)
-            except IndexError:
-                configuration["unit_cell"] = self.unit_cells(0)
+            configuration["unit_cell"] = self.unit_cell(frame)
 
         return configuration
 
@@ -408,16 +405,17 @@ class H5MDTrajectory(TrajectoryFile):
             self.unit_cell_warning = NO_CELL
             return
 
-        if cells.ndim == 3 and cells.shape[1:] == (3, 3):
-            self.unit_cells_raw = cells
-        elif cells.ndim == 2 and cells.shape[1:] == (3,):
-            self.unit_cells_raw = np.eye(3) * cells[:, :, None]
-        elif cells.ndim == 1 and cells.shape[0] == 3:
-            self.unit_cells_raw = np.tile(
-                np.diag(cells), (self.positions.shape[0], 1, 1)
-            )
-        else:
-            raise ValueError(f"Cell array {cells} has a wrong shape {cells.shape}")
+        match cells.shape:
+            case (_, 3, 3):
+                self.unit_cells_raw = cells
+            case (_, 3):
+                self.unit_cells_raw = np.eye(3) * cells[:, :, None]
+            case (3,):
+                self.unit_cells_raw = np.tile(
+                    np.diag(cells), (self.positions.shape[0], 1, 1)
+                )
+            case _:
+                raise ValueError(f"Cell array {cells} has a wrong shape {cells.shape}")
 
         self.check_unit_cells()
 

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -39,11 +39,10 @@ from MDANSE.MolecularDynamics.UnitCell import (
     CELL_SIZE_LIMIT,
     CHANGING_CELL,
     NO_CELL,
-    UnitCell,
 )
 from MDANSE.util_types import FloatArray
 
-from .FileTrajBase import TrajDataArray, TrajectoryFile
+from .FileTrajBase import TrajectoryFile
 
 SLICE_ALL = np.s_[:]
 
@@ -101,7 +100,7 @@ class MdanseTrajectory(TrajectoryFile):
         self._has_database = "atom_database" in self._h5_file
         self._has_atoms = []
 
-        self._check_unit_cells()
+        self._load_unit_cells()
 
         # Load the chemical system
         self._chemical_system = ChemicalSystem(
@@ -318,9 +317,12 @@ class MdanseTrajectory(TrajectoryFile):
 
         return conf
 
-    def _check_unit_cells(self):
+    def _load_unit_cells(self):
         """Check unit cells."""
-        if "unit_cell" not in self._h5_file:
+        if "unit_cell" in self._h5_file:
+            self.unit_cells_raw = self._h5_file["unit_cell"][:]
+        else:
+            self.unit_cells_raw = None
             self.unit_cell_warning = NO_CELL
 
         if not self.unit_cell_warning:
@@ -328,10 +330,10 @@ class MdanseTrajectory(TrajectoryFile):
                 self.unit_cell_warning = BAD_CELL
                 return
 
-            reference_array = self._h5_file["unit_cell"][0]
+            reference_array = self.unit_cells_raw[0]
 
-            if self._h5_file["unit_cell"].shape[0] > 1:
-                directs = self._h5_file["unit_cell"][1:]
+            if self.unit_cells_raw.shape[0] > 1:
+                directs = self.unit_cells_raw[1:]
                 if not np.allclose(directs, reference_array):
                     self.unit_cell_warning = CHANGING_CELL
                     return
@@ -339,30 +341,6 @@ class MdanseTrajectory(TrajectoryFile):
     def time(self):
         """Return the time array for all the frames."""
         return self._h5_file["time"][:]
-
-    def unit_cell(self, frame: int) -> UnitCell | None:
-        """Return the unit cell at a given frame.
-
-        Parameters
-        ----------
-        frame : int
-            Index of the selected trajectory frame.
-
-        Returns
-        -------
-        UnitCell | None
-            Unit cell definition. None if no cell is defined in the trajectory.
-
-        Raises
-        ------
-        IndexError
-            If frame index is out of the range covered by the trajectory.
-
-        """
-        if self.unit_cell_warning == NO_CELL:
-            return None
-        self._check_frame(frame)
-        return UnitCell(self._h5_file["unit_cell"][frame].astype(np.float64))
 
     def __len__(self) -> int:
         """Return the length of the trajectory.

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -101,8 +101,7 @@ class MdanseTrajectory(TrajectoryFile):
         self._has_database = "atom_database" in self._h5_file
         self._has_atoms = []
 
-        # Load all the unit cells
-        self._load_unit_cells()
+        self._check_unit_cells()
 
         # Load the chemical system
         self._chemical_system = ChemicalSystem(
@@ -298,7 +297,7 @@ class MdanseTrajectory(TrajectoryFile):
         """
         self._check_frame(frame)
 
-        unit_cell = self._unit_cells[frame] if self._unit_cells is not None else None
+        unit_cell = self.unit_cell(frame)
 
         variables = {
             k: v[frame, :, :].astype(np.float64)
@@ -319,27 +318,23 @@ class MdanseTrajectory(TrajectoryFile):
 
         return conf
 
-    def _load_unit_cells(self):
-        """Load all the unit cells."""
-        if "unit_cell" in self._h5_file:
-            self._unit_cells = [UnitCell(uc) for uc in self._h5_file["unit_cell"][:]]
-        else:
-            self._unit_cells = None
+    def _check_unit_cells(self):
+        """Check unit cells."""
+        if "unit_cell" not in self._h5_file:
             self.unit_cell_warning = NO_CELL
 
         if not self.unit_cell_warning:
-            if self._unit_cells[0].volume < CELL_SIZE_LIMIT:
+            if self.unit_cell(0).volume < CELL_SIZE_LIMIT:
                 self.unit_cell_warning = BAD_CELL
                 return
 
-            reference_array = self._unit_cells[0].direct
+            reference_array = self._h5_file["unit_cell"][0]
 
-            if any(
-                not np.allclose(reference_array, uc.direct)
-                for uc in self._unit_cells[1:]
-            ):
-                self.unit_cell_warning = CHANGING_CELL
-                return
+            if self._h5_file["unit_cell"].shape[0] > 1:
+                directs = self._h5_file["unit_cell"][1:]
+                if not np.allclose(directs, reference_array):
+                    self.unit_cell_warning = CHANGING_CELL
+                    return
 
     def time(self):
         """Return the time array for all the frames."""
@@ -364,11 +359,10 @@ class MdanseTrajectory(TrajectoryFile):
             If frame index is out of the range covered by the trajectory.
 
         """
+        if self.unit_cell_warning == NO_CELL:
+            return None
         self._check_frame(frame)
-
-        if self._unit_cells is not None:
-            return self._unit_cells[frame]
-        return None
+        return UnitCell(self._h5_file["unit_cell"][frame].astype(np.float64))
 
     def __len__(self) -> int:
         """Return the length of the trajectory.

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -34,12 +34,6 @@ from MDANSE.MolecularDynamics.Configuration import (
     AbsoluteConfiguration,
     PeriodicAbsoluteConfiguration,
 )
-from MDANSE.MolecularDynamics.UnitCell import (
-    BAD_CELL,
-    CELL_SIZE_LIMIT,
-    CHANGING_CELL,
-    NO_CELL,
-)
 from MDANSE.util_types import FloatArray
 
 from .FileTrajBase import TrajectoryFile
@@ -318,25 +312,12 @@ class MdanseTrajectory(TrajectoryFile):
         return conf
 
     def _load_unit_cells(self):
-        """Check unit cells."""
+        """Load the unit cells."""
         if "unit_cell" in self._h5_file:
             self.unit_cells_raw = self._h5_file["unit_cell"][:]
         else:
             self.unit_cells_raw = None
-            self.unit_cell_warning = NO_CELL
-
-        if not self.unit_cell_warning:
-            if self.unit_cell(0).volume < CELL_SIZE_LIMIT:
-                self.unit_cell_warning = BAD_CELL
-                return
-
-            reference_array = self.unit_cells_raw[0]
-
-            if self.unit_cells_raw.shape[0] > 1:
-                directs = self.unit_cells_raw[1:]
-                if not np.allclose(directs, reference_array):
-                    self.unit_cell_warning = CHANGING_CELL
-                    return
+        self.check_unit_cells()
 
     def time(self):
         """Return the time array for all the frames."""


### PR DESCRIPTION
**Description of work**
Decrease the amount of time taken to load a very long trajectory in the GUI and switch job analysis in the Jobs tab. Turned off chunking for unit_cell and time arrays.

**Fixes**
Slowdown of the GUI with a very long trajectory.

**To test**
Generate a very long trajectory e.g. 1 million frames. Just a few atoms should be fine. Convert with the protos version and then autoload into the GUI and select different jobs. Convert with this branch, autoload into GUI, and select different jobs; it should be much faster.
