### PR TITLE
Select a subset of all masses in CenterOfMassesTrajectory

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/CenterOfMassesTrajectory.py
@@ -155,14 +155,15 @@ class CenterOfMassesTrajectory(IJob):
                     continue
 
                 individual_coordinates = conf.coordinates[cluster]
+                individual_masses = [self.masses[at_index] for at_index in cluster]
                 centre_of_mass = center_of_mass(
                     individual_coordinates,
-                    [self.masses[at_index] for at_index in cluster],
+                    individual_masses,
                 )
                 com_coords[mol_index] = centre_of_mass
                 average_radius = individual_coordinates - centre_of_mass.reshape(1, 3)
                 average_radius = np.linalg.norm(average_radius, axis=1)
-                average_radius = np.average(average_radius, weights=self.masses)
+                average_radius = np.average(average_radius, weights=individual_masses)
                 temp_radii[cluster_name].append(average_radius)
                 mol_index += 1
         for atom_index in self.selected_indices:

--- a/MDANSE/Tests/UnitTests/Analysis/test_trajectory.py
+++ b/MDANSE/Tests/UnitTests/Analysis/test_trajectory.py
@@ -7,6 +7,7 @@ from MDANSE.Framework.Jobs.IJob import IJob
 from test_helpers.paths import CONV_DIR
 
 short_traj = CONV_DIR / "short_trajectory_after_changes.mdt"
+molecule_traj = CONV_DIR / "named_molecules.mdt"
 
 
 ################################################################
@@ -64,6 +65,7 @@ def test_CenterOfMassesTrajectory(tmp_path, parameters):
     log_file = temp_name.with_suffix(".log")
 
     parameters["output_files"] = (temp_name, 64, 128, "gzip", "INFO")
+    parameters["trajectory"] = molecule_traj
     job = IJob.create("CenterOfMassesTrajectory")
     job.run(parameters, status=True)
 


### PR DESCRIPTION
**Description of work**
Changes `CenterOfMassesTrajectory` so that the mass array passed to `np.average` has the same length as the array of atom distances from the molecule centre.

closes #1280

**Fixes**
1. Use a list of masses built using the atom indices of the molecule to calculate the average position.
2. Use a trajectory containing named molecules for testing `CenterOfMassesTrajectory` in unit tests.

**To test**
Load a trajectory containing molecules and run `CentreOfMassesTrajectory` on it.
