### PR TITLE
Fix for inactive job message bug

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Visualisers/Action.py
@@ -226,7 +226,7 @@ class Action(QWidget):
             type(self._job_instance).__name__,
             job_name,
         )
-        if type(self._job_instance).__name__ != job_name:
+        if self._job_instance is None or type(self._job_instance).__name__ != job_name:
             self.clear_panel()
             self._has_been_initialised = False
 
@@ -257,6 +257,7 @@ class Action(QWidget):
                 self.layout.addWidget(widget)
                 self._widgets_in_layout["err"] = widget
                 self._widgets.append(widget)
+                self._job_instance = None
                 return
 
             job_instance.build_configuration()


### PR DESCRIPTION
**Description of work**
Fixes the issue in #1289 where a the inactive job message is seen from the previous selection.

**Fixes**
Fixes #1289

**To test**
With the optional dependencies uninstalled try selecting an enabled  job then a disabled job then the same enabled job you selected first. The issue in #1289 should be fixed. Run a few job to check it works as usual.
