### PR TITLE
[RFC] Optional script creating a desktop launcher for MDANSE_GUI

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Scripts/create_mdanse_link.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Scripts/create_mdanse_link.py
@@ -29,15 +29,15 @@ def main():
             "To create a shortcut and menu entry for MDANSE_GUI, "
             "this script needs the 'pyshortcuts' package.\n"
             "You can install it by running\n"
-            "pip install MDANSE_GUI.[extras]"
+            "pip install MDANSE_GUI[extras]"
         )
     else:
-        script_path = os.path.dirname(os.path.abspath(__file__))
+        script_path = Path(__file__).parent
         make_shortcut(
-            os.path.join(script_path, "mdanse_gui.py"),
+            script_path / "mdanse_gui.py",
             name="MDANSE_GUI",
             working_dir=script_path,
-            description="MDANSE 2, software for molecular dynamics trajectory analysis",
+            description=f"MDANSE {MDANSE_GUI.__version__}, software for molecular dynamics trajectory analysis",
             icon=mdanse_icon_path,
         )
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/Scripts/create_mdanse_link.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Scripts/create_mdanse_link.py
@@ -1,0 +1,46 @@
+#    This file is part of MDANSE_GUI.
+#
+#    MDANSE_GUI is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from __future__ import annotations
+
+import os
+import sys
+
+from MDANSE_GUI.main import mdanse_icon_path
+
+
+def main():
+    try:
+        from pyshortcuts import make_shortcut
+    except ImportError:
+        print(  # noqa: T201
+            "To create a shortcut and menu entry for MDANSE_GUI, "
+            "this script needs the 'pyshortcuts' package.\n"
+            "You can install it by running\n"
+            "pip install MDANSE_GUI.[extras]"
+        )
+    else:
+        script_path = os.path.dirname(os.path.abspath(__file__))
+        make_shortcut(
+            os.path.join(script_path, "mdanse_gui.py"),
+            name="MDANSE_GUI",
+            working_dir=script_path,
+            description="MDANSE 2, software for molecular dynamics trajectory analysis",
+            icon=mdanse_icon_path,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Scripts/create_mdanse_link.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Scripts/create_mdanse_link.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
+import MDANSE_GUI
 from MDANSE_GUI.main import mdanse_icon_path
 
 
@@ -34,11 +36,11 @@ def main():
     else:
         script_path = Path(__file__).parent
         make_shortcut(
-            script_path / "mdanse_gui.py",
+            str(script_path / "mdanse_gui.py"),
             name="MDANSE_GUI",
-            working_dir=script_path,
+            working_dir=str(script_path),
             description=f"MDANSE {MDANSE_GUI.__version__}, software for molecular dynamics trajectory analysis",
-            icon=mdanse_icon_path,
+            icon=str(mdanse_icon_path),
         )
 
 

--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -41,8 +41,8 @@ old_hook = sys.excepthook
 sys.excepthook = catch_exceptions
 # end of exception handling part.
 
-mdanse_gui_path = os.path.dirname(os.path.abspath(__file__))
-mdanse_icon_path = os.path.join(mdanse_gui_path, "Icons/MDANSE.ico")
+mdanse_gui_path = Path(__file__).parent
+mdanse_icon_path = mdanse_gui_path / "Icons/MDANSE.ico"
 
 
 def build_parser():
@@ -84,7 +84,7 @@ def startGUI(some_args):
     app = QApplication(some_args)
     app.setStyle(QStyleFactory.create("Fusion"))
 
-    app.setWindowIcon(QIcon(mdanse_icon_path))
+    app.setWindowIcon(QIcon(str(mdanse_icon_path)))
     fixed_locale = QLocale(QLocale.Language.English, QLocale.Country.UnitedKingdom)
     fixed_locale.setNumberOptions(
         QLocale.NumberOption.RejectGroupSeparator

--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -21,6 +21,7 @@ import sys
 import textwrap
 import time
 from argparse import ArgumentParser
+from pathlib import Path
 
 from qtpy.QtCore import QLocale, QSettings, Qt, QTimer
 from qtpy.QtGui import QIcon, QPixmap

--- a/MDANSE_GUI/Src/MDANSE_GUI/main.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/main.py
@@ -41,6 +41,9 @@ old_hook = sys.excepthook
 sys.excepthook = catch_exceptions
 # end of exception handling part.
 
+mdanse_gui_path = os.path.dirname(os.path.abspath(__file__))
+mdanse_icon_path = os.path.join(mdanse_gui_path, "Icons/MDANSE.ico")
+
 
 def build_parser():
     parser = ArgumentParser(
@@ -81,8 +84,7 @@ def startGUI(some_args):
     app = QApplication(some_args)
     app.setStyle(QStyleFactory.create("Fusion"))
 
-    path = os.path.dirname(os.path.abspath(__file__))
-    app.setWindowIcon(QIcon(os.path.join(path, "Icons/MDANSE.ico")))
+    app.setWindowIcon(QIcon(mdanse_icon_path))
     fixed_locale = QLocale(QLocale.Language.English, QLocale.Country.UnitedKingdom)
     fixed_locale.setNumberOptions(
         QLocale.NumberOption.RejectGroupSeparator

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
 ]
 test=["pytest", "pytest-timeout", "pytest-qt"]
 lint=["ruff<0.14"]
+extras=["pyshortcuts"]
 
 [project.urls]
 homepage = "https://pypi.org/project/MDANSE"
@@ -67,6 +68,9 @@ MDANSE_GUI = ["Icons/*.png", "Icons/*.ico", "Icons/*.stl",
 [tool.setuptools-git-versioning]
 enabled = true
 starting_version = "2.0.1"
+
+[project.scripts]
+create_mdanse_link = "MDANSE_GUI.Scripts.create_mdanse_link:main"
 
 [project.gui-scripts]
 mdanse_elements_database = "MDANSE_GUI.Scripts.mdanse_elements_database:main"

--- a/MDANSE_GUI/pyproject.toml
+++ b/MDANSE_GUI/pyproject.toml
@@ -50,6 +50,8 @@ dev = [
 ]
 test=["pytest", "pytest-timeout", "pytest-qt"]
 lint=["ruff<0.14"]
+
+[project.optional-dependencies]
 extras=["pyshortcuts"]
 
 [project.urls]


### PR DESCRIPTION
**Description of work**
Adds a script named `create_mdanse_link`, which the user can run to create a desktop icon for MDANSE_GUI.

Questions:
1. Should the icon contain information about the python environment in which the GUI will be running?
2. What would be the best name for the script? Since we can call it creating a link, or a shortcut, or a launcher.

**Fixes**
1. Adds https://github.com/newville/pyshortcuts as an optional dependency of MDANSE_GUI.
2. Adds a script which executes a `pyshortcuts` function `make_shortcut` to create a desktop and start menu entry that can be used to launch MDANSE_GUI.

Fixes #594 

**To test**
Install MDANSE_GUI.
Try running `create_mdanse_link`. It should inform you that `pyshortcuts` is missing, and give you information on how to install it.
Follow the instructions and install `pyshortcuts`. Run `create_mdanse_link` again. It should create a launcher for MDANSE_GUI.
Run MDANSE_GUI using the new launcher and check if it runs correctly.

Bonus question: is the MDANSE icon assigned correctly to the MDANSE_GUI launcher?
