### PR TITLE
Property viewer only updates when property viewer tab is selected and optimisations for a large number of atoms.

### DIFF
--- a/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
+++ b/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
@@ -148,27 +148,36 @@ class ChemicalSystem:
             list of atom text labels from trajectory, by default None
 
         """
-        self._atom_indices = [
-            self.add_atom(self._database.get_atom_property(symbol, "atomic_number"))
-            for symbol in element_list
-        ]
+        # reduce calls to get_atom_property and create_rdkit_atom
+        # which can be expensive with a large number of atoms
+        atm_nums = {
+            elem: self._database.get_atom_property(elem, "atomic_number")
+            for elem in set(element_list)
+        }
+        rdkit_atms = {
+            elem: self.create_rdkit_atom(atm_num) for elem, atm_num in atm_nums.items()
+        }
+
+        self._atom_indices = []
+        self._rdkit_dummy_atms = set()
+        for symbol in element_list:
+            atm_num = atm_nums[symbol]
+            idx = self.rdkit_mol.AddAtom(rdkit_atms[symbol])
+            self._atom_indices.append(idx)
+            if atm_num is None or atm_num == 0:
+                self._rdkit_dummy_atms.add(idx)
+
         self._atom_types = [str(x) for x in element_list]
         self._total_number_of_atoms = len(self._atom_indices)
         self._unique_elements.update(set(element_list))
         if name_list is not None:
             self._atom_names = [str(x) for x in name_list]
 
-        self._rdkit_dummy_atms = {
-            atom.GetIdx()
-            for atom in self.rdkit_mol.GetAtoms()
-            if atom.GetAtomicNum() == 0
-        }
-
-    def add_atom(self, atm_num: int | None) -> int:
+    def create_rdkit_atom(self, atm_num: int | None) -> Chem.Atom:
         rdkit_atm = Chem.Atom(atm_num) if atm_num is not None else Chem.Atom(0)
         rdkit_atm.SetNumExplicitHs(0)
         rdkit_atm.SetNoImplicit(True)
-        return self.rdkit_mol.AddAtom(rdkit_atm)
+        return rdkit_atm
 
     def add_bonds(self, pair_list: Iterable[tuple[SupportsInt, SupportsInt]]):
         self._bonds.extend(pair_list)

--- a/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
+++ b/MDANSE/Src/MDANSE/Chemistry/ChemicalSystem.py
@@ -164,7 +164,7 @@ class ChemicalSystem:
             atm_num = atm_nums[symbol]
             idx = self.rdkit_mol.AddAtom(rdkit_atms[symbol])
             self._atom_indices.append(idx)
-            if atm_num is None or atm_num == 0:
+            if not atm_num:
                 self._rdkit_dummy_atms.add(idx)
 
         self._atom_types = [str(x) for x in element_list]

--- a/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
+++ b/MDANSE/Src/MDANSE/Framework/Configurators/HDFTrajectoryConfigurator.py
@@ -106,7 +106,7 @@ def next_prime(nchunks: int) -> int:
 def guess_hdf5_trajectory_parameters(
     fname: str | Path,
 ) -> tuple[int, int] | tuple[None, None]:
-    trajectory_instance = Trajectory(fname)
+    trajectory_instance = Trajectory(fname, fast_load=True)
     traj_length = len(trajectory_instance)
     chunk_size = trajectory_instance.chunk_size()
     bytes_per_num = trajectory_instance.dtype_size()

--- a/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
+++ b/MDANSE/Src/MDANSE/Trajectory/MdanseTrajectory.py
@@ -159,17 +159,6 @@ class MdanseTrajectory(TrajectoryFile):
                 "If you run into issues, consider regenerating the file with this version of MDANSE."
             )
 
-        try:
-            mdtraj = cls(filename)
-            chem = ChemicalSystem(filename.stem, mdtraj)
-            chem.load(filename)
-        except Exception:
-            LOG.warning(
-                f"Could not load ChemicalSystem from {filename}. MDANSE will try"
-                " to read it as H5MD next.",
-            )
-            return False
-
         if (
             "/composition" not in file_object
             or "name" not in file_object["/composition"].attrs

--- a/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/MolecularViewer/PropertyWidget.py
@@ -101,12 +101,10 @@ class PropertyWidget(QWidget):
         self._prop_type.addItems(["atoms", "trajectory"])
         self._prop_type.setCurrentIndex(0)
         self._prop_type.currentTextChanged.connect(self.get_props)
-        self._prop_type.currentTextChanged.connect(self._activate)
 
         self._prop_selection = QComboBox(self)
         self._prop_selection.setEditable(False)
         self._prop_selection.currentTextChanged.connect(self.update_table)
-        self._prop_selection.currentTextChanged.connect(self._activate)
 
         self._prop_model = QStandardItemModel()
         self._prop_table = QTableView(self)


### PR DESCRIPTION
**Description of work**
Previously, the property viewer would update even when the property viewer tab was not selected. This causes a slowdown when loading large trajectories and changing the frame for the first time, even when the property viewer tab is not open. Subsequent frame changes after the first slow one are fast.

Optimisation to reduce the amount of time selecting trajectories or analysis jobs for trajectories with a large number of atoms.

**To test**
Check that the property tab updates as usual. Load a large trajectory e.g. 500K atoms (to save disk space, you can test with a small number of frames), and change the frame; an update to the property viewer should not happen anymore, so it should be fast.
