### PR TITLE
Use read_atomic_trajectory_many in other analysis jobs

### DIFF
--- a/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/ElasticIncoherentStructureFactor.py
@@ -22,6 +22,7 @@ from MDANSE.Framework.AtomGrouping.grouping import (
 )
 from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 
 @IJob.register("ElasticIncoherentStructureFactor")
@@ -103,11 +104,22 @@ class ElasticIncoherentStructureFactor(IJob):
         """
         super().initialize()
 
-        self.numberOfSteps = len(self.trajectory.atom_indices)
-
         self._nQShells = self.configuration["q_vectors"]["n_shells"]
 
         self._nFrames = self.configuration["frames"]["number"]
+
+        vectors_per_shell = self.configuration["q_vectors"]["parameters"].get(
+            "n_vectors", 1
+        )
+        n_proc = self.configuration["running_mode"].get("slots", 1)
+
+        self.grouped_indices = group_atom_indices(
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=6 * vectors_per_shell,
+        )
+        self.numberOfSteps = len(self.grouped_indices)
 
         self.labels = [
             (element, (element,)) for element in self.trajectory.get_natoms()
@@ -152,12 +164,11 @@ class ElasticIncoherentStructureFactor(IJob):
             #. index (int): The index of the step.
             #. atomicEISF (np.array): The atomic elastic incoherent structure factor
         """
+        atom_index_group = self.grouped_indices[index]
+        n_atoms = len(atom_index_group)
 
-        # get atom index
-        atom_index = self.trajectory.atom_indices[index]
-
-        series = self.trajectory.read_atomic_trajectory(
-            atom_index,
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=self.configuration["frames"]["first"],
             last=self.configuration["frames"]["last"] + 1,
             step=self.configuration["frames"]["step"],
@@ -165,7 +176,7 @@ class ElasticIncoherentStructureFactor(IJob):
 
         series = self.configuration["projection"]["projector"](series)
 
-        atomicEISF = np.zeros((self._nQShells,), dtype=np.float64)
+        atomicEISF = np.zeros((self._nQShells, n_atoms), dtype=np.float64)
 
         for i, q in enumerate(self.configuration["q_vectors"]["shells"]):
             if self.configuration["q_vectors"]["value"][q] is None:
@@ -175,10 +186,12 @@ class ElasticIncoherentStructureFactor(IJob):
             qVectors = self.configuration["q_vectors"]["value"][q]["q_vectors"]
             qvec_weights = self.configuration["q_vectors"]["value"][q]["weights"]
 
-            a = np.average(np.exp(1j * np.dot(series, qVectors)), axis=0)
+            a = np.average(
+                np.exp(1j * np.dot(qVectors.T, np.swapaxes(series, 1, 2))), axis=1
+            )
             a = np.abs(a) ** 2
 
-            atomicEISF[i] = np.average(a, weights=qvec_weights)
+            atomicEISF[i] = np.average(a, axis=0, weights=qvec_weights)
 
         return index, atomicEISF
 
@@ -189,11 +202,10 @@ class ElasticIncoherentStructureFactor(IJob):
             #. index (int): The index of the step.\n
             #. x (any): The returned result(s) of run_step
         """
-
-        # The symbol of the atom.
-        element = self._atoms[self.trajectory.atom_indices[index]]
-
-        self._outputData[f"eisf/{element}"] += x
+        at_indices = self.grouped_indices[index]
+        for rel_index, abs_index in enumerate(at_indices):
+            element = self._atoms[abs_index]
+            self._outputData[f"eisf/{element}"] += x[:, rel_index]
 
     def finalize(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -25,6 +25,7 @@ from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_
 from MDANSE.Mathematics.Signal import get_spectrum
 from MDANSE.MolecularDynamics.Analysis import mean_square_displacement
 from MDANSE.util_types import FloatArray
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 
 @IJob.register("GaussianDynamicIncoherentStructureFactor")
@@ -108,7 +109,14 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         """
         super().initialize()
 
-        self.numberOfSteps = len(self.trajectory.atom_indices)
+        n_proc = self.configuration["running_mode"].get("slots", 1)
+        self.grouped_indices = group_atom_indices(
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=2,
+        )
+        self.numberOfSteps = len(self.grouped_indices)
 
         self._nQShells = self.configuration["q_shells"]["number"]
 
@@ -248,10 +256,11 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         """
 
         # get atom index
-        atom_index = self.trajectory.atom_indices[index]
+        atom_index_group = self.grouped_indices[index]
+        n_atoms = len(atom_index_group)
 
-        series = self.trajectory.read_atomic_trajectory(
-            atom_index,
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=self.configuration["frames"]["first"],
             last=self.configuration["frames"]["last"] + 1,
             step=self.configuration["frames"]["step"],
@@ -259,15 +268,17 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
 
         series = self.configuration["projection"]["projector"](series)
 
-        atomicSF = np.zeros((self._nQShells, self._nFrames), dtype=np.float64)
+        atomicSF = np.zeros((self._nQShells, self._nFrames, n_atoms), dtype=np.float64)
 
         msd = mean_square_displacement(
-            series, self.configuration["frames"]["n_configs"]
+            series,
+            self.configuration["frames"]["n_configs"],
+            self.configuration["frames"]["n_frames"],
         )
 
         for i, q2 in enumerate(self._kSquare):
             gaussian = np.exp(-msd * q2 / 6.0)
-            atomicSF[i, :] += gaussian
+            atomicSF[i, ...] += gaussian
 
         return index, (atomicSF, msd)
 
@@ -281,10 +292,12 @@ class GaussianDynamicIncoherentStructureFactor(IJob):
         x : tuple[FloatArray, FloatArray]
             A tuple of the GDISF and MSD of an atom.
         """
-        element = self._atoms[self.trajectory.atom_indices[index]]
         atomicSF, msd = x
-        self._outputData[f"gdisf/f(q,t)/{element}"] += atomicSF
-        self._outputData[f"msd/{element}"] += msd
+        at_indices = self.grouped_indices[index]
+        for rel_index, abs_index in enumerate(at_indices):
+            element = self._atoms[abs_index]
+            self._outputData[f"gdisf/f(q,t)/{element}"] += atomicSF[..., rel_index]
+            self._outputData[f"msd/{element}"] += msd[..., rel_index]
 
     def finalize(self):
         """

--- a/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/GaussianDynamicIncoherentStructureFactor.py
@@ -24,8 +24,8 @@ from MDANSE.Framework.Jobs.IJob import IJob
 from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
 from MDANSE.Mathematics.Signal import get_spectrum
 from MDANSE.MolecularDynamics.Analysis import mean_square_displacement
-from MDANSE.util_types import FloatArray
 from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
+from MDANSE.util_types import FloatArray
 
 
 @IJob.register("GaussianDynamicIncoherentStructureFactor")

--- a/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
+++ b/MDANSE/Src/MDANSE/Framework/Jobs/MeanSquareDisplacement.py
@@ -19,8 +19,8 @@ from MDANSE.Framework.AtomGrouping.grouping import (
     add_grouped_totals,
 )
 from MDANSE.Framework.Jobs.IJob import IJob
-from MDANSE.Mathematics.Arithmetic import assign_weights, get_weights, weighted_sum
 from MDANSE.MolecularDynamics.Analysis import mean_square_displacement
+from MDANSE.MolecularDynamics.TrajectoryUtils import group_atom_indices
 
 
 @IJob.register("MeanSquareDisplacement")
@@ -100,7 +100,14 @@ class MeanSquareDisplacement(IJob):
         """
         super().initialize()
 
-        self.numberOfSteps = len(self.trajectory.atom_indices)
+        n_proc = self.configuration["running_mode"].get("slots", 1)
+        self.grouped_indices = group_atom_indices(
+            self.trajectory,
+            self.configuration["frames"]["number"],
+            n_proc=n_proc,
+            memory_scale_factor=2,
+        )
+        self.numberOfSteps = len(self.grouped_indices)
 
         self.labels = [
             (element, (element,)) for element in self.trajectory.get_natoms()
@@ -146,11 +153,10 @@ class MeanSquareDisplacement(IJob):
         Returns:
             tuple: the result of the step
         """
+        atom_index_group = self.grouped_indices[index]
 
-        # get selected atom indices sublist
-        atom_index = self.trajectory.atom_indices[index]
-        series = self.configuration["trajectory"]["instance"].read_atomic_trajectory(
-            atom_index,
+        series = self.trajectory.read_atomic_trajectory_many(
+            atom_index_group,
             first=self.configuration["frames"]["first"],
             last=self.configuration["frames"]["last"] + 1,
             step=self.configuration["frames"]["step"],
@@ -159,7 +165,9 @@ class MeanSquareDisplacement(IJob):
         series = self.configuration["projection"]["projector"](series)
 
         msd = mean_square_displacement(
-            series, self.configuration["frames"]["n_configs"]
+            series,
+            self.configuration["frames"]["n_configs"],
+            self.configuration["frames"]["n_frames"],
         )
 
         return index, msd
@@ -171,12 +179,11 @@ class MeanSquareDisplacement(IJob):
         Args:
             result (tuple): the output of run_step method
         """
-
-        # The symbol of the atom.
-        element = self._atoms[self.trajectory.atom_indices[index]]
-
-        self._outputData[f"msd/{element}"] += result
-        self._outputData["msd/total"] += result
+        at_indices = self.grouped_indices[index]
+        for rel_index, abs_index in enumerate(at_indices):
+            element = self._atoms[abs_index]
+            self._outputData[f"msd/{element}"] += result[:, rel_index]
+            self._outputData["msd/total"] += result[:, rel_index]
 
     def finalize(self):
         """

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from scipy.signal import correlate
+from scipy import fft
 
 from MDANSE.Mathematics.Geometry import center_of_mass
 
@@ -30,7 +30,9 @@ class AnalysisError(Exception):
     pass
 
 
-def mean_square_displacement(coords: FloatArray, n_configs: int) -> FloatArray:
+def mean_square_displacement(
+    coords: FloatArray, n_configs: int, n_frames: int
+) -> FloatArray:
     """Computes the mean square displacement of a set of coordinates
     using the MSD algorithm described in Kneller et al., Com. Phys. Com., 1995.
 
@@ -40,16 +42,26 @@ def mean_square_displacement(coords: FloatArray, n_configs: int) -> FloatArray:
         Coordinates used to calculate MSD.
     n_configs : int
         Size of the window used to correlated positions.
+    n_frames : int
+        Number of correlation frames.
 
     Returns
     -------
     FloatArray
         An array of the MSD.
     """
-    r2 = coords * coords
-    window = np.ones((n_configs, 3))
-    r2t = correlate(r2, window, mode="valid").T[0] / n_configs
-    rtr0 = correlate(coords, coords[:n_configs], mode="valid").T[0] / n_configs
+    r2 = np.sum(coords * coords, axis=2)
+    window = np.ones((n_configs, coords.shape[1]))
+
+    fast_len = fft.next_fast_len(coords.shape[0])
+    v = fft.fft(r2, n=fast_len, axis=0)
+    w = fft.fft(window, n=fast_len, axis=0)
+    r2t = fft.ifft(v * w.conj(), axis=0).real[:n_frames] / n_configs
+
+    v = fft.fft(coords, n=fast_len, axis=0)
+    w = fft.fft(coords[:n_configs], n=fast_len, axis=0)
+    rtr0 = fft.ifft(np.sum(v * w.conj(), axis=2), axis=0).real[:n_frames] / n_configs
+
     msd = r2t[0] + r2t - 2 * rtr0
     return msd
 

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Analysis.py
@@ -39,7 +39,7 @@ def mean_square_displacement(
     Parameters
     ----------
     coords : FloatArray
-        Coordinates used to calculate MSD.
+        Coordinates used to calculate MSD, (time, atom, xyz).
     n_configs : int
         Size of the window used to correlated positions.
     n_frames : int
@@ -48,7 +48,7 @@ def mean_square_displacement(
     Returns
     -------
     FloatArray
-        An array of the MSD.
+        An array of the MSDs, (time, atom).
     """
     r2 = np.sum(coords * coords, axis=2)
     window = np.ones((n_configs, coords.shape[1]))

--- a/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
+++ b/MDANSE/Src/MDANSE/MolecularDynamics/Trajectory.py
@@ -718,7 +718,7 @@ class Trajectory:
 
         Parameters
         ----------
-        index : int
+        index_list : list[int]
             The index of the atom.
         first : int
             The index of the first frame. (Default value = 0)
@@ -732,7 +732,7 @@ class Trajectory:
         Returns
         -------
         ndarray
-            2D array containing the atomic trajectory for the selected frames
+            3D array containing the atomic trajectory for the selected frames
 
         """
         return self._trajectory.read_atomic_trajectory_many(

--- a/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
+++ b/MDANSE/Src/MDANSE/Trajectory/FileTrajBase.py
@@ -371,7 +371,7 @@ class TrajectoryFile(ABC):
 
         Parameters
         ----------
-        index : int
+        index_list : list[int]
             The index of the atom.
         first : int
             The index of the first frame. (Default value = 0)
@@ -385,7 +385,7 @@ class TrajectoryFile(ABC):
         Returns
         -------
         ndarray
-            2D array containing the atomic trajectory for the selected frames
+            3D array containing the atomic trajectory for the selected frames
 
         """
         slc = np.s_[first:last:step]

--- a/MDANSE/Tests/UnitTests/test_analysis.py
+++ b/MDANSE/Tests/UnitTests/test_analysis.py
@@ -7,7 +7,7 @@ from MDANSE.MolecularDynamics.Analysis import (AnalysisError,
 
 COORDS = [
     np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]], dtype=float),
-    np.array([[1, 1, 1], [2, 1, 1], [3, 1, 1]], dtype=float),
+    np.array([[[1, 1, 1]], [[2, 1, 1]], [[3, 1, 1]]], dtype=float),
     np.array([[1, 1, 1], [2, 1, 1], [8, 1, 1]], dtype=float),
     np.array([[1, 2, 1], [2, 1, 1], [10, 5, 5], [1, 1, 2]], dtype=float),
     np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
@@ -17,11 +17,11 @@ COORDS = [
 ]
 
 
-@pytest.mark.parametrize("coords, n_configs, expected", [
-    (COORDS[1], 1, [0., 1., 4.])
+@pytest.mark.parametrize("coords, n_configs, n_frames, expected", [
+    (COORDS[1], 1, 3, [[0.], [1.], [4.]])
 ])
-def test_mean_square_displacement(coords, n_configs, expected):
-    msd = mean_square_displacement(coords, n_configs)
+def test_mean_square_displacement(coords, n_configs, n_frames, expected):
+    msd = mean_square_displacement(coords, n_configs, n_frames)
     assert np.allclose(msd, expected)
 
 @pytest.mark.parametrize("coords, root, expected", [


### PR DESCRIPTION
**Description of work**
The execution time for some jobs are dominated by the file reading as the default chunking has 128 atoms and 1 frame per chunk. This make job which require all frames per step particularly slow, the 1 frame chunking is better for the trajectory conversion and some other analysis jobs e.g. PDF. A performance update was made in #1235 which speed up the DISF calculation, we should be able to apply a similar update to a lot of the other jobs.

**To test**
Tests should pass. Try a few jobs and compare timings against protos, this version should be faster.
