### PR TITLE
Updated the layout engine setting and fix bar chart overlap bug

### DIFF
--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Grid.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Grid.py
@@ -139,6 +139,7 @@ class Grid(Plotter):
             return
 
         self._figure = target
+        self._figure.set_layout_engine(layout="constrained")
         self._axes = []
         self._axes_titles = []
         self._backup_curves = []

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Grouped.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Grouped.py
@@ -160,7 +160,9 @@ class Grouped(Plotter):
                 title if enabled else "",
                 fontsize=self.title_fontsize(title),
             )
-            axes.get_legend().set_visible(enabled)
+            legend = axes.get_legend()
+            legend.set_visible(enabled)
+            legend.set_in_layout(False)
 
         self._figure.canvas.draw()
 
@@ -201,6 +203,7 @@ class Grouped(Plotter):
 
         self.height_max, self.length_max = 0.0, 0.0
         self._figure = target
+        self._figure.set_layout_engine(layout="constrained")
 
         self._axes = []
         self._axes_titles = []

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Vectors.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Vectors.py
@@ -92,6 +92,7 @@ class Vectors(Plotter):
             self._toolbar = toolbar
 
         self._figure = target
+        self._figure.set_layout_engine(layout="constrained")
         self._normalisation_errors = []
         self._axes = []
         self._active_curves = []
@@ -123,7 +124,7 @@ class Vectors(Plotter):
                     for ind, (_x, curve) in enumerate(dataset.curves_vs_axis("|q|")):
                         lab = plotlabel if dataset._n_dim != 2 else next(labels)
                         width = (
-                            0.8 * abs(np.mean(np.diff(curve[0])))
+                            0.8 * abs(np.min(np.diff(curve[0])))
                             if len(curve[0]) > 1
                             else 1
                         )
@@ -240,6 +241,7 @@ class Vectors(Plotter):
         for axes in self._axes:
             legend = axes.legend()
             legend.set_visible(plotting_context.use_legend)
+            legend.set_in_layout(False)
             axes.grid(plotting_context.use_grid)
             axes.relim()
             axes.autoscale()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Vectors3D.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Plotters/Vectors3D.py
@@ -80,6 +80,7 @@ class Vectors3D(Plotter):
             self._toolbar = toolbar
 
         self._figure = target
+        self._figure.set_layout_engine(layout="constrained")
         self._normalisation_errors = []
         self._axes = []
         self.apply_settings(plotting_context)
@@ -208,6 +209,7 @@ class Vectors3D(Plotter):
         for axes in self._axes:
             legend = axes.legend()
             legend.set_visible(plotting_context.use_legend)
+            legend.set_in_layout(False)
             axes.grid(plotting_context.use_grid)
             axes.relim()
             axes.autoscale()

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -444,9 +444,7 @@ def vector_q_statistics_datasets(
         linestyle=":",
         marker="o",
         data=available_vectors,
-        plot_axes={
-            "|q|": qvals
-        },
+        plot_axes={"|q|": qvals},
         axes_units={"|q|": "1/nm"},
         optional_filename=filename,
     )

--- a/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
+++ b/MDANSE_GUI/Src/MDANSE_GUI/Tabs/Views/PlotDataView.py
@@ -404,24 +404,23 @@ def vector_q_statistics_datasets(
             for index in range(len(qvals))
             if source["q_vectors"][qvals[index]] is not None
         ]
-        nshells = len(valid_shells)
 
         def q_data(elem: str) -> Generator:
             for index in valid_shells:
                 yield source["q_vectors"][qvals[index]][elem]
 
         modq_per_shell = [np.linalg.norm(dat, axis=0) for dat in q_data("q_vectors")]
-        available_vectors = np.array(
-            [
-                (
-                    n_found,
-                    n_used,
-                )
-                for n_found, n_used in zip(
-                    q_data("n_q_found"), q_data("n_q_vectors"), strict=False
-                )
-            ],
-        )
+
+        available_vectors = []
+        for idx in range(len(qvals)):
+            if source["q_vectors"][qvals[idx]] is None:
+                n_found, n_used = 0, 0
+            else:
+                n_found = source["q_vectors"][qvals[idx]]["n_q_found"]
+                n_used = source["q_vectors"][qvals[idx]]["n_q_vectors"]
+            available_vectors.append((n_found, n_used))
+        available_vectors = np.array(available_vectors)
+
         vec_weights = [dat[:] for dat in q_data("weights")]
     if q_bin_limits is None:
         qmin, qmax = np.min(modq_per_shell[0]), np.max(modq_per_shell[-1])
@@ -447,8 +446,6 @@ def vector_q_statistics_datasets(
         data=available_vectors,
         plot_axes={
             "|q|": qvals
-            if len(qvals) == len(available_vectors)
-            else qvals[valid_shells]
         },
         axes_units={"|q|": "1/nm"},
         optional_filename=filename,


### PR DESCRIPTION
**Description of work**
Fixed the bar chart overlap issue so the available vectors bar charts from the preview and plot holder should be the same. I've changed the layout engine setting to `constrained` but set `legend.set_in_layout(False)`. This seems to give the best results from my testing.

Before
<img width="2133" height="1568" alt="before" src="https://github.com/user-attachments/assets/a87043ae-c7c2-4bd1-a616-9301c8936227" />


After
<img width="2134" height="1568" alt="after" src="https://github.com/user-attachments/assets/479b55de-cbfd-481b-8dc7-f916a71331d6" />


**Fixes**
Fixes #1290
Fixes #1284

**To test**
Check the preview vector distribution and the plotting for all different plot types e.g. vector, grid, grouped, etc.
