### PR TITLE
Add sliding progress bar on job startup

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/JobStatusProcess.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Subprocess/JobStatusProcess.py
@@ -36,7 +36,6 @@ class JobCommunicator(QObject):
     target = Signal(int)
     progress = Signal(int)
     finished = Signal(bool)
-    oscillate = Signal()
 
     def status_update(self, state: JobInfo):
         """Update relevant status windows.
@@ -51,11 +50,8 @@ class JobCommunicator(QObject):
         NotImplementedError
             Paused is not currently supported in this interface.
         """
-        if state.state is JobStates.STARTING:
-            if state.n_steps is not None:
-                self.target.emit(state.n_steps)
-            else:
-                self.oscillate.emit()
+        if state.state is JobStates.STARTING and state.n_steps is not None:
+            self.target.emit(state.n_steps)
 
         elif state.state is JobStates.RUNNING:
             self.progress.emit(state.progress)

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -35,7 +35,7 @@ from MDANSE.IO.IOUtils import job_status_text_summary
 from MDANSE.MLogging import FMT, LOG
 from MDANSE_GUI.Subprocess.JobStatusProcess import JobCommunicator
 from MDANSE_GUI.Subprocess.Subprocess import Connection, Subprocess
-from MDANSE_GUI.Tabs.Views.Delegates import ProgressDelegate
+from MDANSE_GUI.Tabs.Views.Delegates import OSCILLATOR_STEPS, ProgressDelegate
 
 
 class JobThread(QThread):
@@ -144,8 +144,16 @@ class JobEntry(QObject):
         self._prog_item.setData(0, role=Qt.ItemDataRole.UserRole)
         self._prog_item.setData("progress", role=Qt.ItemDataRole.DisplayRole)
         self._prog_item.setData(0, role=ProgressDelegate.progress_role)
-        self._prog_item.setData(100, role=ProgressDelegate.progress_role + 1)
+        self._prog_item.setData(
+            OSCILLATOR_STEPS, role=ProgressDelegate.progress_role + 1
+        )
+        self.oscillator_timer = QTimer()
+        self.oscillator_timer.setInterval(100)
+        self.oscillator_timer.timeout.connect(self.advance_oscillator)
+        self.oscillator_pos = 0
         self.handler = JobLogHandler()
+        self.oscillator_timer.start()
+        self._stat_item.setText(self.job.state.name.title())
 
     def text_summary(self) -> str:
         nl = "\n"
@@ -157,6 +165,18 @@ Parameters:
 {job_status_text_summary(self.job)}
 """
 
+    def advance_oscillator(self):
+        if self.job.state == JobStates.STARTING:
+            self.oscillator_pos -= 1
+            if self.oscillator_pos < -2 * OSCILLATOR_STEPS:
+                self.oscillator_pos = -1
+            self._prog_item.setData(
+                self.oscillator_pos,
+                role=ProgressDelegate.progress_role,
+            )
+        else:
+            self.oscillator_timer.stop()
+
     def update_fields(self):
         self._prog_item.setText(
             f"{self.job.progress} percent complete ({self.job.pct_rate} %/s)"
@@ -165,6 +185,9 @@ Parameters:
         self._prog_item.setData(
             int(self.job.current_step),
             role=ProgressDelegate.progress_role,
+        )
+        self._prog_item.setData(
+            self.job.n_steps, role=ProgressDelegate.progress_role + 1
         )
         self._prog_item.setData(
             self.job.pct_rate,
@@ -211,11 +234,11 @@ Parameters:
     def on_started(self, target_steps: int):
         LOG.info(f"Item received on_started: {target_steps} total steps")
         self.job.n_steps = target_steps
-        self._prog_item.setData(target_steps, role=ProgressDelegate.progress_role + 1)
-        self.start_job()
+        self._stat_item.setText(self.job.state.name.title())
 
     @Slot(int)
     def on_update(self, completed_steps: int):
+        self.job.state = JobStates.RUNNING
         # print(f"completed {completed_steps} out of {self.total_steps} steps")
         self.job.elapsed = time.time() - self.job.start
         if self.job.n_steps > 0:
@@ -229,10 +252,6 @@ Parameters:
 
         self.update_fields()
         self._prog_item.emitDataChanged()
-
-    @Slot()
-    def on_oscillate(self):
-        """For jobs with unknown duration, the progress bar will bounce."""
 
     def start_job(self):
         self.job.state = JobStates.RUNNING
@@ -348,7 +367,6 @@ class JobHolder(QStandardItemModel):
         communicator.target.connect(item_th.on_started)  # int
         communicator.progress.connect(item_th.on_update)  # int
         communicator.finished.connect(item_th.on_finished)  # bool
-        communicator.oscillate.connect(item_th.on_oscillate)  # nothing
 
         LOG.debug("Watcher thread ready to start!")
         watcher_thread.start()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Models/JobHolder.py
@@ -174,6 +174,8 @@ Parameters:
                 self.oscillator_pos,
                 role=ProgressDelegate.progress_role,
             )
+        elif self.job.state == JobStates.PAUSED:
+            return
         else:
             self.oscillator_timer.stop()
 
@@ -238,7 +240,8 @@ Parameters:
 
     @Slot(int)
     def on_update(self, completed_steps: int):
-        self.job.state = JobStates.RUNNING
+        if self.job.state == JobStates.STARTING:
+            self.job.state = JobStates.RUNNING
         # print(f"completed {completed_steps} out of {self.total_steps} steps")
         self.job.elapsed = time.time() - self.job.start
         if self.job.n_steps > 0:

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/Delegates.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/Delegates.py
@@ -32,6 +32,8 @@ from qtpy.QtWidgets import (
 
 from MDANSE_GUI.Utils import block_signals
 
+OSCILLATOR_STEPS = 20
+
 
 class ColourPicker(QStyledItemDelegate):
     def __init__(self, *args, **kwargs) -> None:
@@ -154,13 +156,27 @@ class ProgressDelegate(QItemDelegate):
         except Exception:
             progress = 0
         opt = QStyleOptionProgressBar()
-        opt.rect = option.rect
-        opt.minimum = 0
-        opt.maximum = progress_max
-        opt.progress = progress
-        opt.text = f"{progress / progress_max:.2%}"
-        with suppress(Exception):
-            opt.text += f" ({round(float(rate), 2)} %/s)"
+        if progress < 0:
+            if progress < -OSCILLATOR_STEPS:
+                opt.direction = Qt.LayoutDirection.RightToLeft
+            else:
+                opt.direction = Qt.LayoutDirection.LeftToRight
+            opt.rect = option.rect
+            opt.minimum = 0
+            opt.maximum = OSCILLATOR_STEPS
+            opt.progress = abs(OSCILLATOR_STEPS + progress)
+            opt.text = "STARTING"
+            opt.textVisible = True
+        else:
+            opt.direction = Qt.LayoutDirection.LeftToRight
+            opt.rect = option.rect
+            opt.minimum = 0
+            opt.maximum = progress_max
+            opt.progress = abs(progress)
+            opt.text = f"{progress / progress_max:.2%}"
+            with suppress(Exception):
+                opt.text += f" ({round(float(rate), 2)} %/s)"
 
-        opt.textVisible = True
+            opt.textVisible = True
+
         QApplication.style().drawControl(QStyle.CE_ProgressBar, opt, painter)


### PR DESCRIPTION
**Description of work**
A minor change to the GUI behaviour: when a job is starting and has not completed a single step, show a scrolling bar in the "Running Jobs" table with the text "STARTING". This is meant mainly to reassure the user that the specific job is being prepared.

**Fixes**
1. Add a `QTimer` to `JobEntry`, to control the progress bar movement in the starting phase.
2. Extend `ProgressDelegate` to handle negative values of progress.

**To test**
Start a converter or an analysis run.
Go to the "Running Jobs" tab and check if the "Starting" message is shown on the progress bar before the run starts.
Try pausing and resuming the run before and after the "Starting" message has disappeared. All the buttons from the context menu should work the same as before.
